### PR TITLE
fix(validation): disable deploy button for invalid agent names and sanitize namespaces

### DIFF
--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -1664,7 +1664,7 @@ export default function DeployForm({ onDeployStarted }: Props) {
           )}
           <button
             className="btn btn-primary"
-            disabled={deploying}
+            disabled={deploying || !isValid}
             onClick={handleDeploy}
           >
             {deploying ? "Deploying..." : "Deploy OpenClaw"}

--- a/src/client/components/__tests__/DeployForm.test.tsx
+++ b/src/client/components/__tests__/DeployForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import DeployForm from "../DeployForm";
 
 // Stub fetch for /api/health to return deployer data
@@ -87,6 +87,57 @@ describe("DeployForm deployer visibility (issue #10)", () => {
     const input = await screen.findByLabelText("Project / Namespace") as HTMLInputElement;
     await waitFor(() => {
       expect(input.value).not.toBe("default");
+    });
+  });
+});
+
+describe("DeployForm agent name validation (issue #7)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("disables deploy button when agent name is empty", async () => {
+    global.fetch = mockHealthResponse([
+      { mode: "local", title: "This Machine", description: "Run locally", available: true, priority: 0, builtIn: true },
+    ]);
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+
+    const buttons = await screen.findAllByRole("button", { name: /deploy openclaw/i });
+    const deployButton = buttons[buttons.length - 1];
+    expect(deployButton.disabled).toBe(true);
+  });
+
+  it("disables deploy button when agent name contains underscores", async () => {
+    global.fetch = mockHealthResponse([
+      { mode: "local", title: "This Machine", description: "Run locally", available: true, priority: 0, builtIn: true },
+    ]);
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+
+    const buttons = await screen.findAllByRole("button", { name: /deploy openclaw/i });
+    const deployButton = buttons[buttons.length - 1];
+
+    const agentInput = screen.getAllByPlaceholderText("e.g., lynx")[0];
+    fireEvent.change(agentInput, { target: { value: "a_0" } });
+
+    expect(deployButton.disabled).toBe(true);
+  });
+
+  it("shows validation error when agent name contains underscores", async () => {
+    global.fetch = mockHealthResponse([
+      { mode: "local", title: "This Machine", description: "Run locally", available: true, priority: 0, builtIn: true },
+    ]);
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+
+    await screen.findAllByRole("button", { name: /deploy openclaw/i });
+
+    const agentInput = screen.getAllByPlaceholderText("e.g., lynx")[0];
+    fireEvent.change(agentInput, { target: { value: "a_0" } });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Agent name can only contain lowercase letters, numbers, and hyphens").length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildOpenClawConfig, deriveModel, namespaceName, normalizeModelRef } from "../k8s-helpers.js";
+import { buildOpenClawConfig, deriveModel, namespaceName, normalizeModelRef, sanitizeForRfc1123 } from "../k8s-helpers.js";
 import type { DeployConfig } from "../types.js";
 
 function makeConfig(overrides: Partial<DeployConfig> = {}): DeployConfig {
@@ -115,5 +115,50 @@ describe("model config generation", () => {
 
     expect(normalizeModelRef(config, "litellm/my-model")).toBe("litellm/my-model");
     expect(normalizeModelRef(config, "anthropic-vertex/my-model")).toBe("anthropic-vertex/my-model");
+  });
+});
+
+// Regression tests for #7: agent names with underscores must produce valid namespaces
+describe("sanitizeForRfc1123", () => {
+  it("replaces underscores with hyphens", () => {
+    expect(sanitizeForRfc1123("a_0")).toBe("a-0");
+  });
+
+  it("collapses consecutive hyphens", () => {
+    expect(sanitizeForRfc1123("a__b")).toBe("a-b");
+  });
+
+  it("removes leading and trailing hyphens", () => {
+    expect(sanitizeForRfc1123("_hello_")).toBe("hello");
+  });
+
+  it("lowercases input", () => {
+    expect(sanitizeForRfc1123("MyAgent")).toBe("myagent");
+  });
+
+  it("passes through already-valid names", () => {
+    expect(sanitizeForRfc1123("my-agent-01")).toBe("my-agent-01");
+  });
+});
+
+describe("namespaceName", () => {
+  it("sanitizes agent names with underscores (issue #7)", () => {
+    const config = makeConfig({ agentName: "a_0", prefix: "bmurdock" });
+    expect(namespaceName(config)).toBe("bmurdock-a-0-openclaw");
+  });
+
+  it("produces RFC 1123-valid namespaces for normal names", () => {
+    const config = makeConfig({ agentName: "demo", prefix: "user" });
+    expect(namespaceName(config)).toBe("user-demo-openclaw");
+  });
+
+  it("uses explicit namespace when provided", () => {
+    const config = makeConfig({ agentName: "demo", namespace: "Custom-NS" });
+    expect(namespaceName(config)).toBe("custom-ns");
+  });
+
+  it("falls back to 'agent' when agent name sanitizes to empty", () => {
+    const config = makeConfig({ agentName: "___", prefix: "user" });
+    expect(namespaceName(config)).toBe("user-agent-openclaw");
   });
 });

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -24,13 +24,21 @@ export function tryParseProjectId(saJson: string): string {
   }
 }
 
+export function sanitizeForRfc1123(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
 export function namespaceName(config: DeployConfig): string {
   const prefix = config.prefix || "openclaw";
   const explicitNamespace = config.namespace?.trim().toLowerCase();
-  const ns = explicitNamespace && explicitNamespace !== "default"
-    ? explicitNamespace
-    : `${prefix}-${config.agentName}-openclaw`;
-  return ns.toLowerCase();
+  if (explicitNamespace && explicitNamespace !== "default") return explicitNamespace;
+  const sanitizedAgent = sanitizeForRfc1123(config.agentName) || "agent";
+  const sanitizedPrefix = sanitizeForRfc1123(prefix);
+  return `${sanitizedPrefix}-${sanitizedAgent}-openclaw`;
 }
 
 export function agentId(config: DeployConfig): string {


### PR DESCRIPTION
## Summary

Fixes #7 — Deploy fails with agent names containing underscores.

Two gaps remained after partial validation was added:

- **Deploy button not disabled**: The button at `DeployForm.tsx:1662` used `disabled={deploying}` instead of `disabled={deploying || !isValid}`, so users could click Deploy when validation errors were shown (the handler returned early, but the UX was confusing)
- **No server-side namespace sanitization**: `namespaceName()` in `k8s-helpers.ts` only called `.toLowerCase()` on agent names, passing through underscores and other RFC 1123-invalid characters to Kubernetes, which rejected them with a 422 error

### Changes

- `src/client/components/DeployForm.tsx`: Disable deploy button when form validation fails
- `src/server/deployers/k8s-helpers.ts`: Add `sanitizeForRfc1123()` to replace invalid characters with hyphens; apply it in `namespaceName()` as defense in depth
- `src/client/components/__tests__/DeployForm.test.tsx`: 3 regression tests for button disabled state and validation error display
- `src/server/deployers/__tests__/k8s-helpers.test.ts`: 9 regression tests for `sanitizeForRfc1123()` and `namespaceName()` with invalid inputs

## Test plan

- [x] All 105 tests pass (93 original + 12 new)
- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors)
- [x] Manual test: enter `a_0` as agent name → button disabled, inline error shown
- [x] Manual test: enter `my-agent` → button enabled, no error
