### PR TITLE
fix(deployers): use actual volume name for teardown when saved config is missing

### DIFF
--- a/src/server/deployers/__tests__/teardown-volume.test.ts
+++ b/src/server/deployers/__tests__/teardown-volume.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock child_process to capture volume-rm calls
+const mockExecFile = vi.fn();
+vi.mock("node:child_process", () => ({
+  execFile: mockExecFile,
+  spawn: vi.fn(),
+}));
+
+// Track calls to removeContainer and removeVolume
+const mockRemoveContainer = vi.fn().mockResolvedValue(undefined);
+const mockRemoveVolume = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../../services/container.js", () => ({
+  detectRuntime: vi.fn().mockResolvedValue("podman"),
+  removeContainer: mockRemoveContainer,
+  removeVolume: mockRemoveVolume,
+  OPENCLAW_LABELS: {
+    managed: "openclaw.managed=true",
+    prefix: (v: string) => `openclaw.prefix=${v}`,
+    agent: (v: string) => `openclaw.agent=${v}`,
+  },
+}));
+
+import type { DeployResult } from "../types.js";
+
+describe("LocalDeployer.teardown — volume name resolution (issue #24)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: make execFileAsync calls resolve (for pod rm etc.)
+    mockExecFile.mockImplementation((_file: string, _args: string[], cb?: Function) => {
+      if (cb) {
+        cb(null, { stdout: "", stderr: "" });
+      }
+      return { stdout: "", stderr: "" };
+    });
+  });
+
+  async function getTeardown() {
+    const { LocalDeployer } = await import("../local.js");
+    return new LocalDeployer();
+  }
+
+  it("uses result.volumeName when set, instead of recomputing from config", async () => {
+    const deployer = await getTeardown();
+
+    // Simulate a stopped instance without saved config:
+    // prefix and agentName are wrong (conflated from container name),
+    // but volumeName carries the actual discovered volume name.
+    const result: DeployResult = {
+      id: "openclaw-sally-lynx",
+      mode: "local",
+      status: "stopped",
+      volumeName: "openclaw-sally-lynx-data", // actual volume from discovery
+      config: {
+        mode: "local",
+        // These are wrong — the bug: both set to the full suffix
+        prefix: "sally-lynx",
+        agentName: "sally-lynx",
+        containerRuntime: "podman",
+      },
+      containerId: "openclaw-sally-lynx",
+      startedAt: "",
+    };
+
+    await deployer.teardown(result, () => {});
+
+    // The fix should use the actual volume name, not the recomputed one
+    expect(mockRemoveVolume).toHaveBeenCalledWith(
+      "podman",
+      "openclaw-sally-lynx-data",
+    );
+    // NOT "openclaw-sally-lynx-sally-lynx-data" (the double-prefixed bug)
+  });
+
+  it("falls back to computed volumeName when result.volumeName is not set", async () => {
+    const deployer = await getTeardown();
+
+    // Running instance with correct config — no volumeName field
+    const result: DeployResult = {
+      id: "openclaw-sally-lynx",
+      mode: "local",
+      status: "running",
+      config: {
+        mode: "local",
+        prefix: "sally",
+        agentName: "lynx",
+        containerRuntime: "podman",
+      },
+      containerId: "openclaw-sally-lynx",
+      startedAt: "",
+    };
+
+    await deployer.teardown(result, () => {});
+
+    // Should compute correctly: openclaw-{prefix}-{agentName}-data
+    expect(mockRemoveVolume).toHaveBeenCalledWith(
+      "podman",
+      "openclaw-sally-lynx-data",
+    );
+  });
+});

--- a/src/server/deployers/__tests__/teardown-volume.test.ts
+++ b/src/server/deployers/__tests__/teardown-volume.test.ts
@@ -28,7 +28,7 @@ describe("LocalDeployer.teardown — volume name resolution (issue #24)", () => 
   beforeEach(() => {
     vi.clearAllMocks();
     // Default: make execFileAsync calls resolve (for pod rm etc.)
-    mockExecFile.mockImplementation((_file: string, _args: string[], cb?: Function) => {
+    mockExecFile.mockImplementation((_file: string, _args: string[], cb?: (...args: unknown[]) => void) => {
       if (cb) {
         cb(null, { stdout: "", stderr: "" });
       }

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -1394,7 +1394,8 @@ something that requires the user's attention.`;
     if (!runtime) throw new Error("No container runtime found");
 
     const name = result.containerId ?? containerName(result.config);
-    const vol = volumeName(result.config);
+    // Use actual discovered volume name when available (fixes #24)
+    const vol = result.volumeName ?? volumeName(result.config);
     const image = resolveImage(result.config);
     const agentId = `${result.config.prefix || "openclaw"}_${result.config.agentName}`;
     const workspaceDir = `/home/node/.openclaw/workspace-${agentId}`;
@@ -1533,7 +1534,9 @@ something that requires the user's attention.`;
       }
     }
 
-    const vol = volumeName(result.config);
+    // Use the actual discovered volume name when available (fixes #24:
+    // reconstructed config produces wrong name when saved config is missing)
+    const vol = result.volumeName ?? volumeName(result.config);
     log(`Deleting data volume: ${vol}`);
     await removeVolume(runtime, vol);
     log("All data deleted.");

--- a/src/server/deployers/types.ts
+++ b/src/server/deployers/types.ts
@@ -88,6 +88,7 @@ export interface DeployResult {
   startedAt: string;
   url?: string;
   containerId?: string;
+  volumeName?: string;
   error?: string;
   // K8s-specific
   statusDetail?: string;

--- a/src/server/routes/status.ts
+++ b/src/server/routes/status.ts
@@ -100,6 +100,7 @@ router.get("/", async (req, res) => {
             id: vol.containerName,
             mode: "local",
             status: "stopped",
+            volumeName: vol.name,
             config: {
               mode: "local",
               prefix,
@@ -689,6 +690,7 @@ async function findInstance(name: string): Promise<DeployResult | null> {
         id: name,
         mode: "local",
         status: "stopped",
+        volumeName: vol.name,
         config: {
           mode: "local",
           prefix,


### PR DESCRIPTION
## Summary

- Fix "Delete Data" failing silently for stopped instances without a saved config file
- Add `volumeName` field to `DeployResult` to carry the actual discovered volume name
- Use actual volume name in `teardown` and `redeploy` instead of recomputing from potentially incorrect config

## Problem

When an instance's saved config is missing, `findInstance` reconstructs `prefix` and `agentName` from the container name by stripping the `openclaw-` prefix. Both fields get the same wrong value (the entire suffix). `teardown` then calls `volumeName(config)` which produces a double-prefixed name (`openclaw-X-X-data`) that doesn't match the real volume. The `podman volume rm` command fails silently.

## Solution

Add an optional `volumeName` field to `DeployResult` and populate it from the actual discovered volume name. `teardown` and `redeploy` now prefer `result.volumeName` over the computed name, falling back for running instances that have correct config.

## Test plan

- [x] Regression test: teardown uses `result.volumeName` when set
- [x] Regression test: teardown falls back to computed name when field is absent
- [x] Full server test suite passes (83/83)
- [x] TypeScript type-check clean
- [x] Manual test: deploy instance, delete saved config, stop instance, click "Delete Data", verify volume is removed

Fixes #24
