### PR TITLE
Add deployer plugin system

### DIFF
--- a/adr/0001-deployer-plugin-system.md
+++ b/adr/0001-deployer-plugin-system.md
@@ -1,0 +1,73 @@
+# ADR 0001: Deployer Plugin System
+
+## Status
+
+Accepted
+
+## Context
+
+The openclaw-installer supports deploying OpenClaw to multiple targets (local containers, Kubernetes). As adoption grows, there is demand for deploying to additional platforms — managed Kubernetes services, cloud-specific environments, edge devices, and enterprise platforms that each have their own authentication, networking, and resource management patterns.
+
+Hardcoding support for every target platform into the installer creates several problems:
+
+1. **Unbounded scope** — each new platform adds code, dependencies, and maintenance burden to the core installer.
+2. **Vendor coupling** — platform-specific code in the core ties the project to particular vendors, which is inappropriate for a community-maintained tool.
+3. **Slow iteration** — platform-specific features must go through the core project's release cycle even when they only affect one deployment target.
+4. **Contributor friction** — contributors adding a new platform must understand the entire codebase rather than implementing a focused interface.
+
+## Decision
+
+We add a deployer plugin system that allows external npm packages to register new deployment targets at runtime.
+
+### Architecture
+
+**DeployerRegistry** (`src/server/deployers/registry.ts`) — a singleton registry where deployers are registered by mode name. Built-in deployers (local, kubernetes) register at startup. Plugins register after.
+
+**InstallerPlugin interface** — plugins are npm packages that export a `register(registry)` function. The registry provides `register()`, `get()`, `list()`, and `detect()` methods.
+
+**DeployerRegistration** — each registration includes:
+- `mode` — unique string identifier (e.g., "local", "kubernetes")
+- `title` / `description` — human-readable labels for the UI
+- `deployer` — an object implementing the `Deployer` interface
+- `detect` — optional async function that returns true if the platform is available
+- `priority` — numeric priority for auto-selection when multiple deployers detect availability
+
+**Plugin discovery** (`src/server/plugins/loader.ts`) — at startup, the installer scans for:
+1. npm packages matching `openclaw-installer-*` in node_modules
+2. Entries in `~/.openclaw/installer/plugins.json` (for local development)
+
+**Dynamic frontend** — the `DeployForm` component no longer hardcodes available modes. It fetches the list of registered deployers from `/api/health` and renders mode cards dynamically. The highest-priority detected deployer is auto-selected.
+
+**Exported API** — the core package exports types and classes that plugins need via `package.json` exports:
+- `./deployers/types` — `Deployer`, `DeployConfig`, `DeployResult`, `LogCallback`
+- `./deployers/registry` — `DeployerRegistry`, `DeployerRegistration`, `InstallerPlugin`
+- `./deployers/kubernetes` — `KubernetesDeployer` (for plugins that extend K8s behavior)
+- `./deployers/k8s-helpers` — shared K8s helper functions
+- `./services/k8s` — K8s client utilities
+
+### Key Changes
+
+- `DeployMode` type widened from a closed union (`"local" | "kubernetes" | ...`) to `string`, allowing plugins to introduce new modes without modifying core types.
+- The hardcoded `getDeployer()` switch statement in `routes/deploy.ts` and the hardcoded deployer instances in `routes/status.ts` are replaced with `registry.get(mode)` lookups.
+- Built-in deployers are registered in `index.ts` before plugins load, so they serve as defaults if no plugins are installed.
+
+## Consequences
+
+### Positive
+
+- New deployment platforms can be added without modifying the core installer.
+- Platform-specific code lives in separate packages with independent release cycles.
+- The core installer remains vendor-neutral and focused on shared functionality.
+- Plugin authors only need to implement the `Deployer` interface and a `register` function.
+- The auto-detection mechanism lets plugins automatically activate when their platform is detected.
+
+### Negative
+
+- The `Deployer` interface and exported helpers become a public API surface. Breaking changes require coordination with plugin authors.
+- Plugin loading adds a small amount of startup time (scanning node_modules).
+- Plugins that wrap `KubernetesDeployer` are coupled to its internal behavior, which isn't formally versioned beyond semver on the package.
+
+### Risks
+
+- A misbehaving plugin could affect the entire installer. Mitigation: plugins run in-process (no sandboxing), but errors during registration are caught and logged without crashing.
+- The exported API surface may need to grow as plugin authors discover they need access to more internals. We accept this and will expand exports conservatively as needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,22 @@
         "vitest": "^4.0.18"
       }
     },
+    "../openclaw-installer-openshift": {
+      "version": "0.1.0",
+      "extraneous": true,
+      "dependencies": {
+        "@kubernetes/client-node": "^1.4.0",
+        "js-yaml": "^4.1.0"
+      },
+      "devDependencies": {
+        "@openclaw/installer": "file:../openclaw-installer",
+        "@types/js-yaml": "^4.0.9",
+        "typescript": "^5.6.0"
+      },
+      "peerDependencies": {
+        "@openclaw/installer": "^0.1.0"
+      }
+    },
     "node_modules/@acemir/cssom": {
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,32 @@
   "version": "0.1.0",
   "description": "OpenClaw installer and fleet manager",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/server/index.d.ts",
+      "default": "./dist/server/index.js"
+    },
+    "./deployers/types": {
+      "types": "./dist/server/deployers/types.d.ts",
+      "default": "./dist/server/deployers/types.js"
+    },
+    "./deployers/kubernetes": {
+      "types": "./dist/server/deployers/kubernetes.d.ts",
+      "default": "./dist/server/deployers/kubernetes.js"
+    },
+    "./deployers/registry": {
+      "types": "./dist/server/deployers/registry.d.ts",
+      "default": "./dist/server/deployers/registry.js"
+    },
+    "./deployers/k8s-helpers": {
+      "types": "./dist/server/deployers/k8s-helpers.d.ts",
+      "default": "./dist/server/deployers/k8s-helpers.js"
+    },
+    "./services/k8s": {
+      "types": "./dist/server/services/k8s.d.ts",
+      "default": "./dist/server/services/k8s.js"
+    }
+  },
   "scripts": {
     "dev": "concurrently \"tsx watch src/server/index.ts\" \"vite\"",
     "build": "vite build && tsc -p tsconfig.server.json",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -31,18 +31,18 @@ export default function App() {
         </button>
       </div>
 
-      {tab === "deploy" && (
-        <>
-          <DeployForm
-            onDeployStarted={(id) => {
-              setActiveDeployId(id);
-            }}
-          />
-          {activeDeployId && <LogStream deployId={activeDeployId} />}
-        </>
-      )}
+      <div style={{ display: tab === "deploy" ? "block" : "none" }}>
+        <DeployForm
+          onDeployStarted={(id) => {
+            setActiveDeployId(id);
+          }}
+        />
+        {activeDeployId && <LogStream deployId={activeDeployId} />}
+      </div>
 
-      {tab === "instances" && <InstanceList />}
+      <div style={{ display: tab === "instances" ? "block" : "none" }}>
+        <InstanceList />
+      </div>
     </div>
   );
 }

--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useState } from "react";
 
-type Mode = "local" | "kubernetes" | "ssh";
 type InferenceProvider = "anthropic" | "openai" | "vertex-anthropic" | "vertex-google" | "custom-endpoint";
+
+interface DeployerInfo {
+  mode: string;
+  title: string;
+  description: string;
+  available: boolean;
+  priority: number;
+}
 
 interface Props {
   onDeployStarted: (deployId: string) => void;
@@ -37,27 +44,11 @@ interface SavedConfig {
   vars: Record<string, string>;
 }
 
-const MODES: Array<{ id: Mode; icon: string; title: string; desc: string; disabled?: boolean }> = [
-  {
-    id: "local" as const,
-    icon: "💻",
-    title: "This Machine",
-    desc: "Run OpenClaw locally with podman/docker",
-  },
-  {
-    id: "kubernetes" as const,
-    icon: "☸️",
-    title: "Kubernetes",
-    desc: "Deploy to a Kubernetes cluster",
-  },
-  {
-    id: "ssh" as const,
-    icon: "🖥️",
-    title: "🚧 Remote Host",
-    desc: "Deploy via SSH to a Linux machine (coming soon)",
-    disabled: true,
-  },
-];
+const MODE_ICONS: Record<string, string> = {
+  local: "💻",
+  kubernetes: "☸️",
+  ssh: "🖥️",
+};
 
 const PROVIDER_OPTIONS: Array<{ id: InferenceProvider; label: string; desc: string }> = [
   { id: "anthropic", label: "Anthropic", desc: "Claude models via Anthropic API" },
@@ -123,9 +114,10 @@ function inferDisplayNameFromAgentName(value: string): string {
 const LAST_AGENT_SOURCE_DIR_KEY = "openclaw:last-agent-source-dir";
 
 export default function DeployForm({ onDeployStarted }: Props) {
-  const [mode, setMode] = useState<Mode>("local");
+  const [mode, setMode] = useState("local");
   const [deploying, setDeploying] = useState(false);
   const [defaults, setDefaults] = useState<ServerDefaults | null>(null);
+  const [deployers, setDeployers] = useState<DeployerInfo[]>([]);
   const [savedConfigs, setSavedConfigs] = useState<SavedConfig[]>([]);
   const [loadedConfigLabel, setLoadedConfigLabel] = useState<string | null>(null);
   const [autoLoadedEnvDir, setAutoLoadedEnvDir] = useState<string | null>(null);
@@ -219,6 +211,18 @@ export default function DeployForm({ onDeployStarted }: Props) {
           k8sContext: data.k8sContext,
         };
         setDefaults(d);
+
+        if (Array.isArray(data.deployers)) {
+          const sorted = [...(data.deployers as DeployerInfo[])].sort((a, b) => {
+            if (a.available !== b.available) return a.available ? -1 : 1;
+            return (b.priority ?? 0) - (a.priority ?? 0);
+          });
+          setDeployers(sorted);
+          if (sorted.length > 0 && sorted[0].available) {
+            setMode(sorted[0].mode);
+          }
+        }
+
         if (d.prefix) {
           setConfig((prev) => ({ ...prev, prefix: d.prefix }));
         }
@@ -645,21 +649,21 @@ export default function DeployForm({ onDeployStarted }: Props) {
     <div>
       {/* Mode selector */}
       <div className="mode-grid">
-        {MODES.map((m) => {
-          const isSelected = mode === m.id;
+        {deployers.map((m) => {
+          const isSelected = mode === m.mode;
           return (
             <div
-              key={m.id}
-              className={`mode-card ${isSelected ? "selected" : ""} ${m.disabled ? "disabled" : ""}`}
-              onClick={() => !m.disabled && setMode(m.id)}
-              style={m.disabled ? { opacity: 0.5, cursor: "not-allowed" } : undefined}
+              key={m.mode}
+              className={`mode-card ${isSelected ? "selected" : ""} ${!m.available ? "disabled" : ""}`}
+              onClick={() => m.available && setMode(m.mode)}
+              style={!m.available ? { opacity: 0.5, cursor: "not-allowed" } : undefined}
             >
               <div className="mode-radio">
                 <span className={`radio-dot ${isSelected ? "checked" : ""}`} />
               </div>
-              <div className="mode-icon">{m.icon}</div>
+              <div className="mode-icon">{MODE_ICONS[m.mode] || "🔌"}</div>
               <div className="mode-title">{m.title}</div>
-              <div className="mode-desc">{m.desc}</div>
+              <div className="mode-desc">{m.description}</div>
               {isSelected && <div className="mode-selected-badge">Selected</div>}
             </div>
           );

--- a/src/client/components/InstanceList.tsx
+++ b/src/client/components/InstanceList.tsx
@@ -53,7 +53,7 @@ function StatusBadge({ inst, isActing }: { inst: Instance; isActing: boolean }) 
 }
 
 function K8sProgress({ inst }: { inst: Instance }) {
-  if (inst.mode !== "kubernetes") return null;
+  if (inst.mode === "local") return null;
   if (!inst.statusDetail && (!inst.pods || inst.pods.length === 0)) return null;
   if (inst.status === "running") return null;
 
@@ -90,7 +90,7 @@ export default function InstanceList() {
   const [instances, setInstances] = useState<Instance[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [includeK8s, setIncludeK8s] = useState(false);
+  const [includeK8s, setIncludeK8s] = useState(true);
   const [acting, setActing] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Record<string, ExpandedPanel>>({});
   const [panelData, setPanelData] = useState<Record<string, string>>({});
@@ -121,7 +121,7 @@ export default function InstanceList() {
 
   const k8sToggle = (
     <button className="btn btn-ghost" onClick={() => setIncludeK8s((prev) => !prev)}>
-      {includeK8s ? "Hide K8s" : "Include K8s"}
+      {includeK8s ? "Hide Cluster" : "Show Cluster"}
     </button>
   );
 
@@ -154,7 +154,7 @@ export default function InstanceList() {
   const handleDeleteData = async (id: string, mode?: string) => {
     if (
       !confirm(
-        mode === "kubernetes"
+        mode !== "local"
           ? "Delete namespace and all data? This removes the PVC, secrets, deployment, and namespace. Cannot be undone."
           : "Delete all data? This removes the data volume (config, sessions, workspaces). Cannot be undone.",
       )
@@ -269,7 +269,7 @@ export default function InstanceList() {
         const isStopped = inst.status === "stopped";
         const isDeploying = inst.status === "deploying";
         const isError = inst.status === "error";
-        const isK8s = inst.mode === "kubernetes";
+        const isK8s = inst.mode !== "local";
         const canStop = isRunning || isDeploying || isError;
         // K8s: allow delete anytime (it deletes the whole namespace)
         // Local: must stop first
@@ -282,12 +282,12 @@ export default function InstanceList() {
                 <div className="instance-name">
                   {inst.containerId || inst.id}
                   <StatusBadge inst={inst} isActing={isActing} />
-                  {inst.mode === "kubernetes" && (
+                  {isK8s && (
                     <span
                       className="badge"
                       style={{ marginLeft: "0.25rem", background: "var(--accent)", color: "#fff", fontSize: "0.65rem" }}
                     >
-                      K8s
+                      {inst.mode === "openshift" ? "OpenShift" : "K8s"}
                     </span>
                   )}
                 </div>

--- a/src/client/components/__tests__/InstanceList.test.tsx
+++ b/src/client/components/__tests__/InstanceList.test.tsx
@@ -163,7 +163,7 @@ describe("InstanceList", () => {
     await waitFor(() => {
       expect(screen.getByText("secret-token-123")).toBeInTheDocument();
     });
-    expect(screen.getByRole("button", { name: /hide/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^hide$/i })).toBeInTheDocument();
   });
 
   it("calls start endpoint when Start is clicked", async () => {
@@ -278,20 +278,20 @@ describe("InstanceList", () => {
     });
   });
 
-  it("opts into kubernetes discovery only when requested", async () => {
+  it("includes cluster instances by default and allows hiding them", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     const fetchMock = mockFetchWith([]);
     globalThis.fetch = fetchMock;
 
     render(<InstanceList />);
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /include k8s/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /hide cluster/i })).toBeInTheDocument();
     });
-    expect(fetchMock).toHaveBeenCalledWith("/api/instances");
+    expect(fetchMock).toHaveBeenCalledWith("/api/instances?includeK8s=1");
 
-    await user.click(screen.getByRole("button", { name: /include k8s/i }));
+    await user.click(screen.getByRole("button", { name: /hide cluster/i }));
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith("/api/instances?includeK8s=1");
+      expect(fetchMock).toHaveBeenCalledWith("/api/instances");
     });
   });
 });

--- a/src/server/deployers/__tests__/registry.test.ts
+++ b/src/server/deployers/__tests__/registry.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { DeployerRegistry } from "../registry.js";
+import type { Deployer, DeployConfig, DeployResult, LogCallback } from "../types.js";
+
+function stubDeployer(): Deployer {
+  return {
+    async deploy(_config: DeployConfig, _log: LogCallback): Promise<DeployResult> {
+      return { id: "test", mode: "test", status: "running", config: { mode: "test", agentName: "t" }, startedAt: "" };
+    },
+    async start(result: DeployResult): Promise<DeployResult> { return result; },
+    async status(result: DeployResult): Promise<DeployResult> { return result; },
+    async stop(): Promise<void> {},
+    async teardown(): Promise<void> {},
+  };
+}
+
+describe("DeployerRegistry", () => {
+  it("registers and retrieves a deployer by mode", () => {
+    const reg = new DeployerRegistry();
+    const deployer = stubDeployer();
+    reg.register({ mode: "test", title: "Test", description: "A test deployer", deployer });
+
+    expect(reg.get("test")).toBe(deployer);
+  });
+
+  it("returns null for unknown mode", () => {
+    const reg = new DeployerRegistry();
+    expect(reg.get("nonexistent")).toBeNull();
+  });
+
+  it("lists all registrations", () => {
+    const reg = new DeployerRegistry();
+    reg.register({ mode: "a", title: "A", description: "First", deployer: stubDeployer() });
+    reg.register({ mode: "b", title: "B", description: "Second", deployer: stubDeployer() });
+
+    const list = reg.list();
+    expect(list).toHaveLength(2);
+    expect(list.map((r) => r.mode)).toEqual(["a", "b"]);
+  });
+
+  it("overwrites duplicate mode registrations", () => {
+    const reg = new DeployerRegistry();
+    const first = stubDeployer();
+    const second = stubDeployer();
+    reg.register({ mode: "dup", title: "First", description: "First", deployer: first });
+    reg.register({ mode: "dup", title: "Second", description: "Second", deployer: second });
+
+    expect(reg.get("dup")).toBe(second);
+    expect(reg.list()).toHaveLength(1);
+    expect(reg.list()[0].title).toBe("Second");
+  });
+
+  it("detect returns registrations where detect() returns true", async () => {
+    const reg = new DeployerRegistry();
+    reg.register({ mode: "yes", title: "Yes", description: "Available", deployer: stubDeployer(), detect: async () => true });
+    reg.register({ mode: "no", title: "No", description: "Unavailable", deployer: stubDeployer(), detect: async () => false });
+
+    const detected = await reg.detect();
+    expect(detected).toHaveLength(1);
+    expect(detected[0].mode).toBe("yes");
+  });
+
+  it("detect includes registrations without detect function", async () => {
+    const reg = new DeployerRegistry();
+    reg.register({ mode: "nodetect", title: "No Detect", description: "Always available", deployer: stubDeployer() });
+
+    const detected = await reg.detect();
+    expect(detected).toHaveLength(1);
+    expect(detected[0].mode).toBe("nodetect");
+  });
+
+  it("detect handles detect() throwing gracefully", async () => {
+    const reg = new DeployerRegistry();
+    reg.register({
+      mode: "broken",
+      title: "Broken",
+      description: "Throws",
+      deployer: stubDeployer(),
+      detect: async () => { throw new Error("boom"); },
+    });
+    reg.register({ mode: "ok", title: "OK", description: "Fine", deployer: stubDeployer(), detect: async () => true });
+
+    const detected = await reg.detect();
+    expect(detected).toHaveLength(1);
+    expect(detected[0].mode).toBe("ok");
+  });
+
+  it("preserves priority in registrations", () => {
+    const reg = new DeployerRegistry();
+    reg.register({ mode: "low", title: "Low", description: "Low priority", deployer: stubDeployer(), priority: -1 });
+    reg.register({ mode: "high", title: "High", description: "High priority", deployer: stubDeployer(), priority: 10 });
+
+    const list = reg.list();
+    const low = list.find((r) => r.mode === "low");
+    const high = list.find((r) => r.mode === "high");
+    expect(low?.priority).toBe(-1);
+    expect(high?.priority).toBe(10);
+  });
+});

--- a/src/server/deployers/registry.ts
+++ b/src/server/deployers/registry.ts
@@ -1,0 +1,53 @@
+import type { Deployer } from "./types.js";
+
+export interface DeployerRegistration {
+  mode: string;
+  title: string;
+  description: string;
+  deployer: Deployer;
+  detect?: () => Promise<boolean>;
+  priority?: number;
+}
+
+export interface InstallerPlugin {
+  register(registry: DeployerRegistry): void;
+}
+
+export class DeployerRegistry {
+  private registrations = new Map<string, DeployerRegistration>();
+
+  register(reg: DeployerRegistration): void {
+    if (this.registrations.has(reg.mode)) {
+      console.warn(`DeployerRegistry: overwriting existing registration for mode "${reg.mode}"`);
+    }
+    this.registrations.set(reg.mode, reg);
+  }
+
+  get(mode: string): Deployer | null {
+    return this.registrations.get(mode)?.deployer ?? null;
+  }
+
+  list(): DeployerRegistration[] {
+    return Array.from(this.registrations.values());
+  }
+
+  async detect(): Promise<DeployerRegistration[]> {
+    const results: DeployerRegistration[] = [];
+    for (const reg of this.registrations.values()) {
+      if (!reg.detect) {
+        results.push(reg);
+        continue;
+      }
+      try {
+        if (await reg.detect()) {
+          results.push(reg);
+        }
+      } catch {
+        // detect failed — treat as unavailable
+      }
+    }
+    return results;
+  }
+}
+
+export const registry = new DeployerRegistry();

--- a/src/server/deployers/types.ts
+++ b/src/server/deployers/types.ts
@@ -1,4 +1,5 @@
-export type DeployMode = "local" | "kubernetes" | "ssh" | "fleet";
+export type DeployMode = string;
+export type BuiltinDeployMode = "local" | "kubernetes" | "ssh" | "fleet";
 
 export interface DeployConfig {
   mode: DeployMode;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,6 +13,33 @@ import { detectGcpDefaults } from "./services/gcp.js";
 import { readdir, readFile } from "node:fs/promises";
 import { userInfo } from "node:os";
 import { installerDataDir } from "./paths.js";
+import { registry } from "./deployers/registry.js";
+import { LocalDeployer } from "./deployers/local.js";
+import { KubernetesDeployer } from "./deployers/kubernetes.js";
+import { loadPlugins } from "./plugins/loader.js";
+
+// Register built-in deployers
+registry.register({
+  mode: "local",
+  title: "This Machine",
+  description: "Run OpenClaw locally with podman/docker",
+  deployer: new LocalDeployer(),
+  detect: async () => !!(await detectRuntime()),
+  priority: 0,
+});
+registry.register({
+  mode: "kubernetes",
+  title: "Kubernetes",
+  description: "Deploy to a Kubernetes cluster",
+  deployer: new KubernetesDeployer(),
+  detect: async () => isClusterReachable(),
+  priority: 0,
+});
+
+// Load external plugins
+console.log("Loading plugins...");
+await loadPlugins(registry);
+console.log(`Plugins loaded. Registered deployers: ${registry.list().map(r => r.mode).join(", ")}`);
 
 const app = express();
 const server = createServer(app);
@@ -29,6 +56,7 @@ app.use("/api/agents", agentsRoutes);
 app.get("/api/health", async (_req, res) => {
   const runtime = await detectRuntime();
   const k8sReachable = await isClusterReachable();
+  const detected = await registry.detect();
 
   res.json({
     status: "ok",
@@ -36,6 +64,13 @@ app.get("/api/health", async (_req, res) => {
     k8sAvailable: k8sReachable,
     k8sContext: k8sReachable ? currentContext() : "",
     version: "0.1.0",
+    deployers: registry.list().map((reg) => ({
+      mode: reg.mode,
+      title: reg.title,
+      description: reg.description,
+      available: detected.some((d) => d.mode === reg.mode),
+      priority: reg.priority ?? 0,
+    })),
     defaults: {
       hasAnthropicKey: !!process.env.ANTHROPIC_API_KEY,
       hasOpenaiKey: !!process.env.OPENAI_API_KEY,

--- a/src/server/plugins/loader.ts
+++ b/src/server/plugins/loader.ts
@@ -1,0 +1,93 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import type { DeployerRegistry, InstallerPlugin } from "../deployers/registry.js";
+
+const PLUGIN_PREFIX = "openclaw-installer-";
+const CONFIG_PATH = join(homedir(), ".openclaw", "installer", "plugins.json");
+
+async function discoverNpmPlugins(): Promise<string[]> {
+  const require = createRequire(import.meta.url);
+  const plugins: string[] = [];
+
+  try {
+    const expressPath = require.resolve("express");
+    const nodeModulesDir = join(expressPath.split("node_modules")[0], "node_modules");
+    const entries = await readdir(nodeModulesDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+
+      if (entry.name.startsWith(PLUGIN_PREFIX)) {
+        plugins.push(entry.name);
+        continue;
+      }
+
+      // Check scoped packages (@scope/openclaw-installer-*)
+      if (entry.name.startsWith("@")) {
+        try {
+          const scopedEntries = await readdir(join(nodeModulesDir, entry.name), { withFileTypes: true });
+          for (const scoped of scopedEntries) {
+            if ((scoped.isDirectory() || scoped.isSymbolicLink()) && scoped.name.startsWith(PLUGIN_PREFIX)) {
+              plugins.push(`${entry.name}/${scoped.name}`);
+            }
+          }
+        } catch {
+          // skip unreadable scope dirs
+        }
+      }
+    }
+  } catch {
+    // node_modules not found or unreadable
+  }
+  return plugins;
+}
+
+async function loadConfigPlugins(): Promise<string[]> {
+  if (!existsSync(CONFIG_PATH)) return [];
+
+  try {
+    const content = await readFile(CONFIG_PATH, "utf8");
+    const config = JSON.parse(content);
+    if (Array.isArray(config.plugins)) {
+      return config.plugins.filter((p: unknown) => typeof p === "string");
+    }
+  } catch (err) {
+    console.warn(`Failed to read plugin config at ${CONFIG_PATH}:`, err);
+  }
+
+  return [];
+}
+
+async function loadPlugin(registry: DeployerRegistry, moduleId: string): Promise<void> {
+  console.log(`Attempting to load plugin: ${moduleId}`);
+  try {
+    const mod = await import(moduleId);
+    const plugin: InstallerPlugin | undefined = mod.default ?? mod;
+
+    if (typeof plugin?.register !== "function") {
+      console.warn(`Plugin "${moduleId}" does not export a register function, skipping`);
+      return;
+    }
+
+    plugin.register(registry);
+    console.log(`Loaded plugin: ${moduleId}`);
+  } catch (err) {
+    console.warn(`Failed to load plugin "${moduleId}":`, err);
+  }
+}
+
+export async function loadPlugins(registry: DeployerRegistry): Promise<void> {
+  const npmPlugins = await discoverNpmPlugins();
+  const configPlugins = await loadConfigPlugins();
+
+  const allPlugins = [...new Set([...npmPlugins, ...configPlugins])];
+
+  if (allPlugins.length === 0) return;
+
+  for (const pluginId of allPlugins) {
+    await loadPlugin(registry, pluginId);
+  }
+}

--- a/src/server/routes/deploy.ts
+++ b/src/server/routes/deploy.ts
@@ -4,29 +4,15 @@ import { readFileSync, existsSync } from "node:fs";
 import { userInfo } from "node:os";
 import type { DeployConfig } from "../deployers/types.js";
 import { detectGcpDefaults, defaultVertexLocation } from "../services/gcp.js";
-import { LocalDeployer } from "../deployers/local.js";
-import { KubernetesDeployer } from "../deployers/kubernetes.js";
+import { registry } from "../deployers/registry.js";
 import { createLogCallback, sendStatus } from "../ws.js";
 
 const router = Router();
-const localDeployer = new LocalDeployer();
-const k8sDeployer = new KubernetesDeployer();
 
 function normalizeSshMaterial(value: string): string {
   const withoutBom = value.replace(/^\uFEFF/, "");
   const normalizedNewlines = withoutBom.replace(/\r\n?/g, "\n");
   return normalizedNewlines.endsWith("\n") ? normalizedNewlines : `${normalizedNewlines}\n`;
-}
-
-function getDeployer(mode: string) {
-  switch (mode) {
-    case "local":
-      return localDeployer;
-    case "kubernetes":
-      return k8sDeployer;
-    default:
-      return null;
-  }
 }
 
 router.post("/", async (req, res) => {
@@ -143,7 +129,7 @@ router.post("/", async (req, res) => {
     }
   }
 
-  const deployer = getDeployer(config.mode);
+  const deployer = registry.get(config.mode);
   if (!deployer) {
     res.status(400).json({ error: `Unsupported mode: ${config.mode}` });
     return;

--- a/src/server/routes/status.ts
+++ b/src/server/routes/status.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { readFile } from "node:fs/promises";
 import { installerLocalInstanceDir } from "../paths.js";
+import { installerDataDir } from "../paths.js";
 import { join } from "node:path";
 import {
   discoverContainers,
@@ -8,15 +9,13 @@ import {
   detectRuntime,
   type DiscoveredContainer,
 } from "../services/container.js";
-import { LocalDeployer } from "../deployers/local.js";
-import { KubernetesDeployer, discoverK8sInstances } from "../deployers/kubernetes.js";
+import { discoverK8sInstances } from "../deployers/kubernetes.js";
 import { isClusterReachable } from "../services/k8s.js";
+import { registry } from "../deployers/registry.js";
 import { createLogCallback, sendStatus } from "../ws.js";
 import type { DeployResult } from "../deployers/types.js";
 
 const router = Router();
-const localDeployer = new LocalDeployer();
-const k8sDeployer = new KubernetesDeployer();
 
 function containerToInstance(c: DiscoveredContainer): DeployResult {
   const prefix = c.labels["openclaw.prefix"] || "";
@@ -76,7 +75,7 @@ function decodeSavedBase64UnlessPath(savedValue?: string, savedPath?: string): s
 // List all instances: running containers + stopped volumes (no container due to --rm) + K8s
 router.get("/", async (req, res) => {
   const instances: DeployResult[] = [];
-  const includeK8s = req.query.includeK8s === "1";
+  const includeK8s = req.query.includeK8s !== "0";
 
   try {
     // Local instances
@@ -168,12 +167,13 @@ router.get("/", async (req, res) => {
       try {
         const k8sInstances = await discoverK8sInstances();
         for (const ki of k8sInstances) {
-          instances.push({
+          const mode = await savedDeployMode(ki.namespace);
+          let instance: DeployResult = {
             id: ki.namespace,
-            mode: "kubernetes",
+            mode,
             status: ki.status,
             config: {
-              mode: "kubernetes",
+              mode,
               prefix: ki.prefix,
               agentName: ki.agentName,
               agentDisplayName: ki.agentName
@@ -187,7 +187,19 @@ router.get("/", async (req, res) => {
             containerId: ki.namespace,
             statusDetail: ki.statusDetail,
             pods: ki.pods,
-          });
+          };
+
+          // Let the deployer enrich with platform-specific info (e.g. Route URL)
+          const deployer = registry.get(mode);
+          if (deployer && typeof deployer.status === "function") {
+            try {
+              instance = await deployer.status(instance);
+            } catch {
+              // Use base instance if status enrichment fails
+            }
+          }
+
+          instances.push(instance);
         }
       } catch {
         // Keep local instances visible even if cluster discovery fails.
@@ -233,7 +245,11 @@ router.post("/:id/start", async (req, res) => {
     return;
   }
 
-  const deployer = instance.mode === "kubernetes" ? k8sDeployer : localDeployer;
+  const deployer = registry.get(instance.mode);
+  if (!deployer) {
+    res.status(400).json({ error: `No deployer registered for mode: ${instance.mode}` });
+    return;
+  }
   const log = createLogCallback(instance.id);
   try {
     await deployer.start(instance, log);
@@ -254,7 +270,11 @@ router.post("/:id/stop", async (req, res) => {
     return;
   }
 
-  const deployer = instance.mode === "kubernetes" ? k8sDeployer : localDeployer;
+  const deployer = registry.get(instance.mode);
+  if (!deployer) {
+    res.status(400).json({ error: `No deployer registered for mode: ${instance.mode}` });
+    return;
+  }
   const log = createLogCallback(instance.id);
   await deployer.stop(instance, log);
   sendStatus(instance.id, "stopped");
@@ -269,14 +289,20 @@ router.post("/:id/redeploy", async (req, res) => {
     return;
   }
 
-  if (instance.mode !== "kubernetes") {
-    res.status(400).json({ error: "Use Stop/Start for local instances — agent files are synced automatically on Start" });
+  const deployer = registry.get(instance.mode);
+  if (!deployer) {
+    res.status(400).json({ error: `No deployer registered for mode: ${instance.mode}` });
+    return;
+  }
+
+  if (!("redeploy" in deployer) || typeof (deployer as unknown as Record<string, unknown>).redeploy !== "function") {
+    res.status(400).json({ error: "Use Stop/Start for this deployer — redeploy is not supported" });
     return;
   }
 
   const log = createLogCallback(instance.id);
   try {
-    await k8sDeployer.redeploy(instance, log);
+    await ((deployer as unknown as Record<string, unknown> & { redeploy: (r: DeployResult, l: typeof log) => Promise<void> }).redeploy(instance, log));
     sendStatus(instance.id, "running");
     res.json({ status: "redeploying" });
   } catch (err) {
@@ -290,7 +316,7 @@ router.post("/:id/redeploy", async (req, res) => {
 router.get("/:id/token", async (req, res) => {
   // Check if this is a K8s instance
   const instance = await findInstance(req.params.id);
-  if (instance?.mode === "kubernetes") {
+  if (instance && instance.mode !== "local") {
     try {
       const core = (await import("../services/k8s.js")).coreApi();
       const ns = instance.config.namespace || instance.containerId || "";
@@ -349,8 +375,8 @@ router.get("/:id/token", async (req, res) => {
 router.get("/:id/command", async (req, res) => {
   const instance = await findInstance(req.params.id);
 
-  // K8s instance — return useful kubectl commands
-  if (instance?.mode === "kubernetes") {
+  // Cluster instance — return useful kubectl/oc commands
+  if (instance && instance.mode !== "local") {
     const ns = instance.config.namespace || instance.containerId || "";
 
     // Detect if LiteLLM sidecar is running
@@ -527,8 +553,8 @@ router.get("/:id/command", async (req, res) => {
 router.get("/:id/logs", async (req, res) => {
   const instance = await findInstance(req.params.id);
 
-  // K8s instance — read pod logs via K8s API
-  if (instance?.mode === "kubernetes") {
+  // Cluster instance — read pod logs via K8s API
+  if (instance && instance.mode !== "local") {
     const ns = instance.config.namespace || instance.containerId || "";
     try {
       const core = (await import("../services/k8s.js")).coreApi();
@@ -590,7 +616,11 @@ router.delete("/:id", async (req, res) => {
     return;
   }
 
-  const deployer = instance.mode === "kubernetes" ? k8sDeployer : localDeployer;
+  const deployer = registry.get(instance.mode);
+  if (!deployer) {
+    res.status(400).json({ error: `No deployer registered for mode: ${instance.mode}` });
+    return;
+  }
   const log = createLogCallback(instance.id);
   await deployer.teardown(instance, log);
   res.json({ status: "deleted" });
@@ -616,6 +646,21 @@ async function readSavedConfig(containerName: string): Promise<Record<string, st
   return vars;
 }
 
+
+/**
+ * Read the saved deploy-config.json for a K8s namespace to get the actual deploy mode.
+ * Returns "kubernetes" as fallback if no saved config exists.
+ */
+async function savedDeployMode(namespace: string): Promise<string> {
+  try {
+    const configPath = join(installerDataDir(), "k8s", namespace, "deploy-config.json");
+    const content = await readFile(configPath, "utf8");
+    const config = JSON.parse(content);
+    return config.mode || "kubernetes";
+  } catch {
+    return "kubernetes";
+  }
+}
 
 // Helper: find instance by container name, volume, or K8s namespace
 async function findInstance(name: string): Promise<DeployResult | null> {
@@ -717,12 +762,13 @@ async function findInstance(name: string): Promise<DeployResult | null> {
     const k8sInstances = await discoverK8sInstances();
     const ki = k8sInstances.find((i) => i.namespace === name);
     if (ki) {
-      return {
+      const mode = await savedDeployMode(ki.namespace);
+      let instance: DeployResult = {
         id: ki.namespace,
-        mode: "kubernetes",
+        mode,
         status: ki.status,
         config: {
-          mode: "kubernetes",
+          mode,
           prefix: ki.prefix,
           agentName: ki.agentName,
           agentDisplayName: ki.agentName
@@ -737,6 +783,17 @@ async function findInstance(name: string): Promise<DeployResult | null> {
         statusDetail: ki.statusDetail,
         pods: ki.pods,
       };
+
+      const deployer = registry.get(mode);
+      if (deployer && typeof deployer.status === "function") {
+        try {
+          instance = await deployer.status(instance);
+        } catch {
+          // Use base instance if status enrichment fails
+        }
+      }
+
+      return instance;
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds a deployer plugin system that allows external npm packages to register new deployment targets at runtime
- Replaces hardcoded deployer switch statements with a `DeployerRegistry` that supports `register/get/list/detect`
- Plugin discovery scans `node_modules` for packages matching `openclaw-installer-*` and loads them at startup
- Frontend dynamically fetches available deployers from `/api/health` instead of hardcoding mode cards
- Instance list correctly identifies deployment mode from saved config and enriches with deployer-specific info (e.g. Route URLs for OpenShift)
- Tab state (deploy settings + logs) preserved when switching between Deploy and Instances views
- Adds package.json exports so plugins can import types, KubernetesDeployer, registry, and K8s helpers
- Includes ADR documenting the design decisions

See also: [ADR 0001 - Deployer Plugin System](adr/0001-deployer-plugin-system.md)

**Note:** Plugins should NOT be added as dependencies in this repo's package.json. They are discovered at runtime via node_modules. Developers using plugins locally with `file:` references should ensure those don't leak into PRs.

## Test plan

- [ ] `npm test` passes (includes registry unit tests)
- [ ] `npm run build` succeeds
- [ ] Deploy locally without any plugins — local and kubernetes modes work as before
- [ ] Install a plugin (e.g. `openclaw-installer-openshift`) and verify it appears in the UI
- [ ] Instances page correctly shows mode badges and URLs for plugin-deployed instances
- [ ] Deploy log and settings persist when switching between Deploy and Instances tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)