### PR TITLE
feat(ui): show gateway token in deploy log and instances page

### DIFF
--- a/src/client/components/InstanceList.tsx
+++ b/src/client/components/InstanceList.tsx
@@ -30,7 +30,7 @@ interface Instance {
   pods?: PodInfo[];
 }
 
-type ExpandedPanel = "token" | "command" | "logs" | null;
+type ExpandedPanel = "connection" | "command" | "logs" | null;
 
 function StatusBadge({ inst, isActing }: { inst: Instance; isActing: boolean }) {
   const badgeColor: Record<string, string> = {
@@ -204,11 +204,11 @@ export default function InstanceList() {
       return;
     }
 
-    const endpoint = panel === "token" ? "token" : panel === "logs" ? "logs" : "command";
+    const endpoint = panel === "connection" ? "token" : panel === "logs" ? "logs" : "command";
     try {
       const res = await fetch(`/api/instances/${id}/${endpoint}`);
       const data = await res.json();
-      const value = panel === "token" ? data.token : panel === "logs" ? data.logs : data.command;
+      const value = panel === "connection" ? data.token : panel === "logs" ? data.logs : data.command;
       if (value) {
         setPanelData((prev) => ({ ...prev, [`${id}-${panel}`]: value }));
         setExpanded((prev) => ({ ...prev, [id]: panel }));
@@ -346,9 +346,9 @@ export default function InstanceList() {
                   <>
                     <button
                       className="btn btn-ghost"
-                      onClick={() => togglePanel(inst.id, "token")}
+                      onClick={() => togglePanel(inst.id, "connection")}
                     >
-                      {activePanel === "token" ? "Hide" : "Token"}
+                      {activePanel === "connection" ? "Hide" : "Connection Info"}
                     </button>
                     <button
                       className="btn btn-ghost"
@@ -411,7 +411,50 @@ export default function InstanceList() {
               </div>
             </div>
             <K8sProgress inst={inst} />
-            {activePanel && panelContent && (
+            {activePanel === "connection" && panelContent && inst.url && (
+              <div
+                style={{
+                  padding: "0 1rem 1rem",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "0.5rem",
+                }}
+              >
+                {[
+                  { label: "URL", value: `${inst.url}?session=main#token=${encodeURIComponent(panelContent)}` },
+                  { label: "Token", value: panelContent },
+                ].map(({ label, value }) => (
+                  <div key={label} style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                    <span style={{ fontSize: "0.8rem", color: "var(--text-secondary)", minWidth: "3rem" }}>
+                      {label}
+                    </span>
+                    <code
+                      style={{
+                        flex: 1,
+                        padding: "0.35rem 0.75rem",
+                        background: "var(--bg-primary)",
+                        border: "1px solid var(--border)",
+                        borderRadius: "var(--radius-sm)",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.8rem",
+                        color: "var(--text-secondary)",
+                        wordBreak: "break-all",
+                        whiteSpace: "pre-wrap",
+                      }}
+                    >
+                      {value}
+                    </code>
+                    <button
+                      className="btn btn-ghost"
+                      onClick={() => handleCopy(value)}
+                    >
+                      Copy
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            {activePanel && activePanel !== "connection" && panelContent && (
               <div
                 style={{
                   padding: "0 1rem 1rem",

--- a/src/client/components/__tests__/InstanceList.test.tsx
+++ b/src/client/components/__tests__/InstanceList.test.tsx
@@ -96,7 +96,7 @@ describe("InstanceList", () => {
     expect(screen.getByText("running")).toBeInTheDocument();
     expect(screen.getByText("http://localhost:18789")).toBeInTheDocument();
     // Running instances show panel and lifecycle buttons
-    expect(screen.getByText("Token")).toBeInTheDocument();
+    expect(screen.getByText("Connection Info")).toBeInTheDocument();
     expect(screen.getByText("Command")).toBeInTheDocument();
     expect(screen.getByText("Logs")).toBeInTheDocument();
     expect(screen.getByText("Stop")).toBeInTheDocument();
@@ -110,7 +110,7 @@ describe("InstanceList", () => {
     await waitFor(() => {
       expect(screen.getByText("Start")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Token")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connection Info")).not.toBeInTheDocument();
     expect(screen.queryByText("Command")).not.toBeInTheDocument();
     expect(screen.queryByText("Logs")).not.toBeInTheDocument();
   });
@@ -145,7 +145,7 @@ describe("InstanceList", () => {
     expect(screen.getByRole("button", { name: /delete data/i })).not.toBeDisabled();
   });
 
-  it("toggles token panel on button click", async () => {
+  it("toggles connection info panel on button click", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     globalThis.fetch = vi.fn((url: string) => {
       if (url === "/api/health") {
@@ -162,12 +162,14 @@ describe("InstanceList", () => {
 
     render(<InstanceList />);
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /token/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /connection info/i })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: /token/i }));
+    await user.click(screen.getByRole("button", { name: /connection info/i }));
     await waitFor(() => {
+      // Connection info shows both URL with token and raw token
       expect(screen.getByText("secret-token-123")).toBeInTheDocument();
+      expect(screen.getByText(/http:\/\/localhost:18789\?session=main#token=secret-token-123/)).toBeInTheDocument();
     });
     expect(screen.getByRole("button", { name: /^hide$/i })).toBeInTheDocument();
   });

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -299,7 +299,8 @@ export class KubernetesDeployer implements Deployer {
 
     log(`OpenClaw deployed to ${ns}`);
     log(`Access via port-forward: kubectl port-forward svc/openclaw 18789:18789 -n ${ns}`);
-    log("Use the Open action from the Instances page to open with the saved token");
+    // Show URL with token so users can copy-paste after port-forward (fix for #29)
+    log(`Gateway URL (after port-forward): http://localhost:18789#token=${encodeURIComponent(gatewayToken)}`);
 
     // Save deploy config for re-deploy (strip secrets, keep references)
     try {

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -968,8 +968,8 @@ something that requires the user's attention.`;
     const token = await this.readSavedToken(name);
     const url = `http://localhost:${port}`;
     if (token) {
-      log(`OpenClaw running at ${url}`);
-      log("Use the Open action from the Instances page to open with the saved token");
+      // Show URL with token so users can copy-paste directly (fix for #29)
+      log(`OpenClaw running at ${url}#token=${encodeURIComponent(token)}`);
     } else {
       log(`OpenClaw running at ${url}`);
     }
@@ -1181,8 +1181,8 @@ something that requires the user's attention.`;
     const token = await this.readSavedToken(name);
     const url = `http://localhost:${port}`;
     if (token) {
-      log(`OpenClaw running at ${url}`);
-      log("Use the Open action from the Instances page to open with the saved token");
+      // Show URL with token so users can copy-paste directly (fix for #29)
+      log(`OpenClaw running at ${url}#token=${encodeURIComponent(token)}`);
     } else {
       log(`OpenClaw running at ${url}`);
     }


### PR DESCRIPTION
## Summary

- Show gateway token in deploy log as a copy-pasteable URL with embedded token fragment
- Replace the subtle "Token" button on the instances page with a "Connection Info" section showing URL + token with individual copy buttons

Fixes #29

## Changes

**Deploy log (local + K8s):**
- After deployment completes, the log now shows the full URL with token: `http://localhost:8080#token=abc123`
- For K8s, shows: `Gateway URL (after port-forward): http://localhost:18789#token=...`
- Falls back to bare URL if token is unavailable

**Instances page:**
- "Token" button replaced with "Connection Info" button
- Panel shows two rows: full URL with token (for browser) and raw token (for CLI/API)
- Each row has its own Copy button
- Command and Logs panels unchanged

## Test plan

- [x] 3 existing InstanceList tests updated for "Connection Info" button and panel content
- [x] Full test suite passes (110/110)
- [x] Build clean
- [x] Lint passes
- [x] Manual: deploy a local instance and verify the deploy log shows the URL with token
- [x] Manual: click "Connection Info" on a running instance and verify URL + token display
