### PR TITLE
show reason why deployer is disabled on mode card

### DIFF
--- a/provider-plugins/openshift/src/index.ts
+++ b/provider-plugins/openshift/src/index.ts
@@ -24,6 +24,7 @@ const plugin = {
       description: "Deploy to an OpenShift cluster with OAuth proxy and Routes",
       deployer: new OpenShiftDeployer(),
       detect: isOpenShift,
+      unavailableReason: "Not connected to an OpenShift cluster.",
       priority: 10,
     });
   },

--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -8,6 +8,7 @@ interface DeployerInfo {
   title: string;
   description: string;
   available: boolean;
+  unavailableReason?: string;
   priority: number;
   builtIn: boolean;
 }
@@ -759,6 +760,9 @@ export default function DeployForm({ onDeployStarted }: Props) {
               <div className="mode-icon">{MODE_ICONS[m.mode] || "🔌"}</div>
               <div className="mode-title">{m.title}</div>
               <div className="mode-desc">{m.description}</div>
+              {!m.available && m.unavailableReason && (
+                <div className="mode-unavailable-reason">{m.unavailableReason}</div>
+              )}
               {isSelected && <div className="mode-selected-badge">Selected</div>}
             </div>
           );

--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { validateAgentName } from "../../shared/validate-agent-name.js";
 
 type InferenceProvider = "anthropic" | "openai" | "vertex-anthropic" | "vertex-google" | "custom-endpoint";
@@ -212,13 +212,16 @@ export default function DeployForm({ onDeployStarted }: Props) {
 
   const [gcpDefaults, setGcpDefaults] = useState<GcpDefaults | null>(null);
   const [gcpDefaultsFetched, setGcpDefaultsFetched] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   const isClusterMode = mode === "kubernetes" || mode === "openshift";
   const isVertex = inferenceProvider === "vertex-anthropic" || inferenceProvider === "vertex-google";
   const displayedDeployers = useMemo(
     () => {
       // Hide unavailable plugin deployers (issue #10) — only built-in
-      // deployers should appear as disabled; plugin deployers are hidden entirely.
+      // deployers should appear as disabled; plugin deployers are hidden
+      // entirely so we don't promote commercial offerings to users who
+      // aren't already using them.
       const visible = deployers.filter((d) => d.builtIn || d.available);
       return defaults?.isOpenShift
         ? visible.filter((d) => d.mode !== "kubernetes")
@@ -244,8 +247,10 @@ export default function DeployForm({ onDeployStarted }: Props) {
       .catch(() => {});
   }, [isVertex, gcpDefaultsFetched]);
 
-  // Fetch server defaults (detected env vars + K8s availability)
-  useEffect(() => {
+  // Re-detect environment (K8s availability, deployers, env vars).
+  // Called on mount, on tab focus, and via the manual Refresh button.
+  const refreshEnvironment = useCallback((isInitial = false) => {
+    setRefreshing(true);
     fetch("/api/health")
       .then((r) => r.json())
       .then((data) => {
@@ -264,25 +269,34 @@ export default function DeployForm({ onDeployStarted }: Props) {
             return (b.priority ?? 0) - (a.priority ?? 0);
           });
           setDeployers(sorted);
-          if (sorted.length > 0 && sorted[0].available) {
+          // Only auto-select mode on first load
+          if (isInitial && sorted.length > 0 && sorted[0].available) {
             setMode(sorted[0].mode);
           }
         }
 
-        if (d.prefix) {
-          setConfig((prev) => ({ ...prev, prefix: d.prefix }));
-        }
-        if (d.modelEndpoint) {
-          setConfig((prev) => ({ ...prev, modelEndpoint: d.modelEndpoint }));
-          setInferenceProvider("custom-endpoint");
-        } else if (d.hasOpenaiKey && !d.hasAnthropicKey) {
-          setInferenceProvider("openai");
-        }
-        if (d.image) {
-          setConfig((prev) => ({ ...prev, image: d.image }));
+        if (isInitial) {
+          if (d.prefix) {
+            setConfig((prev) => ({ ...prev, prefix: d.prefix }));
+          }
+          if (d.modelEndpoint) {
+            setConfig((prev) => ({ ...prev, modelEndpoint: d.modelEndpoint }));
+            setInferenceProvider("custom-endpoint");
+          } else if (d.hasOpenaiKey && !d.hasAnthropicKey) {
+            setInferenceProvider("openai");
+          }
+          if (d.image) {
+            setConfig((prev) => ({ ...prev, image: d.image }));
+          }
         }
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => setRefreshing(false));
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    refreshEnvironment(true);
 
     // Load saved configs from ~/.openclaw/installer/
     fetch("/api/configs")
@@ -291,7 +305,18 @@ export default function DeployForm({ onDeployStarted }: Props) {
         setSavedConfigs(configs);
       })
       .catch(() => {});
-  }, []);
+  }, [refreshEnvironment]);
+
+  // Re-detect environment when the browser tab regains focus
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        refreshEnvironment();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [refreshEnvironment]);
 
   useEffect(() => {
     if (defaults?.isOpenShift && mode === "kubernetes") {
@@ -744,6 +769,17 @@ export default function DeployForm({ onDeployStarted }: Props) {
   return (
     <div>
       {/* Mode selector */}
+      <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "0.5rem" }}>
+        <button
+          type="button"
+          className="btn btn-ghost"
+          style={{ fontSize: "0.8rem", padding: "0.3rem 0.6rem" }}
+          disabled={refreshing}
+          onClick={() => refreshEnvironment()}
+        >
+          {refreshing ? "Refreshing\u2026" : "\u21BB Refresh Environment"}
+        </button>
+      </div>
       <div className="mode-grid">
         {displayedDeployers.map((m) => {
           const isSelected = mode === m.mode;

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -234,6 +234,12 @@ body {
   color: var(--text-secondary);
 }
 
+.mode-card .mode-unavailable-reason {
+  font-size: 0.75rem;
+  color: #e74c3c;
+  margin-top: 0.4rem;
+}
+
 /* Buttons */
 .btn {
   padding: 0.6rem 1.25rem;

--- a/src/server/deployers/registry.ts
+++ b/src/server/deployers/registry.ts
@@ -7,6 +7,7 @@ export interface DeployerRegistration {
   description: string;
   deployer: Deployer;
   detect?: () => Promise<boolean>;
+  unavailableReason?: string;
   priority?: number;
   builtIn?: boolean;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,6 +25,7 @@ registry.register({
   description: "Run OpenClaw locally with podman/docker",
   deployer: new LocalDeployer(),
   detect: async () => !!(await detectRuntime()),
+  unavailableReason: "No container runtime found. Install podman or docker.",
   priority: 0,
   builtIn: true,
 });
@@ -34,6 +35,7 @@ registry.register({
   description: "Deploy to a Kubernetes cluster",
   deployer: new KubernetesDeployer(),
   detect: async () => isClusterReachable(),
+  unavailableReason: "No Kubernetes cluster detected. Configure kubectl and ensure you are logged in.",
   priority: 0,
   builtIn: true,
 });
@@ -68,14 +70,18 @@ app.get("/api/health", async (_req, res) => {
     k8sNamespace: k8sReachable ? currentNamespace() : "",
     isOpenShift: detected.some((d) => d.mode === "openshift"),
     version: "0.1.0",
-    deployers: registry.list().map((reg) => ({
-      mode: reg.mode,
-      title: reg.title,
-      description: reg.description,
-      available: detected.some((d) => d.mode === reg.mode),
-      priority: reg.priority ?? 0,
-      builtIn: reg.builtIn ?? false,
-    })),
+    deployers: registry.list().map((reg) => {
+      const available = detected.some((d) => d.mode === reg.mode);
+      return {
+        mode: reg.mode,
+        title: reg.title,
+        description: reg.description,
+        available,
+        unavailableReason: !available ? (reg.unavailableReason || "") : "",
+        priority: reg.priority ?? 0,
+        builtIn: reg.builtIn ?? false,
+      };
+    }),
     defaults: {
       hasAnthropicKey: !!process.env.ANTHROPIC_API_KEY,
       hasOpenaiKey: !!process.env.OPENAI_API_KEY,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,7 +7,7 @@ import deployRoutes from "./routes/deploy.js";
 import statusRoutes from "./routes/status.js";
 import agentsRoutes from "./routes/agents.js";
 import { detectRuntime } from "./services/container.js";
-import { isClusterReachable, currentContext, currentNamespace } from "./services/k8s.js";
+import { isClusterReachable, currentContext, currentNamespace, resetKubeConfig } from "./services/k8s.js";
 import { stopAllK8sPortForwards } from "./services/k8s-port-forward.js";
 import { detectGcpDefaults } from "./services/gcp.js";
 import { readdir, readFile } from "node:fs/promises";
@@ -58,6 +58,7 @@ app.use("/api/agents", agentsRoutes);
 
 // Health check + environment defaults for the frontend
 app.get("/api/health", async (_req, res) => {
+  resetKubeConfig();
   const runtime = await detectRuntime();
   const k8sReachable = await isClusterReachable();
   const detected = await registry.detect();


### PR DESCRIPTION
When a deployer (e.g. Kubernetes) is unavailable, the mode card now displays a short red message explaining why, so users know what to fix.