### PR TITLE
fix(deployers): route LiteLLM proxy correctly for custom models and exclude API keys in proxy mode

### DIFF
--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -52,4 +52,48 @@ describe("model config generation", () => {
 
     expect(deriveModel(config)).toBe("anthropic/claude-sonnet-4-6");
   });
+
+  // Regression tests for #1: normalizeModelRef must use litellm/ prefix when proxy is active
+  it("normalizes vertex-anthropic custom model to litellm/ when proxy is enabled", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      litellmProxy: true,
+      agentModel: "claude-opus-4-6",
+    });
+
+    expect(normalizeModelRef(config, "claude-opus-4-6")).toBe("litellm/claude-opus-4-6");
+    expect(deriveModel(config)).toBe("litellm/claude-opus-4-6");
+  });
+
+  it("normalizes vertex-google custom model to litellm/ when proxy is enabled", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-google",
+      litellmProxy: true,
+      agentModel: "gemini-2.5-pro",
+    });
+
+    expect(normalizeModelRef(config, "gemini-2.5-pro")).toBe("litellm/gemini-2.5-pro");
+    expect(deriveModel(config)).toBe("litellm/gemini-2.5-pro");
+  });
+
+  it("normalizes vertex-anthropic custom model to anthropic-vertex/ when proxy is disabled", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      litellmProxy: false,
+      agentModel: "claude-opus-4-6",
+    });
+
+    expect(normalizeModelRef(config, "claude-opus-4-6")).toBe("anthropic-vertex/claude-opus-4-6");
+    expect(deriveModel(config)).toBe("anthropic-vertex/claude-opus-4-6");
+  });
+
+  it("passes through model refs that already contain a provider prefix", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      litellmProxy: true,
+    });
+
+    expect(normalizeModelRef(config, "litellm/my-model")).toBe("litellm/my-model");
+    expect(normalizeModelRef(config, "anthropic-vertex/my-model")).toBe("anthropic-vertex/my-model");
+  });
 });

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -1,15 +1,27 @@
 import { describe, expect, it } from "vitest";
 import { deploymentManifest, fileConfigMapManifest, fileTreeConfigMapManifest } from "../k8s-manifests.js";
 import type { DeployConfig } from "../types.js";
+import type * as k8s from "@kubernetes/client-node";
 
-describe("k8s state sync manifests", () => {
-  const config: DeployConfig = {
+function makeConfig(overrides: Partial<DeployConfig> = {}): DeployConfig {
+  return {
     mode: "kubernetes",
     prefix: "openclaw",
     agentName: "alpha",
     agentDisplayName: "Alpha",
     agentModel: "claude-sonnet-4-6",
+    ...overrides,
   };
+}
+
+/** Extract env var names from the gateway container in a deployment manifest. */
+function gatewayEnvNames(deployment: k8s.V1Deployment): string[] {
+  const container = deployment.spec?.template.spec?.containers?.find((c) => c.name === "gateway");
+  return (container?.env ?? []).map((e) => e.name);
+}
+
+describe("k8s state sync manifests", () => {
+  const config: DeployConfig = makeConfig();
 
   it("renders skill and cron ConfigMaps from host state entries", () => {
     const skillsCm = fileTreeConfigMapManifest("openclaw-alpha-openclaw", "openclaw-skills", [
@@ -57,5 +69,52 @@ describe("k8s state sync manifests", () => {
     expect(skillsVolume?.configMap?.items).toEqual([{ key: "f0", path: "briefing-bot/SKILL.md" }]);
     expect(cronVolume?.configMap?.name).toBe("openclaw-cron");
     expect(cronVolume?.configMap?.items).toEqual([{ key: "jobs.json", path: "jobs.json" }]);
+  });
+});
+
+// Regression tests for #6: API keys must not leak to the gateway in proxy mode
+describe("gateway env vars in proxy mode", () => {
+  it("excludes ANTHROPIC_API_KEY and OPENAI_API_KEY when litellm proxy is active", () => {
+    const proxyConfig = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      litellmProxy: true,
+      anthropicApiKey: "sk-ant-test",
+      openaiApiKey: "sk-oai-test",
+      gcpServiceAccountJson: '{"project_id":"test"}',
+    });
+
+    const deployment = deploymentManifest("ns", proxyConfig);
+    const envNames = gatewayEnvNames(deployment);
+
+    expect(envNames).not.toContain("ANTHROPIC_API_KEY");
+    expect(envNames).not.toContain("OPENAI_API_KEY");
+  });
+
+  it("includes ANTHROPIC_API_KEY and OPENAI_API_KEY when proxy is not active", () => {
+    const directConfig = makeConfig({
+      inferenceProvider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+      openaiApiKey: "sk-oai-test",
+    });
+
+    const deployment = deploymentManifest("ns", directConfig);
+    const envNames = gatewayEnvNames(deployment);
+
+    expect(envNames).toContain("ANTHROPIC_API_KEY");
+    expect(envNames).toContain("OPENAI_API_KEY");
+  });
+
+  it("excludes GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION when proxy is active", () => {
+    const proxyConfig = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      litellmProxy: true,
+      gcpServiceAccountJson: '{"project_id":"test"}',
+    });
+
+    const deployment = deploymentManifest("ns", proxyConfig);
+    const envNames = gatewayEnvNames(deployment);
+
+    expect(envNames).not.toContain("GOOGLE_CLOUD_PROJECT");
+    expect(envNames).not.toContain("GOOGLE_CLOUD_LOCATION");
   });
 });

--- a/src/server/deployers/k8s-helpers.js
+++ b/src/server/deployers/k8s-helpers.js
@@ -44,10 +44,13 @@ export function normalizeModelRef(config, modelRef) {
     if (config.inferenceProvider === "openai" || config.inferenceProvider === "custom-endpoint") {
         return `openai/${trimmed}`;
     }
-    if (config.inferenceProvider === "vertex-anthropic")
-        return `anthropic-vertex/${trimmed}`;
-    if (config.inferenceProvider === "vertex-google")
-        return `google-vertex/${trimmed}`;
+    // Fix for #1: check litellm proxy before falling back to direct vertex providers
+    if (config.inferenceProvider === "vertex-anthropic") {
+        return shouldUseLitellmProxy(config) ? `litellm/${trimmed}` : `anthropic-vertex/${trimmed}`;
+    }
+    if (config.inferenceProvider === "vertex-google") {
+        return shouldUseLitellmProxy(config) ? `litellm/${trimmed}` : `google-vertex/${trimmed}`;
+    }
     if (config.vertexEnabled && shouldUseLitellmProxy(config))
         return `litellm/${trimmed}`;
     if (config.vertexEnabled) {

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -48,8 +48,13 @@ export function normalizeModelRef(config: DeployConfig, modelRef: string): strin
   if (config.inferenceProvider === "openai" || config.inferenceProvider === "custom-endpoint") {
     return `openai/${trimmed}`;
   }
-  if (config.inferenceProvider === "vertex-anthropic") return `anthropic-vertex/${trimmed}`;
-  if (config.inferenceProvider === "vertex-google") return `google-vertex/${trimmed}`;
+  // Fix for #1: check litellm proxy before falling back to direct vertex providers
+  if (config.inferenceProvider === "vertex-anthropic") {
+    return shouldUseLitellmProxy(config) ? `litellm/${trimmed}` : `anthropic-vertex/${trimmed}`;
+  }
+  if (config.inferenceProvider === "vertex-google") {
+    return shouldUseLitellmProxy(config) ? `litellm/${trimmed}` : `google-vertex/${trimmed}`;
+  }
   if (config.vertexEnabled && shouldUseLitellmProxy(config)) return `litellm/${trimmed}`;
   if (config.vertexEnabled) {
     return `${config.vertexProvider === "anthropic" ? "anthropic-vertex" : "google-vertex"}/${trimmed}`;

--- a/src/server/deployers/k8s-manifests.js
+++ b/src/server/deployers/k8s-manifests.js
@@ -185,8 +185,9 @@ export function deploymentManifest(ns, config, otelViaOperator = false, skillEnt
     // Direct sidecar only when OTEL is enabled and operator is NOT handling it
     const useOtelDirect = useOtel && !otelViaOperator;
     const optionalKeys = [
-        "ANTHROPIC_API_KEY",
-        "OPENAI_API_KEY",
+        // Fix for #6: in proxy mode the gateway talks to LiteLLM, not directly
+        // to Anthropic/OpenAI, so don't leak API keys into the gateway env.
+        ...(!useProxy ? ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"] : []),
         "MODEL_ENDPOINT",
         "TELEGRAM_BOT_TOKEN",
         // In proxy mode LiteLLM gets project/location from its config.yaml;

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -207,8 +207,9 @@ export function deploymentManifest(
   const useOtelDirect = useOtel && !otelViaOperator;
 
   const optionalKeys = [
-    "ANTHROPIC_API_KEY",
-    "OPENAI_API_KEY",
+    // Fix for #6: in proxy mode the gateway talks to LiteLLM, not directly
+    // to Anthropic/OpenAI, so don't leak API keys into the gateway env.
+    ...(!useProxy ? ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"] : []),
     "MODEL_ENDPOINT",
     "TELEGRAM_BOT_TOKEN",
     // In proxy mode LiteLLM gets project/location from its config.yaml;

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -465,10 +465,12 @@ function buildRunArgs(
     NODE_ENV: "production",
   };
 
-  if (effectiveConfig.anthropicApiKey) {
+  // Fix for #6: in proxy mode the gateway talks to LiteLLM, not directly
+  // to Anthropic/OpenAI, so don't expose API keys to the gateway.
+  if (!useProxy && effectiveConfig.anthropicApiKey) {
     env.ANTHROPIC_API_KEY = effectiveConfig.anthropicApiKey;
   }
-  if (effectiveConfig.openaiApiKey) {
+  if (!useProxy && effectiveConfig.openaiApiKey) {
     env.OPENAI_API_KEY = effectiveConfig.openaiApiKey;
   }
   if (effectiveConfig.modelEndpoint) {


### PR DESCRIPTION
## Summary

Fixes two complementary bugs that prevented the LiteLLM proxy from working correctly when deploying with Vertex AI:

- **Issue #1**: `normalizeModelRef()` returned the wrong provider prefix (`anthropic-vertex/` instead of `litellm/`) for custom model names when the LiteLLM proxy was active
- **Issue #6**: `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` were unconditionally injected into the gateway container, causing OpenClaw to bypass the LiteLLM proxy and use the direct Anthropic API

Both bugs produced the same user-visible symptom: requests went to `api.anthropic.com` instead of routing through LiteLLM to Vertex AI.

## Changes

- `k8s-helpers.ts` / `.js`: Added `shouldUseLitellmProxy()` check to `normalizeModelRef()` for `vertex-anthropic` and `vertex-google` inference providers
- `k8s-manifests.ts` / `.js`: Wrapped `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` in the existing `!useProxy` conditional in `optionalKeys`
- `local.ts`: Added `!useProxy` guard to API key env var assignments
- 7 new regression tests covering both fixes

## Test plan

- [x] 4 new tests verify `normalizeModelRef()` returns correct prefix with/without proxy
- [x] 3 new tests verify API keys are excluded/included in gateway env based on proxy mode
- [x] All 90 tests pass (7 new + 83 existing)
- [x] Manual verification: deploy with Vertex AI + LiteLLM proxy and confirm requests route through proxy

Fixes #1, Fixes #6
