### PR TITLE
Add self-reference for plugin compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",
+        "@openclaw/installer": "file:.",
         "express": "^4.21.0",
         "uuid": "^10.0.0",
         "ws": "^8.18.0"
@@ -1323,6 +1324,10 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
+    },
+    "node_modules/@openclaw/installer": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@openclaw/installer": "file:.",
     "@kubernetes/client-node": "^1.4.0",
     "express": "^4.21.0",
     "uuid": "^10.0.0",


### PR DESCRIPTION
## Summary

- Adds `"@openclaw/installer": "file:."` to dependencies so plugins can resolve imports at runtime

Plugins compiled against `@openclaw/installer` (e.g., `openclaw-installer-openshift`) have import statements like `import { KubernetesDeployer } from "@openclaw/installer/deployers/kubernetes"`. Without a self-reference, Node.js can't resolve `@openclaw/installer` from within `node_modules/`, causing plugins to fail with `ERR_MODULE_NOT_FOUND`.

This is a standard npm pattern for packages that need to be importable by their own name (e.g., for plugins or tests).

## Test plan

- [x] `npm test` passes
- [x] `npm install https://github.com/jwm4/openclaw-installer-openshift` succeeds
- [x] Plugin loads at startup: `Loaded plugin: openclaw-installer-openshift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)