### PR TITLE
fix(plugins): show Kubernetes as superseded when OpenShift is active

### DIFF
--- a/src/client/components/PluginList.tsx
+++ b/src/client/components/PluginList.tsx
@@ -9,6 +9,7 @@ interface PluginInfo {
   available: boolean;
   builtIn: boolean;
   priority: number;
+  supersededBy?: string;
 }
 
 interface PluginLoadError {
@@ -178,21 +179,27 @@ function PluginRow({
   toggling: string | null;
   onToggle: (mode: string, enabled: boolean) => void;
 }) {
+  const isSuperseded = plugin.enabled && plugin.supersededBy;
+
   const statusColor = !plugin.enabled
     ? "var(--text-muted)"
-    : plugin.available
-      ? "var(--success)"
-      : "var(--warning)";
+    : isSuperseded
+      ? "var(--text-muted)"
+      : plugin.available
+        ? "var(--success)"
+        : "var(--warning)";
 
   const statusLabel = !plugin.enabled
     ? "Disabled"
-    : plugin.available
-      ? "Active"
-      : "Unavailable";
+    : isSuperseded
+      ? "Superseded"
+      : plugin.available
+        ? "Active"
+        : "Unavailable";
 
   return (
     <div className="instance-row">
-      <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", flex: 1, opacity: plugin.enabled ? 1 : 0.55 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.75rem", flex: 1, opacity: plugin.enabled && !isSuperseded ? 1 : 0.55 }}>
         <div style={{ fontSize: "1.5rem", width: "2rem", textAlign: "center" }}>
           {MODE_ICONS[plugin.mode] || "\uD83D\uDD0C"}
         </div>
@@ -205,6 +212,11 @@ function PluginRow({
           </div>
           <div className="instance-meta">
             {plugin.description}
+            {isSuperseded && (
+              <span style={{ marginLeft: "0.5rem", color: "var(--text-muted)", fontStyle: "italic" }}>
+                {" \u2022 "}Superseded by {plugin.supersededBy}
+              </span>
+            )}
             <span style={{ marginLeft: "0.5rem" }}>
               {" \u2022 "}
               <span style={{
@@ -222,7 +234,7 @@ function PluginRow({
       </div>
       <div className="instance-actions" style={{ alignItems: "center", gap: "0.75rem" }}>
         <span
-          className={`badge ${!plugin.enabled ? "badge-stopped" : plugin.available ? "badge-running" : "badge-deploying"}`}
+          className={`badge ${!plugin.enabled ? "badge-stopped" : isSuperseded ? "badge-stopped" : plugin.available ? "badge-running" : "badge-deploying"}`}
           style={{ minWidth: "5rem", textAlign: "center" }}
         >
           <span style={{

--- a/src/client/components/__tests__/PluginList.test.tsx
+++ b/src/client/components/__tests__/PluginList.test.tsx
@@ -183,4 +183,51 @@ describe("PluginList", () => {
     expect(screen.getAllByText("Built-in").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Provider Plugin")).toBeTruthy();
   });
+
+  // Regression tests for issue #46: Kubernetes superseded by OpenShift
+  it("shows Superseded badge when plugin has supersededBy field", async () => {
+    const response = {
+      plugins: [
+        { mode: "kubernetes", title: "Kubernetes", description: "Deploy to K8s", source: "built-in", enabled: true, available: true, builtIn: true, priority: 0, supersededBy: "openshift" },
+        { mode: "openshift", title: "OpenShift", description: "Deploy to OpenShift", source: "provider-plugin", enabled: true, available: true, builtIn: false, priority: 10 },
+      ],
+      errors: [],
+    };
+    global.fetch = mockFetch(response);
+    render(<PluginList />);
+
+    await screen.findByText("Kubernetes");
+    expect(screen.getByText("Superseded")).toBeTruthy();
+    expect(screen.getByText(/Superseded by openshift/)).toBeTruthy();
+  });
+
+  it("does not show Superseded when plugin has no supersededBy field", async () => {
+    const response = {
+      plugins: [
+        { mode: "kubernetes", title: "Kubernetes", description: "Deploy to K8s", source: "built-in", enabled: true, available: true, builtIn: true, priority: 0 },
+      ],
+      errors: [],
+    };
+    global.fetch = mockFetch(response);
+    render(<PluginList />);
+
+    await screen.findByText("Kubernetes");
+    expect(screen.getByText("Active")).toBeTruthy();
+    expect(screen.queryByText("Superseded")).toBeNull();
+  });
+
+  it("does not show Superseded when plugin is disabled even with supersededBy", async () => {
+    const response = {
+      plugins: [
+        { mode: "kubernetes", title: "Kubernetes", description: "Deploy to K8s", source: "built-in", enabled: false, available: true, builtIn: true, priority: 0, supersededBy: "openshift" },
+      ],
+      errors: [],
+    };
+    global.fetch = mockFetch(response);
+    render(<PluginList />);
+
+    await screen.findByText("Kubernetes");
+    expect(screen.getByText("Disabled")).toBeTruthy();
+    expect(screen.queryByText("Superseded")).toBeNull();
+  });
 });

--- a/src/server/routes/__tests__/plugins.test.ts
+++ b/src/server/routes/__tests__/plugins.test.ts
@@ -127,6 +127,72 @@ describe("GET /api/plugins", () => {
   });
 });
 
+// Regression tests for issue #46: Kubernetes superseded by OpenShift
+describe("GET /api/plugins — supersededBy (issue #46)", () => {
+  beforeEach(() => {
+    vi.mocked(getDisabledModes).mockReset().mockResolvedValue([]);
+    vi.mocked(setModeDisabled).mockReset().mockResolvedValue(undefined);
+  });
+
+  it("marks kubernetes as supersededBy openshift when openshift is detected and enabled", async () => {
+    registry.register({
+      mode: "kubernetes",
+      title: "Kubernetes",
+      description: "Deploy to K8s",
+      deployer: stubDeployer(),
+      detect: async () => true,
+      builtIn: true,
+    });
+    registry.register({
+      mode: "openshift",
+      title: "OpenShift",
+      description: "Deploy to OpenShift",
+      deployer: stubDeployer(),
+      detect: async () => true,
+      builtIn: false,
+      priority: 10,
+    });
+
+    const res = mockRes();
+    await getPlugins(mockReq(), res);
+
+    const k8s = res.body.plugins.find((p: any) => p.mode === "kubernetes");
+    expect(k8s.supersededBy).toBe("openshift");
+
+    const openshift = res.body.plugins.find((p: any) => p.mode === "openshift");
+    expect(openshift.supersededBy).toBeUndefined();
+  });
+
+  it("does not mark kubernetes as superseded when openshift is disabled", async () => {
+    vi.mocked(getDisabledModes).mockResolvedValue(["openshift"]);
+
+    const res = mockRes();
+    await getPlugins(mockReq(), res);
+
+    const k8s = res.body.plugins.find((p: any) => p.mode === "kubernetes");
+    expect(k8s.supersededBy).toBeUndefined();
+  });
+
+  it("does not mark kubernetes as superseded when openshift is not detected", async () => {
+    // Re-register openshift with detect returning false
+    registry.register({
+      mode: "openshift",
+      title: "OpenShift",
+      description: "Deploy to OpenShift",
+      deployer: stubDeployer(),
+      detect: async () => false,
+      builtIn: false,
+      priority: 10,
+    });
+
+    const res = mockRes();
+    await getPlugins(mockReq(), res);
+
+    const k8s = res.body.plugins.find((p: any) => p.mode === "kubernetes");
+    expect(k8s.supersededBy).toBeUndefined();
+  });
+});
+
 describe("POST /api/plugins/:mode/disable", () => {
   beforeEach(() => {
     vi.mocked(getDisabledModes).mockReset().mockResolvedValue([]);

--- a/src/server/routes/plugins.ts
+++ b/src/server/routes/plugins.ts
@@ -10,6 +10,11 @@ router.get("/", async (_req, res) => {
   const detectedModes = new Set(detected.map((d) => d.mode));
   const disabledModes = new Set(await getDisabledModes());
 
+  // Fix for #46: when OpenShift is detected and enabled, mark Kubernetes as
+  // superseded so the Plugins tab can reflect the same hiding the Deploy tab does.
+  const openshiftActive =
+    detectedModes.has("openshift") && !disabledModes.has("openshift");
+
   const plugins = registry.list().map((reg) => ({
     mode: reg.mode,
     title: reg.title,
@@ -19,6 +24,9 @@ router.get("/", async (_req, res) => {
     available: detectedModes.has(reg.mode),
     builtIn: reg.builtIn ?? false,
     priority: reg.priority ?? 0,
+    ...(reg.mode === "kubernetes" && openshiftActive
+      ? { supersededBy: "openshift" }
+      : {}),
   }));
 
   res.json({


### PR DESCRIPTION
The Plugins tab showed Kubernetes as "Active" even when the Deploy tab hid it because OpenShift supersedes it. This was confusing — users saw a deployer as active that they couldn't actually use.

Add a `supersededBy` field to the plugins API response when OpenShift is detected and enabled, and render a "Superseded" status badge in the Plugins tab UI with a "Superseded by openshift" note.

## Summary

- Add `supersededBy` field to the plugins API when OpenShift is detected and enabled, marking Kubernetes as superseded
- Render "Superseded" status badge and "Superseded by openshift" note in the Plugins tab UI
- Add 6 regression tests (3 server, 3 client)

## Test plan

- [x] Verify Plugins tab shows "Superseded" badge for Kubernetes when logged into OpenShift
- [x] Verify Plugins tab shows "Active" for Kubernetes when OpenShift is not present
- [x] Verify disabling OpenShift plugin removes the superseded status from Kubernetes
- [x] Run full test suite: `npm test` (152 tests, all passing)

Fixes #46