### PR TITLE
fix(deploy-form): clear custom model when switching inference providers

### DIFF
--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -1261,7 +1261,10 @@ export default function DeployForm({ onDeployStarted }: Props) {
           <label>Provider</label>
           <select
             value={inferenceProvider}
-            onChange={(e) => setInferenceProvider(e.target.value as InferenceProvider)}
+            onChange={(e) => {
+              setInferenceProvider(e.target.value as InferenceProvider);
+              update("agentModel", ""); // Fix for #23: clear provider-specific model on switch
+            }}
           >
             {PROVIDER_OPTIONS.map((p) => (
               <option key={p.id} value={p.id}>{p.label}</option>

--- a/src/client/components/__tests__/reproduce-issue-23.test.tsx
+++ b/src/client/components/__tests__/reproduce-issue-23.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for issue #23:
+ * "Custom model override carries over across providers"
+ *
+ * Verifies that switching inference providers clears the custom model field.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import DeployForm from "../DeployForm";
+
+function mockFetch() {
+  return vi.fn().mockImplementation((url: string) => {
+    if (url.includes("/api/configs/gcp-defaults")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          projectId: null,
+          location: null,
+          hasServiceAccountJson: false,
+          credentialType: null,
+          sources: {},
+        }),
+      });
+    }
+    // Default: /api/health
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({
+        status: "ok",
+        containerRuntime: "podman",
+        k8sAvailable: false,
+        k8sContext: "",
+        k8sNamespace: "",
+        isOpenShift: false,
+        version: "0.1.0",
+        deployers: [
+          { mode: "local", title: "This Machine", description: "Run locally", available: true, priority: 0, builtIn: true },
+        ],
+        defaults: {
+          hasAnthropicKey: true,
+          hasOpenaiKey: false,
+          hasTelegramToken: false,
+          telegramAllowFrom: "",
+          modelEndpoint: "",
+          prefix: "testuser",
+          image: "",
+        },
+      }),
+    });
+  });
+}
+
+function getProviderSelect() {
+  return screen.getByText("Provider").closest(".form-group")!.querySelector("select")! as HTMLSelectElement;
+}
+
+function getModelInput() {
+  return screen.getByText("Model").closest(".form-group")!.querySelector("input")! as HTMLInputElement;
+}
+
+describe("Issue #23: Custom model override carries over across providers", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("clears agentModel when switching from Anthropic to OpenAI", async () => {
+    global.fetch = mockFetch();
+    render(<DeployForm onDeployStarted={() => {}} />);
+    await screen.findByText("This Machine");
+
+    const providerSelect = getProviderSelect();
+    const modelInput = getModelInput();
+
+    // Set a custom model for Anthropic
+    fireEvent.change(modelInput, { target: { value: "claude-opus-4-6" } });
+    expect(modelInput.value).toBe("claude-opus-4-6");
+
+    // Switch to OpenAI — model should be cleared
+    fireEvent.change(providerSelect, { target: { value: "openai" } });
+    await waitFor(() => {
+      expect(modelInput.value).toBe("");
+    });
+  });
+
+  it("clears agentModel when switching from OpenAI to Vertex", async () => {
+    global.fetch = mockFetch();
+    render(<DeployForm onDeployStarted={() => {}} />);
+    await screen.findByText("This Machine");
+
+    const providerSelect = getProviderSelect();
+    const modelInput = getModelInput();
+
+    // Switch to OpenAI and set a custom model
+    fireEvent.change(providerSelect, { target: { value: "openai" } });
+    fireEvent.change(modelInput, { target: { value: "openai/gpt-5" } });
+    expect(modelInput.value).toBe("openai/gpt-5");
+
+    // Switch to Vertex Anthropic — model should be cleared
+    fireEvent.change(providerSelect, { target: { value: "vertex-anthropic" } });
+    await waitFor(() => {
+      expect(modelInput.value).toBe("");
+    });
+  });
+
+  it("clears agentModel on every consecutive provider switch", async () => {
+    global.fetch = mockFetch();
+    render(<DeployForm onDeployStarted={() => {}} />);
+    await screen.findByText("This Machine");
+
+    const providerSelect = getProviderSelect();
+    const modelInput = getModelInput();
+
+    // Set model, switch, verify cleared — repeat for multiple providers
+    fireEvent.change(modelInput, { target: { value: "model-a" } });
+    fireEvent.change(providerSelect, { target: { value: "openai" } });
+    await waitFor(() => expect(modelInput.value).toBe(""));
+
+    fireEvent.change(modelInput, { target: { value: "model-b" } });
+    fireEvent.change(providerSelect, { target: { value: "vertex-google" } });
+    await waitFor(() => expect(modelInput.value).toBe(""));
+
+    fireEvent.change(modelInput, { target: { value: "model-c" } });
+    fireEvent.change(providerSelect, { target: { value: "anthropic" } });
+    await waitFor(() => expect(modelInput.value).toBe(""));
+  });
+
+  it("does not interfere when model field is already empty", async () => {
+    global.fetch = mockFetch();
+    render(<DeployForm onDeployStarted={() => {}} />);
+    await screen.findByText("This Machine");
+
+    const providerSelect = getProviderSelect();
+    const modelInput = getModelInput();
+
+    // Switch without setting a model — should remain empty
+    expect(modelInput.value).toBe("");
+    fireEvent.change(providerSelect, { target: { value: "openai" } });
+    await waitFor(() => {
+      expect(modelInput.value).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Clear the custom model field (`agentModel`) when switching inference providers in the deploy form
- Add regression tests covering provider switching scenarios

Fixes #23

## Root Cause

The provider dropdown's `onChange` handler only called `setInferenceProvider()` without resetting `config.agentModel`. Model IDs are provider-specific, so the stale value was meaningless after a switch.

## Changes

- `DeployForm.tsx`: Added `update("agentModel", "")` to provider onChange handler
- `reproduce-issue-23.test.tsx`: 4 regression tests (Anthropic→OpenAI, OpenAI→Vertex, consecutive switches, empty-model edge case)

## Test Plan

- [x] Regression tests fail without fix, pass with fix
- [x] Full suite: 116 tests pass, 0 failures
- [x] Build and lint pass
- [x] Manual: open UI, set custom model, switch provider, verify field clears
