### PR TITLE
fix(deployers): hide unavailable plugin deployers instead of showing disabled

### DIFF
--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -9,6 +9,7 @@ interface DeployerInfo {
   description: string;
   available: boolean;
   priority: number;
+  builtIn: boolean;
 }
 
 interface Props {
@@ -209,9 +210,14 @@ export default function DeployForm({ onDeployStarted }: Props) {
   const isClusterMode = mode === "kubernetes" || mode === "openshift";
   const isVertex = inferenceProvider === "vertex-anthropic" || inferenceProvider === "vertex-google";
   const displayedDeployers = useMemo(
-    () => (defaults?.isOpenShift
-      ? deployers.filter((deployer) => deployer.mode !== "kubernetes")
-      : deployers),
+    () => {
+      // Hide unavailable plugin deployers (issue #10) — only built-in
+      // deployers should appear as disabled; plugin deployers are hidden entirely.
+      const visible = deployers.filter((d) => d.builtIn || d.available);
+      return defaults?.isOpenShift
+        ? visible.filter((d) => d.mode !== "kubernetes")
+        : visible;
+    },
     [defaults?.isOpenShift, deployers],
   );
 

--- a/src/client/components/__tests__/DeployForm.test.tsx
+++ b/src/client/components/__tests__/DeployForm.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DeployForm from "../DeployForm";
+
+// Stub fetch for /api/health to return deployer data
+function mockHealthResponse(deployers: Array<{ mode: string; title: string; description: string; available: boolean; priority: number; builtIn: boolean }>, overrides: Record<string, unknown> = {}) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      status: "ok",
+      containerRuntime: "podman",
+      k8sAvailable: false,
+      k8sContext: "",
+      k8sNamespace: "",
+      isOpenShift: false,
+      version: "0.1.0",
+      deployers,
+      defaults: {
+        hasAnthropicKey: true,
+        hasOpenaiKey: false,
+        hasTelegramToken: false,
+        telegramAllowFrom: "",
+        modelEndpoint: "",
+        prefix: "testuser",
+        image: "",
+      },
+      ...overrides,
+    }),
+  });
+}
+
+describe("DeployForm deployer visibility (issue #10)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("hides unavailable plugin deployers", async () => {
+    global.fetch = mockHealthResponse([
+      { mode: "local", title: "This Machine", description: "Run locally", available: true, priority: 0, builtIn: true },
+      { mode: "kubernetes", title: "Kubernetes", description: "Deploy to K8s", available: false, priority: 0, builtIn: true },
+      { mode: "openshift", title: "OpenShift", description: "Deploy to OpenShift", available: false, priority: 10, builtIn: false },
+    ]);
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+
+    // Wait for the health fetch to resolve and deployers to render
+    const localCard = await screen.findByText("This Machine");
+    expect(localCard).toBeTruthy();
+
+    // Built-in kubernetes should still appear even though unavailable
+    expect(screen.getByText("Kubernetes")).toBeTruthy();
+
+    // Plugin deployer (openshift) should be hidden when unavailable
+    expect(screen.queryByText("OpenShift")).toBeNull();
+  });
+
+  it("shows available plugin deployers", async () => {
+    global.fetch = mockHealthResponse([
+      { mode: "local", title: "This Machine", description: "Run locally", available: true, priority: 0, builtIn: true },
+      { mode: "openshift", title: "OpenShift", description: "Deploy to OpenShift", available: true, priority: 10, builtIn: false },
+    ]);
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+
+    const localCard = await screen.findByText("This Machine");
+    expect(localCard).toBeTruthy();
+
+    // Available plugin deployer should be visible
+    expect(screen.getByText("OpenShift")).toBeTruthy();
+  });
+});

--- a/src/server/deployers/__tests__/registry.test.ts
+++ b/src/server/deployers/__tests__/registry.test.ts
@@ -96,4 +96,16 @@ describe("DeployerRegistry", () => {
     expect(low?.priority).toBe(-1);
     expect(high?.priority).toBe(10);
   });
+
+  it("preserves builtIn flag in registrations", () => {
+    const reg = new DeployerRegistry();
+    reg.register({ mode: "core", title: "Core", description: "Built-in", deployer: stubDeployer(), builtIn: true });
+    reg.register({ mode: "plugin", title: "Plugin", description: "External", deployer: stubDeployer() });
+
+    const list = reg.list();
+    const core = list.find((r) => r.mode === "core");
+    const plugin = list.find((r) => r.mode === "plugin");
+    expect(core?.builtIn).toBe(true);
+    expect(plugin?.builtIn).toBeUndefined();
+  });
 });

--- a/src/server/deployers/registry.ts
+++ b/src/server/deployers/registry.ts
@@ -8,6 +8,7 @@ export interface DeployerRegistration {
   deployer: Deployer;
   detect?: () => Promise<boolean>;
   priority?: number;
+  builtIn?: boolean;
 }
 
 export interface InstallerPlugin {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -26,6 +26,7 @@ registry.register({
   deployer: new LocalDeployer(),
   detect: async () => !!(await detectRuntime()),
   priority: 0,
+  builtIn: true,
 });
 registry.register({
   mode: "kubernetes",
@@ -34,6 +35,7 @@ registry.register({
   deployer: new KubernetesDeployer(),
   detect: async () => isClusterReachable(),
   priority: 0,
+  builtIn: true,
 });
 
 // Load external plugins
@@ -72,6 +74,7 @@ app.get("/api/health", async (_req, res) => {
       description: reg.description,
       available: detected.some((d) => d.mode === reg.mode),
       priority: reg.priority ?? 0,
+      builtIn: reg.builtIn ?? false,
     })),
     defaults: {
       hasAnthropicKey: !!process.env.ANTHROPIC_API_KEY,


### PR DESCRIPTION
## Summary

- Add `builtIn` boolean to deployer registration, API response, and client type
- Filter out unavailable plugin deployers in the UI while keeping built-in deployers visible as disabled
- Add regression tests for registry field and DeployForm filtering behavior

Fixes #10

## Root Cause

The deployer plugin system had no way to distinguish built-in deployers from plugin deployers. All deployers were rendered identically, causing unavailable plugin deployers (like OpenShift when not on a cluster) to appear as confusing greyed-out cards.

## Changes

| File | Change |
|------|--------|
| `src/server/deployers/registry.ts` | Added `builtIn?: boolean` to `DeployerRegistration` |
| `src/server/index.ts` | Set `builtIn: true` on local/kubernetes; include in API response |
| `src/client/components/DeployForm.tsx` | Added `builtIn` to type; filter `!builtIn && !available` |

## Test plan

- [x] Registry preserves `builtIn` flag on registrations
- [x] DeployForm hides unavailable plugin deployers
- [x] DeployForm shows available plugin deployers
- [x] Full test suite passes (93/93)
- [x] Manual: verify OpenShift card hidden when logged out of cluster
- [x] Manual: verify OpenShift card appears when on OpenShift cluster
