### PR TITLE
feat: make cron opt-in and subagent spawning configurable

### DIFF
--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -198,6 +198,9 @@ export default function DeployForm({ onDeployStarted }: Props) {
     telegramEnabled: false,
     telegramBotToken: "",
     telegramAllowFrom: "",
+    // Agent security
+    cronEnabled: false,
+    subagentPolicy: "none" as "none" | "self" | "unrestricted",
     // Kubernetes
     namespace: "",
     // LiteLLM proxy
@@ -456,6 +459,8 @@ export default function DeployForm({ onDeployStarted }: Props) {
       otelEndpoint: v("OTEL_ENDPOINT", "otelEndpoint") || prev.otelEndpoint,
       otelExperimentId: v("OTEL_EXPERIMENT_ID", "otelExperimentId") || prev.otelExperimentId,
       otelImage: v("OTEL_IMAGE", "otelImage") || prev.otelImage,
+      cronEnabled: vars.cronEnabled === "true" ? true : prev.cronEnabled,
+      subagentPolicy: (vars.subagentPolicy as "none" | "self" | "unrestricted") || prev.subagentPolicy,
     }));
   };
 
@@ -619,6 +624,8 @@ export default function DeployForm({ onDeployStarted }: Props) {
         otelJaeger: config.otelEnabled ? config.otelJaeger || undefined : undefined,
         otelEndpoint: config.otelEnabled ? trimToUndefined(config.otelEndpoint) : undefined,
         otelExperimentId: config.otelEnabled ? trimToUndefined(config.otelExperimentId) : undefined,
+        cronEnabled: config.cronEnabled || undefined,
+        subagentPolicy: config.subagentPolicy !== "none" ? config.subagentPolicy : undefined,
       };
 
       const res = await fetch("/api/deploy", {
@@ -1655,6 +1662,48 @@ export default function DeployForm({ onDeployStarted }: Props) {
             </div>
           </>
         )}
+
+        <h3 style={{ marginTop: "1.5rem" }}>Agent Security</h3>
+
+        <div className="form-group">
+          <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            <input
+              type="checkbox"
+              checked={config.cronEnabled}
+              onChange={(e) =>
+                setConfig((prev) => ({ ...prev, cronEnabled: e.target.checked }))
+              }
+              style={{ width: "auto" }}
+            />
+            Enable cron jobs
+          </label>
+          <div className="hint">
+            Allow the agent to create and run scheduled tasks.
+            Most use cases don't require this, and it is a known risk vector
+            (agents can modify their own schedules).
+          </div>
+        </div>
+
+        <div className="form-group">
+          <label>Subagent spawning</label>
+          <select
+            value={config.subagentPolicy}
+            onChange={(e) =>
+              setConfig((prev) => ({
+                ...prev,
+                subagentPolicy: e.target.value as "none" | "self" | "unrestricted",
+              }))
+            }
+          >
+            <option value="none">Disabled</option>
+            <option value="self">Same agent only (self-delegation)</option>
+            <option value="unrestricted">Unrestricted (any agent)</option>
+          </select>
+          <div className="hint">
+            Controls whether the agent can spawn subagents.
+            "Unrestricted" allows spawning any agent, which increases attack surface.
+          </div>
+        </div>
 
         <div style={{ marginTop: "1.5rem" }}>
           {!isValid && (

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -97,6 +97,14 @@ export function deriveModel(config: DeployConfig): string {
   return "anthropic/claude-sonnet-4-6";
 }
 
+function subagentConfig(policy?: string): { allowAgents: string[] } {
+  switch (policy) {
+    case "self": return { allowAgents: ["self"] };
+    case "unrestricted": return { allowAgents: ["*"] };
+    default: return { allowAgents: [] };
+  }
+}
+
 export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): object {
   const id = agentId(config);
   const model = deriveModel(config);
@@ -142,7 +150,7 @@ export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string):
           name: config.agentDisplayName || config.agentName,
           workspace: `~/.openclaw/workspace-${id}`,
           model: { primary: model },
-          subagents: sourceBundle?.mainAgent?.subagents || { allowAgents: ["*"] },
+          subagents: sourceBundle?.mainAgent?.subagents || subagentConfig(config.subagentPolicy),
           ...(sourceBundle?.mainAgent?.tools ? { tools: sourceBundle.mainAgent.tools } : {}),
         },
         ...((sourceBundle?.agents || []).map((entry) => ({
@@ -171,7 +179,7 @@ export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string):
     skills: {
       load: { extraDirs: ["~/.openclaw/skills"], watch: true, watchDebounceMs: 1000 },
     },
-    cron: { enabled: true },
+    cron: { enabled: !!config.cronEnabled },
   };
 
   const sandboxToolPolicy = buildSandboxToolPolicy(config);

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -157,6 +157,14 @@ function deriveModel(config: DeployConfig): string {
 /**
  * Build the openclaw.json config for a fresh volume.
  */
+function subagentConfig(policy?: string): { allowAgents: string[] } {
+  switch (policy) {
+    case "self": return { allowAgents: ["self"] };
+    case "unrestricted": return { allowAgents: ["*"] };
+    default: return { allowAgents: [] };
+  }
+}
+
 function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string {
   const agentId = `${config.prefix || "openclaw"}_${config.agentName}`;
   const model = deriveModel(config);
@@ -211,7 +219,7 @@ function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string
           name: config.agentDisplayName || config.agentName,
           workspace: `~/.openclaw/workspace-${agentId}`,
           model: { primary: model },
-          subagents: sourceBundle?.mainAgent?.subagents || { allowAgents: ["*"] },
+          subagents: sourceBundle?.mainAgent?.subagents || subagentConfig(config.subagentPolicy),
           ...(sourceBundle?.mainAgent?.tools ? { tools: sourceBundle.mainAgent.tools } : {}),
         },
         ...((sourceBundle?.agents || []).map((entry) => ({
@@ -244,7 +252,7 @@ function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string
         watchDebounceMs: 1000,
       },
     },
-    cron: { enabled: true },
+    cron: { enabled: !!config.cronEnabled },
   };
 
   const sandboxToolPolicy = buildSandboxToolPolicy(config);

--- a/src/server/deployers/types.ts
+++ b/src/server/deployers/types.ts
@@ -59,6 +59,9 @@ export interface DeployConfig {
   otelExperimentId?: string;   // MLflow experiment ID (optional, for MLflow endpoints)
   otelImage?: string;
   otelJaeger?: boolean;        // Run Jaeger all-in-one as a sidecar (UI on port 16686)
+  // Agent security
+  cronEnabled?: boolean; // default: false (opt-in)
+  subagentPolicy?: "none" | "self" | "unrestricted"; // default: "none"
   // Telegram channel
   telegramEnabled?: boolean;
   telegramBotToken?: string;


### PR DESCRIPTION
Cron jobs are now disabled by default and subagent spawning defaults to "none" instead of unrestricted. 
Both settings are configurable through the deploy UI under a new "Agent Security" section.

Fixes #26