### PR TITLE
add Plugins tab with enable/disable for deployer plugins

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -2,8 +2,9 @@ import React, { useState } from "react";
 import DeployForm from "./components/DeployForm";
 import InstanceList from "./components/InstanceList";
 import LogStream from "./components/LogStream";
+import PluginList from "./components/PluginList";
 
-type Tab = "deploy" | "instances";
+type Tab = "deploy" | "instances" | "plugins";
 
 export default function App() {
   const [tab, setTab] = useState<Tab>("deploy");
@@ -29,6 +30,12 @@ export default function App() {
         >
           Instances
         </button>
+        <button
+          className={`tab ${tab === "plugins" ? "active" : ""}`}
+          onClick={() => setTab("plugins")}
+        >
+          Plugins
+        </button>
       </div>
 
       <div style={{ display: tab === "deploy" ? "block" : "none" }}>
@@ -42,6 +49,10 @@ export default function App() {
 
       <div style={{ display: tab === "instances" ? "block" : "none" }}>
         <InstanceList />
+      </div>
+
+      <div style={{ display: tab === "plugins" ? "block" : "none" }}>
+        <PluginList />
       </div>
     </div>
   );

--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -18,6 +18,7 @@ interface DeployerInfo {
   unavailableReason?: string;
   priority: number;
   builtIn: boolean;
+  enabled: boolean;
 }
 
 interface Props {
@@ -263,11 +264,17 @@ export default function DeployForm({ onDeployStarted }: Props) {
   const displayedDeployers = useMemo(
     () => {
       // Hide unavailable plugin deployers (issue #10) — only built-in
-      // deployers should appear as disabled; plugin deployers are hidden
-      // entirely so we don't promote commercial offerings to users who
-      // aren't already using them.
-      const visible = deployers.filter((d) => d.builtIn || d.available);
-      return defaults?.isOpenShift
+      // deployers should appear as disabled; plugin deployers are hidden entirely.
+      // Also hide deployers that have been disabled via the Plugins tab.
+      const visible = deployers.filter((d) =>
+        d.enabled !== false && (d.builtIn || d.available),
+      );
+      // Only hide Kubernetes when OpenShift is both available and enabled,
+      // so disabling the OpenShift plugin falls back to the Kubernetes deployer.
+      const openshiftActive = visible.some(
+        (d) => d.mode === "openshift" && d.available,
+      );
+      return defaults?.isOpenShift && openshiftActive
         ? visible.filter((d) => d.mode !== "kubernetes")
         : visible;
     },

--- a/src/client/components/PluginList.tsx
+++ b/src/client/components/PluginList.tsx
@@ -1,0 +1,256 @@
+import React, { useEffect, useState } from "react";
+
+interface PluginInfo {
+  mode: string;
+  title: string;
+  description: string;
+  source: string;
+  enabled: boolean;
+  available: boolean;
+  builtIn: boolean;
+  priority: number;
+}
+
+interface PluginLoadError {
+  pluginId: string;
+  error: string;
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  "built-in": "Built-in",
+  "provider-plugin": "Provider Plugin",
+  "npm": "NPM Package",
+  "config": "Custom",
+};
+
+const MODE_ICONS: Record<string, string> = {
+  local: "\uD83D\uDCBB",
+  kubernetes: "\u2638\uFE0F",
+  openshift: "\u2638\uFE0F",
+  ssh: "\uD83D\uDDA5\uFE0F",
+};
+
+export default function PluginList() {
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+  const [errors, setErrors] = useState<PluginLoadError[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState<string | null>(null);
+  const [showErrors, setShowErrors] = useState(false);
+
+  const fetchPlugins = () => {
+    fetch("/api/plugins")
+      .then((r) => r.json())
+      .then((data) => {
+        setPlugins(data.plugins || []);
+        setErrors(data.errors || []);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchPlugins();
+  }, []);
+
+  const handleToggle = async (mode: string, currentlyEnabled: boolean) => {
+    setToggling(mode);
+    try {
+      const action = currentlyEnabled ? "disable" : "enable";
+      const res = await fetch(`/api/plugins/${mode}/${action}`, { method: "POST" });
+      if (res.ok) {
+        fetchPlugins();
+      }
+    } catch {
+      // ignore
+    } finally {
+      setToggling(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="card">
+        <div className="empty-state">
+          <p>Loading plugins...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const builtInPlugins = plugins.filter((p) => p.builtIn);
+  const externalPlugins = plugins.filter((p) => !p.builtIn);
+
+  return (
+    <div>
+      <div className="card">
+        <h3>Registered Deployers</h3>
+        <p style={{ fontSize: "0.85rem", color: "var(--text-secondary)", marginBottom: "1rem" }}>
+          Deployer plugins provide deployment targets. Built-in deployers are always available.
+          Provider and third-party plugins can be enabled or disabled.
+        </p>
+
+        {builtInPlugins.length > 0 && (
+          <>
+            <div style={{ fontSize: "0.8rem", color: "var(--text-muted)", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.5rem" }}>
+              Built-in
+            </div>
+            {builtInPlugins.map((p) => (
+              <PluginRow key={p.mode} plugin={p} toggling={toggling} onToggle={handleToggle} />
+            ))}
+          </>
+        )}
+
+        {externalPlugins.length > 0 && (
+          <>
+            <div style={{ fontSize: "0.8rem", color: "var(--text-muted)", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", marginTop: "1rem", marginBottom: "0.5rem" }}>
+              Plugins
+            </div>
+            {externalPlugins.map((p) => (
+              <PluginRow key={p.mode} plugin={p} toggling={toggling} onToggle={handleToggle} />
+            ))}
+          </>
+        )}
+
+        {plugins.length === 0 && (
+          <div className="empty-state">
+            <div className="empty-icon">{"\uD83D\uDD0C"}</div>
+            <p>No deployers registered</p>
+          </div>
+        )}
+      </div>
+
+      {errors.length > 0 && (
+        <div className="card" style={{ borderColor: "rgba(248, 81, 73, 0.3)" }}>
+          <button
+            type="button"
+            onClick={() => setShowErrors(!showErrors)}
+            style={{
+              background: "none",
+              border: "none",
+              color: "var(--danger)",
+              cursor: "pointer",
+              fontWeight: 600,
+              fontSize: "0.9rem",
+              padding: 0,
+              display: "flex",
+              alignItems: "center",
+              gap: "0.5rem",
+            }}
+          >
+            <span>{showErrors ? "\u25BC" : "\u25B6"}</span>
+            {errors.length} plugin{errors.length !== 1 ? "s" : ""} failed to load
+          </button>
+          {showErrors && (
+            <div style={{ marginTop: "0.75rem" }}>
+              {errors.map((err) => (
+                <div
+                  key={err.pluginId}
+                  style={{
+                    padding: "0.5rem 0.75rem",
+                    marginBottom: "0.5rem",
+                    background: "rgba(248, 81, 73, 0.08)",
+                    borderRadius: "var(--radius-sm)",
+                    fontSize: "0.85rem",
+                  }}
+                >
+                  <div style={{ fontWeight: 500, color: "var(--text-primary)" }}>
+                    {err.pluginId}
+                  </div>
+                  <div style={{ color: "var(--text-secondary)", marginTop: "0.25rem", fontFamily: "var(--font-mono)", fontSize: "0.8rem" }}>
+                    {err.error}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PluginRow({
+  plugin,
+  toggling,
+  onToggle,
+}: {
+  plugin: PluginInfo;
+  toggling: string | null;
+  onToggle: (mode: string, enabled: boolean) => void;
+}) {
+  const statusColor = !plugin.enabled
+    ? "var(--text-muted)"
+    : plugin.available
+      ? "var(--success)"
+      : "var(--warning)";
+
+  const statusLabel = !plugin.enabled
+    ? "Disabled"
+    : plugin.available
+      ? "Active"
+      : "Unavailable";
+
+  return (
+    <div className="instance-row">
+      <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", flex: 1, opacity: plugin.enabled ? 1 : 0.55 }}>
+        <div style={{ fontSize: "1.5rem", width: "2rem", textAlign: "center" }}>
+          {MODE_ICONS[plugin.mode] || "\uD83D\uDD0C"}
+        </div>
+        <div className="instance-info">
+          <div className="instance-name">
+            {plugin.title}
+            <span style={{ fontWeight: 400, color: "var(--text-muted)", marginLeft: "0.5rem", fontSize: "0.8rem" }}>
+              {plugin.mode}
+            </span>
+          </div>
+          <div className="instance-meta">
+            {plugin.description}
+            <span style={{ marginLeft: "0.5rem" }}>
+              {" \u2022 "}
+              <span style={{
+                fontSize: "0.75rem",
+                padding: "0.1rem 0.4rem",
+                borderRadius: "99px",
+                background: "rgba(139, 148, 158, 0.15)",
+                color: "var(--text-secondary)",
+              }}>
+                {SOURCE_LABELS[plugin.source] || plugin.source}
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div className="instance-actions" style={{ alignItems: "center", gap: "0.75rem" }}>
+        <span
+          className={`badge ${!plugin.enabled ? "badge-stopped" : plugin.available ? "badge-running" : "badge-deploying"}`}
+          style={{ minWidth: "5rem", textAlign: "center" }}
+        >
+          <span style={{
+            display: "inline-block",
+            width: "6px",
+            height: "6px",
+            borderRadius: "50%",
+            backgroundColor: statusColor,
+            marginRight: "0.35rem",
+          }} />
+          {statusLabel}
+        </span>
+        {!plugin.builtIn && (
+          <button
+            className={`btn ${plugin.enabled ? "btn-ghost" : "btn-primary"}`}
+            style={{ minWidth: "5rem", justifyContent: "center" }}
+            disabled={toggling === plugin.mode}
+            onClick={() => onToggle(plugin.mode, plugin.enabled)}
+            aria-label={`${plugin.enabled ? "Disable" : "Enable"} ${plugin.title} plugin`}
+          >
+            {toggling === plugin.mode
+              ? "..."
+              : plugin.enabled
+                ? "Disable"
+                : "Enable"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/__tests__/DeployForm.test.tsx
+++ b/src/client/components/__tests__/DeployForm.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/re
 import DeployForm from "../DeployForm";
 
 // Stub fetch for /api/health to return deployer data
-function mockHealthResponse(deployers: Array<{ mode: string; title: string; description: string; available: boolean; priority: number; builtIn: boolean }>, overrides: Record<string, unknown> = {}) {
+function mockHealthResponse(deployers: Array<{ mode: string; title: string; description: string; available: boolean; priority: number; builtIn: boolean; enabled?: boolean }>, overrides: Record<string, unknown> = {}) {
   return vi.fn().mockResolvedValue({
     ok: true,
     json: async () => ({
@@ -71,6 +71,23 @@ describe("DeployForm deployer visibility (issue #10)", () => {
 
     // Available plugin deployer should be visible
     expect(screen.getByText("OpenShift")).toBeTruthy();
+  });
+
+  it("hides disabled plugin deployers from mode selector", async () => {
+    global.fetch = mockHealthResponse([
+      { mode: "local", title: "This Machine", description: "Run locally", available: true, priority: 0, builtIn: true, enabled: true },
+      { mode: "openshift", title: "OpenShift", description: "Deploy to OpenShift", available: true, priority: 10, builtIn: false, enabled: false },
+    ]);
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+
+    // Wait for deployers to render
+    await waitFor(() => {
+      expect(screen.getAllByText("This Machine").length).toBeGreaterThan(0);
+    });
+
+    // Disabled plugin deployer should be hidden
+    expect(screen.queryByText("OpenShift")).toBeNull();
   });
 
   it("does not auto-fill the default cluster namespace into the form", async () => {

--- a/src/client/components/__tests__/PluginList.test.tsx
+++ b/src/client/components/__tests__/PluginList.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import PluginList from "../PluginList";
+
+const pluginsResponse = {
+  plugins: [
+    { mode: "local", title: "This Machine", description: "Run locally", source: "built-in", enabled: true, available: true, builtIn: true, priority: 0 },
+    { mode: "kubernetes", title: "Kubernetes", description: "Deploy to K8s", source: "built-in", enabled: true, available: false, builtIn: true, priority: 0 },
+    { mode: "openshift", title: "OpenShift", description: "Deploy to OpenShift", source: "provider-plugin", enabled: true, available: true, builtIn: false, priority: 10 },
+  ],
+  errors: [],
+};
+
+function mockFetch(response = pluginsResponse) {
+  return vi.fn((url: string, opts?: RequestInit) => {
+    if (url === "/api/plugins" && !opts?.method) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(response) });
+    }
+    // enable/disable POST
+    if (url.startsWith("/api/plugins/") && opts?.method === "POST") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe("PluginList", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders all plugins grouped by source", async () => {
+    global.fetch = mockFetch();
+    render(<PluginList />);
+
+    await screen.findByText("This Machine");
+    expect(screen.getByText("Kubernetes")).toBeTruthy();
+    expect(screen.getByText("OpenShift")).toBeTruthy();
+
+    // Section headers and source badges
+    expect(screen.getAllByText("Built-in").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Plugins")).toBeTruthy();
+  });
+
+  it("shows Active badge for available enabled plugins", async () => {
+    global.fetch = mockFetch();
+    render(<PluginList />);
+
+    await screen.findByText("This Machine");
+    const badges = screen.getAllByText("Active");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows Unavailable badge for enabled but not detected plugins", async () => {
+    global.fetch = mockFetch();
+    render(<PluginList />);
+
+    await screen.findByText("Kubernetes");
+    expect(screen.getByText("Unavailable")).toBeTruthy();
+  });
+
+  it("shows Disabled badge for disabled plugins", async () => {
+    const response = {
+      plugins: [
+        { mode: "openshift", title: "OpenShift", description: "Deploy to OpenShift", source: "provider-plugin", enabled: false, available: true, builtIn: false, priority: 10 },
+      ],
+      errors: [],
+    };
+    global.fetch = mockFetch(response);
+    render(<PluginList />);
+
+    await screen.findByText("OpenShift");
+    expect(screen.getByText("Disabled")).toBeTruthy();
+  });
+
+  it("does not show Enable/Disable button for built-in deployers", async () => {
+    global.fetch = mockFetch();
+    render(<PluginList />);
+
+    await screen.findByText("This Machine");
+    // Built-in plugins should not have Enable/Disable buttons
+    expect(screen.queryByRole("button", { name: /disable this machine/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /enable this machine/i })).toBeNull();
+  });
+
+  it("shows Disable button for non-built-in enabled plugins", async () => {
+    global.fetch = mockFetch();
+    render(<PluginList />);
+
+    await screen.findByText("OpenShift");
+    const btn = screen.getByRole("button", { name: /disable openshift/i });
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toBe("Disable");
+  });
+
+  it("shows Enable button for disabled plugins", async () => {
+    const response = {
+      plugins: [
+        { mode: "openshift", title: "OpenShift", description: "Deploy to OpenShift", source: "provider-plugin", enabled: false, available: true, builtIn: false, priority: 10 },
+      ],
+      errors: [],
+    };
+    global.fetch = mockFetch(response);
+    render(<PluginList />);
+
+    await screen.findByText("OpenShift");
+    const btn = screen.getByRole("button", { name: /enable openshift/i });
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toBe("Enable");
+  });
+
+  it("calls disable API and re-fetches on Disable click", async () => {
+    const fetchMock = mockFetch();
+    global.fetch = fetchMock;
+    render(<PluginList />);
+
+    await screen.findByText("OpenShift");
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /disable openshift/i }));
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls;
+      const disableCall = calls.find(
+        ([url, opts]: [string, RequestInit?]) =>
+          url === "/api/plugins/openshift/disable" && opts?.method === "POST",
+      );
+      expect(disableCall).toBeTruthy();
+    });
+  });
+
+  it("shows load errors section when errors exist", async () => {
+    const response = {
+      plugins: [],
+      errors: [
+        { pluginId: "openclaw-installer-broken", error: "Module not found" },
+      ],
+    };
+    global.fetch = mockFetch(response);
+    render(<PluginList />);
+
+    await screen.findByText(/1 plugin failed to load/);
+  });
+
+  it("toggles error details visibility", async () => {
+    const response = {
+      plugins: [],
+      errors: [
+        { pluginId: "openclaw-installer-broken", error: "Module not found" },
+      ],
+    };
+    global.fetch = mockFetch(response);
+    render(<PluginList />);
+
+    const toggle = await screen.findByText(/1 plugin failed to load/);
+
+    // Error details hidden by default
+    expect(screen.queryByText("openclaw-installer-broken")).toBeNull();
+
+    // Click to expand
+    const user = userEvent.setup();
+    await user.click(toggle);
+    expect(screen.getByText("openclaw-installer-broken")).toBeTruthy();
+    expect(screen.getByText("Module not found")).toBeTruthy();
+  });
+
+  it("shows empty state when no plugins", async () => {
+    global.fetch = mockFetch({ plugins: [], errors: [] });
+    render(<PluginList />);
+
+    await screen.findByText("No deployers registered");
+  });
+
+  it("shows source badges", async () => {
+    global.fetch = mockFetch();
+    render(<PluginList />);
+
+    await screen.findByText("This Machine");
+    expect(screen.getAllByText("Built-in").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Provider Plugin")).toBeTruthy();
+  });
+});

--- a/src/server/deployers/__tests__/registry.test.ts
+++ b/src/server/deployers/__tests__/registry.test.ts
@@ -108,4 +108,47 @@ describe("DeployerRegistry", () => {
     expect(core?.builtIn).toBe(true);
     expect(plugin?.builtIn).toBeUndefined();
   });
+
+  it("applies currentSource to registrations", () => {
+    const reg = new DeployerRegistry();
+    reg.currentSource = "built-in";
+    reg.register({ mode: "local", title: "Local", description: "Local deploy", deployer: stubDeployer() });
+
+    reg.currentSource = "provider-plugin";
+    reg.register({ mode: "openshift", title: "OpenShift", description: "OpenShift deploy", deployer: stubDeployer() });
+
+    const list = reg.list();
+    expect(list.find((r) => r.mode === "local")?.source).toBe("built-in");
+    expect(list.find((r) => r.mode === "openshift")?.source).toBe("provider-plugin");
+  });
+
+  it("explicit source in registration overrides currentSource", () => {
+    const reg = new DeployerRegistry();
+    reg.currentSource = "npm";
+    reg.register({ mode: "custom", title: "Custom", description: "Custom", deployer: stubDeployer(), source: "config" });
+
+    expect(reg.list()[0].source).toBe("config");
+  });
+
+  it("tracks load errors", () => {
+    const reg = new DeployerRegistry();
+    expect(reg.loadErrors()).toHaveLength(0);
+
+    reg.addLoadError({ pluginId: "bad-plugin", error: "Missing register function" });
+    reg.addLoadError({ pluginId: "broken-plugin", error: "Import failed" });
+
+    const errors = reg.loadErrors();
+    expect(errors).toHaveLength(2);
+    expect(errors[0].pluginId).toBe("bad-plugin");
+    expect(errors[1].error).toBe("Import failed");
+  });
+
+  it("loadErrors returns a copy", () => {
+    const reg = new DeployerRegistry();
+    reg.addLoadError({ pluginId: "test", error: "err" });
+    const a = reg.loadErrors();
+    const b = reg.loadErrors();
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
 });

--- a/src/server/deployers/registry.ts
+++ b/src/server/deployers/registry.ts
@@ -1,6 +1,8 @@
 import console from "node:console";
 import type { Deployer } from "./types.js";
 
+export type PluginSource = "built-in" | "provider-plugin" | "npm" | "config";
+
 export interface DeployerRegistration {
   mode: string;
   title: string;
@@ -10,6 +12,12 @@ export interface DeployerRegistration {
   unavailableReason?: string;
   priority?: number;
   builtIn?: boolean;
+  source?: PluginSource;
+}
+
+export interface PluginLoadError {
+  pluginId: string;
+  error: string;
 }
 
 export interface InstallerPlugin {
@@ -18,12 +26,16 @@ export interface InstallerPlugin {
 
 export class DeployerRegistry {
   private registrations = new Map<string, DeployerRegistration>();
+  private _loadErrors: PluginLoadError[] = [];
+
+  /** Set before calling plugin.register() so that source is auto-applied. */
+  currentSource: PluginSource = "built-in";
 
   register(reg: DeployerRegistration): void {
     if (this.registrations.has(reg.mode)) {
       console.warn(`DeployerRegistry: overwriting existing registration for mode "${reg.mode}"`);
     }
-    this.registrations.set(reg.mode, reg);
+    this.registrations.set(reg.mode, { ...reg, source: reg.source ?? this.currentSource });
   }
 
   get(mode: string): Deployer | null {
@@ -32,6 +44,14 @@ export class DeployerRegistry {
 
   list(): DeployerRegistration[] {
     return Array.from(this.registrations.values());
+  }
+
+  addLoadError(err: PluginLoadError): void {
+    this._loadErrors.push(err);
+  }
+
+  loadErrors(): PluginLoadError[] {
+    return [...this._loadErrors];
   }
 
   async detect(): Promise<DeployerRegistration[]> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,6 +6,7 @@ import { setupWebSocket } from "./ws.js";
 import deployRoutes from "./routes/deploy.js";
 import statusRoutes from "./routes/status.js";
 import agentsRoutes from "./routes/agents.js";
+import pluginsRoutes from "./routes/plugins.js";
 import { detectRuntime } from "./services/container.js";
 import { isClusterReachable, currentContext, currentNamespace, resetKubeConfig } from "./services/k8s.js";
 import { stopAllK8sPortForwards } from "./services/k8s-port-forward.js";
@@ -16,7 +17,7 @@ import { installerDataDir } from "./paths.js";
 import { registry } from "./deployers/registry.js";
 import { LocalDeployer } from "./deployers/local.js";
 import { KubernetesDeployer } from "./deployers/kubernetes.js";
-import { loadPlugins } from "./plugins/loader.js";
+import { loadPlugins, getDisabledModes } from "./plugins/loader.js";
 
 // Register built-in deployers
 registry.register({
@@ -55,6 +56,7 @@ app.use(express.json());
 app.use("/api/deploy", deployRoutes);
 app.use("/api/instances", statusRoutes);
 app.use("/api/agents", agentsRoutes);
+app.use("/api/plugins", pluginsRoutes);
 
 // Health check + environment defaults for the frontend
 app.get("/api/health", async (_req, res) => {
@@ -62,6 +64,7 @@ app.get("/api/health", async (_req, res) => {
   const runtime = await detectRuntime();
   const k8sReachable = await isClusterReachable();
   const detected = await registry.detect();
+  const disabledModes = new Set(await getDisabledModes());
 
   res.json({
     status: "ok",
@@ -81,6 +84,7 @@ app.get("/api/health", async (_req, res) => {
         unavailableReason: !available ? (reg.unavailableReason || "") : "",
         priority: reg.priority ?? 0,
         builtIn: reg.builtIn ?? false,
+        enabled: !disabledModes.has(reg.mode),
       };
     }),
     defaults: {

--- a/src/server/plugins/loader.ts
+++ b/src/server/plugins/loader.ts
@@ -1,5 +1,5 @@
-import { readdir, readFile } from "node:fs/promises";
-import { join, sep } from "node:path";
+import { readdir, readFile, writeFile, mkdir } from "node:fs/promises";
+import { join, dirname, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 import { homedir } from "node:os";
 import { existsSync } from "node:fs";
@@ -10,8 +10,58 @@ const PLUGIN_PREFIX = "openclaw-installer-";
 const CONFIG_PATH = join(homedir(), ".openclaw", "installer", "plugins.json");
 const BUILT_RUNTIME_SEGMENT = `${sep}dist${sep}`;
 
+export interface PluginConfig {
+  plugins?: string[];
+  disabled?: string[];
+}
+
 function isBuiltRuntime(): boolean {
   return import.meta.dirname.includes(BUILT_RUNTIME_SEGMENT);
+}
+
+async function readPluginConfig(): Promise<PluginConfig> {
+  if (!existsSync(CONFIG_PATH)) return {};
+
+  try {
+    const content = await readFile(CONFIG_PATH, "utf8");
+    return JSON.parse(content) as PluginConfig;
+  } catch {
+    return {};
+  }
+}
+
+async function writePluginConfig(config: PluginConfig): Promise<void> {
+  const dir = dirname(CONFIG_PATH);
+  if (!existsSync(dir)) {
+    await mkdir(dir, { recursive: true });
+  }
+  await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf8");
+}
+
+export async function getDisabledModes(): Promise<string[]> {
+  const config = await readPluginConfig();
+  if (Array.isArray(config.disabled)) {
+    return config.disabled.filter((m): m is string => typeof m === "string");
+  }
+  return [];
+}
+
+export async function setModeDisabled(mode: string, disabled: boolean): Promise<void> {
+  const config = await readPluginConfig();
+  const current = new Set(
+    Array.isArray(config.disabled)
+      ? config.disabled.filter((m): m is string => typeof m === "string")
+      : [],
+  );
+
+  if (disabled) {
+    current.add(mode);
+  } else {
+    current.delete(mode);
+  }
+
+  config.disabled = [...current];
+  await writePluginConfig(config);
 }
 
 async function discoverProviderPlugins(registry: DeployerRegistry): Promise<void> {
@@ -31,6 +81,8 @@ async function discoverProviderPlugins(registry: DeployerRegistry): Promise<void
     return;
   }
 
+  registry.currentSource = "provider-plugin";
+
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
 
@@ -49,6 +101,7 @@ async function discoverProviderPlugins(registry: DeployerRegistry): Promise<void
 
       if (typeof plugin?.register !== "function") {
         console.warn(`Provider plugin "${name}" does not export a register function, skipping`);
+        registry.addLoadError({ pluginId: name, error: "Does not export a register function" });
         continue;
       }
 
@@ -56,6 +109,7 @@ async function discoverProviderPlugins(registry: DeployerRegistry): Promise<void
       console.log(`Loaded provider plugin: ${name}`);
     } catch (err) {
       console.warn(`Failed to load provider plugin "${name}":`, err);
+      registry.addLoadError({ pluginId: name, error: String(err) });
     }
   }
 }
@@ -98,29 +152,23 @@ async function discoverNpmPlugins(): Promise<string[]> {
 }
 
 async function loadConfigPlugins(): Promise<string[]> {
-  if (!existsSync(CONFIG_PATH)) return [];
-
-  try {
-    const content = await readFile(CONFIG_PATH, "utf8");
-    const config = JSON.parse(content);
-    if (Array.isArray(config.plugins)) {
-      return config.plugins.filter((p: unknown) => typeof p === "string");
-    }
-  } catch (err) {
-    console.warn(`Failed to read plugin config at ${CONFIG_PATH}:`, err);
+  const config = await readPluginConfig();
+  if (Array.isArray(config.plugins)) {
+    return config.plugins.filter((p: unknown) => typeof p === "string");
   }
-
   return [];
 }
 
-async function loadPlugin(registry: DeployerRegistry, moduleId: string): Promise<void> {
+async function loadPlugin(registry: DeployerRegistry, moduleId: string, source: "npm" | "config"): Promise<void> {
   console.log(`Attempting to load plugin: ${moduleId}`);
+  registry.currentSource = source;
   try {
     const mod = await import(moduleId);
     const plugin: InstallerPlugin | undefined = mod.default ?? mod;
 
     if (typeof plugin?.register !== "function") {
       console.warn(`Plugin "${moduleId}" does not export a register function, skipping`);
+      registry.addLoadError({ pluginId: moduleId, error: "Does not export a register function" });
       return;
     }
 
@@ -128,6 +176,7 @@ async function loadPlugin(registry: DeployerRegistry, moduleId: string): Promise
     console.log(`Loaded plugin: ${moduleId}`);
   } catch (err) {
     console.warn(`Failed to load plugin "${moduleId}":`, err);
+    registry.addLoadError({ pluginId: moduleId, error: String(err) });
   }
 }
 
@@ -138,11 +187,17 @@ export async function loadPlugins(registry: DeployerRegistry): Promise<void> {
   const npmPlugins = await discoverNpmPlugins();
   const configPlugins = await loadConfigPlugins();
 
+  // Determine source for each plugin (npm takes precedence for duplicates)
+  const npmSet = new Set(npmPlugins);
   const allPlugins = [...new Set([...npmPlugins, ...configPlugins])];
 
   if (allPlugins.length === 0) return;
 
   for (const pluginId of allPlugins) {
-    await loadPlugin(registry, pluginId);
+    const source = npmSet.has(pluginId) ? "npm" as const : "config" as const;
+    await loadPlugin(registry, pluginId, source);
   }
+
+  // Reset source to built-in as default
+  registry.currentSource = "built-in";
 }

--- a/src/server/plugins/loader.ts
+++ b/src/server/plugins/loader.ts
@@ -46,22 +46,39 @@ export async function getDisabledModes(): Promise<string[]> {
   return [];
 }
 
-export async function setModeDisabled(mode: string, disabled: boolean): Promise<void> {
-  const config = await readPluginConfig();
-  const current = new Set(
-    Array.isArray(config.disabled)
-      ? config.disabled.filter((m): m is string => typeof m === "string")
-      : [],
-  );
+let configLock: Promise<void> = Promise.resolve();
 
-  if (disabled) {
-    current.add(mode);
-  } else {
-    current.delete(mode);
+export async function setModeDisabled(mode: string, disabled: boolean): Promise<void> {
+  // Validate mode string to prevent arbitrary values from reaching the config file
+  if (!/^[a-z][a-z0-9-]*$/.test(mode)) {
+    throw new Error(`Invalid mode identifier: ${mode}`);
   }
 
-  config.disabled = [...current];
-  await writePluginConfig(config);
+  // Serialize concurrent read-modify-write cycles to avoid data loss
+  const prevLock = configLock;
+  let release!: () => void;
+  configLock = new Promise<void>((resolve) => { release = resolve; });
+
+  await prevLock;
+  try {
+    const config = await readPluginConfig();
+    const current = new Set(
+      Array.isArray(config.disabled)
+        ? config.disabled.filter((m): m is string => typeof m === "string")
+        : [],
+    );
+
+    if (disabled) {
+      current.add(mode);
+    } else {
+      current.delete(mode);
+    }
+
+    config.disabled = [...current];
+    await writePluginConfig(config);
+  } finally {
+    release();
+  }
 }
 
 async function discoverProviderPlugins(registry: DeployerRegistry): Promise<void> {

--- a/src/server/routes/__tests__/plugins.test.ts
+++ b/src/server/routes/__tests__/plugins.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Deployer, DeployConfig, DeployResult, LogCallback } from "../../deployers/types.js";
+
+// Mock the loader module before importing the router
+vi.mock("../../plugins/loader.js", () => ({
+  getDisabledModes: vi.fn(async () => []),
+  setModeDisabled: vi.fn(async () => {}),
+}));
+
+// Mock the registry singleton with a fresh DeployerRegistry
+vi.mock("../../deployers/registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../deployers/registry.js")>();
+  return {
+    ...actual,
+    registry: new actual.DeployerRegistry(),
+  };
+});
+
+import { getDisabledModes, setModeDisabled } from "../../plugins/loader.js";
+import { registry } from "../../deployers/registry.js";
+
+// Import the router after mocks are set up
+const { default: pluginsRouter } = await import("../plugins.js");
+
+function stubDeployer(): Deployer {
+  return {
+    async deploy(_config: DeployConfig, _log: LogCallback): Promise<DeployResult> {
+      return { id: "test", mode: "test", status: "running", config: { mode: "test", agentName: "t" }, startedAt: "" };
+    },
+    async start(result: DeployResult): Promise<DeployResult> { return result; },
+    async status(result: DeployResult): Promise<DeployResult> { return result; },
+    async stop(): Promise<void> {},
+    async teardown(): Promise<void> {},
+  };
+}
+
+// Minimal mock for Express req/res to test route handlers directly
+function mockReq(params: Record<string, string> = {}): any {
+  return { params };
+}
+
+function mockRes() {
+  const res: any = {
+    statusCode: 200,
+    body: null,
+    status(code: number) { res.statusCode = code; return res; },
+    json(data: any) { res.body = data; return res; },
+  };
+  return res;
+}
+
+// Extract route handlers from the router
+function findHandler(method: string, path: string) {
+  for (const layer of (pluginsRouter as any).stack) {
+    if (
+      layer.route &&
+      layer.route.path === path &&
+      layer.route.methods[method]
+    ) {
+      return layer.route.stack[0].handle;
+    }
+  }
+  throw new Error(`No handler found for ${method.toUpperCase()} ${path}`);
+}
+
+const getPlugins = findHandler("get", "/");
+const disablePlugin = findHandler("post", "/:mode/disable");
+const enablePlugin = findHandler("post", "/:mode/enable");
+
+describe("GET /api/plugins", () => {
+  beforeEach(() => {
+    vi.mocked(getDisabledModes).mockReset().mockResolvedValue([]);
+    vi.mocked(setModeDisabled).mockReset().mockResolvedValue(undefined);
+  });
+
+  it("returns registered deployers with enabled status", async () => {
+    registry.register({
+      mode: "local",
+      title: "This Machine",
+      description: "Run locally",
+      deployer: stubDeployer(),
+      detect: async () => true,
+      builtIn: true,
+      priority: 0,
+    });
+
+    const res = mockRes();
+    await getPlugins(mockReq(), res);
+
+    expect(res.body.plugins).toBeDefined();
+    const local = res.body.plugins.find((p: any) => p.mode === "local");
+    expect(local).toBeDefined();
+    expect(local.title).toBe("This Machine");
+    expect(local.builtIn).toBe(true);
+    expect(local.enabled).toBe(true);
+  });
+
+  it("marks disabled deployers correctly", async () => {
+    vi.mocked(getDisabledModes).mockResolvedValue(["openshift"]);
+
+    registry.register({
+      mode: "openshift",
+      title: "OpenShift",
+      description: "Deploy to OpenShift",
+      deployer: stubDeployer(),
+      detect: async () => true,
+      builtIn: false,
+      priority: 10,
+    });
+
+    const res = mockRes();
+    await getPlugins(mockReq(), res);
+
+    const openshift = res.body.plugins.find((p: any) => p.mode === "openshift");
+    expect(openshift).toBeDefined();
+    expect(openshift.enabled).toBe(false);
+  });
+
+  it("includes load errors in response", async () => {
+    registry.addLoadError({ pluginId: "broken-plugin", error: "Import failed" });
+
+    const res = mockRes();
+    await getPlugins(mockReq(), res);
+
+    expect(res.body.errors).toBeDefined();
+    expect(res.body.errors.some((e: any) => e.pluginId === "broken-plugin")).toBe(true);
+  });
+});
+
+describe("POST /api/plugins/:mode/disable", () => {
+  beforeEach(() => {
+    vi.mocked(getDisabledModes).mockReset().mockResolvedValue([]);
+    vi.mocked(setModeDisabled).mockReset().mockResolvedValue(undefined);
+  });
+
+  it("returns 404 for unknown deployer mode", async () => {
+    const res = mockRes();
+    await disablePlugin(mockReq({ mode: "nonexistent" }), res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body.error).toMatch(/unknown deployer mode/i);
+    expect(vi.mocked(setModeDisabled)).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when trying to disable a built-in deployer", async () => {
+    registry.register({
+      mode: "builtin-test",
+      title: "Built-in Test",
+      description: "Test",
+      deployer: stubDeployer(),
+      builtIn: true,
+    });
+
+    const res = mockRes();
+    await disablePlugin(mockReq({ mode: "builtin-test" }), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/built-in/i);
+    expect(vi.mocked(setModeDisabled)).not.toHaveBeenCalled();
+  });
+
+  it("disables a non-built-in deployer", async () => {
+    registry.register({
+      mode: "plugin-test",
+      title: "Plugin Test",
+      description: "Test",
+      deployer: stubDeployer(),
+      builtIn: false,
+    });
+
+    const res = mockRes();
+    await disablePlugin(mockReq({ mode: "plugin-test" }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(vi.mocked(setModeDisabled)).toHaveBeenCalledWith("plugin-test", true);
+  });
+});
+
+describe("POST /api/plugins/:mode/enable", () => {
+  beforeEach(() => {
+    vi.mocked(getDisabledModes).mockReset().mockResolvedValue([]);
+    vi.mocked(setModeDisabled).mockReset().mockResolvedValue(undefined);
+  });
+
+  it("returns 404 for unknown deployer mode", async () => {
+    const res = mockRes();
+    await enablePlugin(mockReq({ mode: "nonexistent" }), res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body.error).toMatch(/unknown deployer mode/i);
+    expect(vi.mocked(setModeDisabled)).not.toHaveBeenCalled();
+  });
+
+  it("enables a previously disabled deployer", async () => {
+    registry.register({
+      mode: "plugin-enable-test",
+      title: "Plugin Enable Test",
+      description: "Test",
+      deployer: stubDeployer(),
+      builtIn: false,
+    });
+
+    const res = mockRes();
+    await enablePlugin(mockReq({ mode: "plugin-enable-test" }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(vi.mocked(setModeDisabled)).toHaveBeenCalledWith("plugin-enable-test", false);
+  });
+});

--- a/src/server/routes/plugins.ts
+++ b/src/server/routes/plugins.ts
@@ -1,0 +1,63 @@
+import { Router } from "express";
+import { registry } from "../deployers/registry.js";
+import { getDisabledModes, setModeDisabled } from "../plugins/loader.js";
+
+const router = Router();
+
+// List all plugins with status info
+router.get("/", async (_req, res) => {
+  const detected = await registry.detect();
+  const detectedModes = new Set(detected.map((d) => d.mode));
+  const disabledModes = new Set(await getDisabledModes());
+
+  const plugins = registry.list().map((reg) => ({
+    mode: reg.mode,
+    title: reg.title,
+    description: reg.description,
+    source: reg.source ?? (reg.builtIn ? "built-in" : "unknown"),
+    enabled: !disabledModes.has(reg.mode),
+    available: detectedModes.has(reg.mode),
+    builtIn: reg.builtIn ?? false,
+    priority: reg.priority ?? 0,
+  }));
+
+  res.json({
+    plugins,
+    errors: registry.loadErrors(),
+  });
+});
+
+// Disable a plugin by mode
+router.post("/:mode/disable", async (req, res) => {
+  const { mode } = req.params;
+
+  const reg = registry.list().find((r) => r.mode === mode);
+  if (!reg) {
+    res.status(404).json({ error: `Unknown deployer mode: ${mode}` });
+    return;
+  }
+
+  if (reg.builtIn) {
+    res.status(400).json({ error: "Built-in deployers cannot be disabled" });
+    return;
+  }
+
+  await setModeDisabled(mode, true);
+  res.json({ ok: true });
+});
+
+// Enable a plugin by mode
+router.post("/:mode/enable", async (req, res) => {
+  const { mode } = req.params;
+
+  const reg = registry.list().find((r) => r.mode === mode);
+  if (!reg) {
+    res.status(404).json({ error: `Unknown deployer mode: ${mode}` });
+    return;
+  }
+
+  await setModeDisabled(mode, false);
+  res.json({ ok: true });
+});
+
+export default router;


### PR DESCRIPTION
Adds a Plugins tab to the installer UI that shows all registered deployers grouped by source (built-in vs provider/npm plugins) with status indicators and enable/disable controls. Disabled modes are persisted in ~/.openclaw/installer/plugins.json and filtered from the Deploy tab mode selector.

- Extend DeployerRegistration with source tracking and load error reporting
- Add GET /api/plugins, POST /api/plugins/:mode/enable|disable endpoints
- Add PluginList component with status badges and enable/disable buttons
- Filter disabled deployers from Deploy tab mode selector
- Fall back to Kubernetes deployer when OpenShift plugin is disabled