### PR TITLE
feat: auto-switch deployer based on cluster connection

### DIFF
--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -42,6 +42,13 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
   const [loadedConfigLabel, setLoadedConfigLabel] = useState<string | null>(null);
   const [autoLoadedEnvDir, setAutoLoadedEnvDir] = useState<string | null>(null);
   const [inferenceProvider, setInferenceProvider] = useState<InferenceProvider>("anthropic");
+  const [modeManuallySelected, setModeManuallySelected] = useState(false);
+  const [autoSwitchMessage, setAutoSwitchMessage] = useState<string | null>(null);
+  // Refs so refreshEnvironment can read latest values without re-creating the callback
+  const modeManualRef = useRef(false);
+  const deployingRef = useRef(false);
+  modeManualRef.current = modeManuallySelected;
+  deployingRef.current = deploying;
   const [config, setConfig] = useState<DeployFormConfig>(createInitialDeployFormConfig);
 
   const [gcpDefaults, setGcpDefaults] = useState<GcpDefaults | null>(null);
@@ -112,9 +119,46 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
             return (b.priority ?? 0) - (a.priority ?? 0);
           });
           setDeployers(sorted);
-          // Only auto-select mode on first load
-          if (isInitial && sorted.length > 0 && sorted[0].available) {
-            setMode(sorted[0].mode);
+
+          if (isInitial) {
+            // Auto-select best deployer on first load
+            if (sorted.length > 0 && sorted[0].available) {
+              setMode(sorted[0].mode);
+            }
+          } else if (!deployingRef.current) {
+            // Auto-switch logic on subsequent refreshes (tab focus, manual refresh).
+            // Never switch while a deploy is in progress.
+            setMode((currentMode) => {
+              const enabledSorted = sorted.filter((dd) => dd.enabled !== false);
+              const currentDeployer = enabledSorted.find((dd) => dd.mode === currentMode);
+              const bestAvailable = enabledSorted.find((dd) => dd.available);
+
+              if (!bestAvailable) return currentMode;
+
+              // Rule 1: Current mode became unavailable — always switch.
+              if (!currentDeployer?.available) {
+                setAutoSwitchMessage(
+                  `Switched to ${bestAvailable.title} — ${currentMode} is no longer available`,
+                );
+                setModeManuallySelected(false);
+                return bestAvailable.mode;
+              }
+
+              // Rule 2: A higher-priority deployer became newly available.
+              // Only auto-switch if the user hasn't manually picked a mode.
+              if (
+                !modeManualRef.current
+                && bestAvailable.mode !== currentMode
+                && (bestAvailable.priority ?? 0) > (currentDeployer.priority ?? 0)
+              ) {
+                setAutoSwitchMessage(
+                  `Switched to ${bestAvailable.title} — detected ${bestAvailable.title} cluster`,
+                );
+                return bestAvailable.mode;
+              }
+
+              return currentMode;
+            });
           }
         }
 
@@ -161,11 +205,12 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
     return () => document.removeEventListener("visibilitychange", onVisibilityChange);
   }, [refreshEnvironment]);
 
+  // Auto-dismiss the auto-switch notification after 8 seconds
   useEffect(() => {
-    if (defaults?.isOpenShift && mode === "kubernetes") {
-      setMode("openshift");
-    }
-  }, [defaults?.isOpenShift, mode]);
+    if (!autoSwitchMessage) return;
+    const timer = globalThis.setTimeout(() => setAutoSwitchMessage(null), 8000);
+    return () => globalThis.clearTimeout(timer);
+  }, [autoSwitchMessage]);
 
   useEffect(() => {
     try {
@@ -512,7 +557,13 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
             <div
               key={m.mode}
               className={`mode-card ${isSelected ? "selected" : ""} ${!m.available ? "disabled" : ""}`}
-              onClick={() => m.available && setMode(m.mode)}
+              onClick={() => {
+                if (m.available) {
+                  setMode(m.mode);
+                  setModeManuallySelected(true);
+                  setAutoSwitchMessage(null);
+                }
+              }}
               style={!m.available ? { opacity: 0.5, cursor: "not-allowed" } : undefined}
             >
               <div className="mode-radio">
@@ -529,6 +580,41 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
           );
         })}
       </div>
+
+      {autoSwitchMessage && (
+        <div
+          style={{
+            marginBottom: "1rem",
+            padding: "0.6rem 1rem",
+            background: "rgba(52, 152, 219, 0.1)",
+            border: "1px solid rgba(52, 152, 219, 0.3)",
+            borderRadius: "var(--radius-sm)",
+            fontSize: "0.85rem",
+            color: "var(--text-secondary)",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <span>{autoSwitchMessage}</span>
+          <button
+            type="button"
+            onClick={() => setAutoSwitchMessage(null)}
+            style={{
+              background: "none",
+              border: "none",
+              color: "var(--text-muted)",
+              cursor: "pointer",
+              fontSize: "1rem",
+              padding: "0 0.25rem",
+              lineHeight: 1,
+            }}
+            aria-label="Dismiss"
+          >
+            {"\u00D7"}
+          </button>
+        </div>
+      )}
 
       {isClusterMode && (
         <div className="card" style={{ marginBottom: "1rem", padding: "0.75rem 1rem" }}>

--- a/src/client/components/__tests__/DeployForm.test.tsx
+++ b/src/client/components/__tests__/DeployForm.test.tsx
@@ -1,31 +1,37 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import DeployForm from "../DeployForm";
 
+type DeployerStub = { mode: string; title: string; description: string; available: boolean; priority: number; builtIn: boolean; enabled?: boolean };
+
+function healthJson(deployers: DeployerStub[], overrides: Record<string, unknown> = {}) {
+  return {
+    status: "ok",
+    containerRuntime: "podman",
+    k8sAvailable: false,
+    k8sContext: "",
+    k8sNamespace: "",
+    isOpenShift: false,
+    version: "0.1.0",
+    deployers,
+    defaults: {
+      hasAnthropicKey: true,
+      hasOpenaiKey: false,
+      hasTelegramToken: false,
+      telegramAllowFrom: "",
+      modelEndpoint: "",
+      prefix: "testuser",
+      image: "",
+    },
+    ...overrides,
+  };
+}
+
 // Stub fetch for /api/health to return deployer data
-function mockHealthResponse(deployers: Array<{ mode: string; title: string; description: string; available: boolean; priority: number; builtIn: boolean; enabled?: boolean }>, overrides: Record<string, unknown> = {}) {
+function mockHealthResponse(deployers: DeployerStub[], overrides: Record<string, unknown> = {}) {
   return vi.fn().mockResolvedValue({
     ok: true,
-    json: async () => ({
-      status: "ok",
-      containerRuntime: "podman",
-      k8sAvailable: false,
-      k8sContext: "",
-      k8sNamespace: "",
-      isOpenShift: false,
-      version: "0.1.0",
-      deployers,
-      defaults: {
-        hasAnthropicKey: true,
-        hasOpenaiKey: false,
-        hasTelegramToken: false,
-        telegramAllowFrom: "",
-        modelEndpoint: "",
-        prefix: "testuser",
-        image: "",
-      },
-      ...overrides,
-    }),
+    json: async () => healthJson(deployers, overrides),
   });
 }
 
@@ -581,6 +587,208 @@ describe("DeployForm agent name validation (issue #7)", () => {
       expect(
         screen.queryByRole("option", { name: "Llama 4 Scout 17B (llama-4-scout-17b-16e-w4a16)" }),
       ).toBeNull();
+    });
+  });
+});
+
+const LOCAL: DeployerStub = { mode: "local", title: "This Machine", description: "Run locally", available: true, priority: 0, builtIn: true };
+const K8S_AVAIL: DeployerStub = { mode: "kubernetes", title: "Kubernetes", description: "Deploy to K8s", available: true, priority: 0, builtIn: true };
+const K8S_UNAVAIL: DeployerStub = { mode: "kubernetes", title: "Kubernetes", description: "Deploy to K8s", available: false, priority: 0, builtIn: true };
+const OCP_AVAIL: DeployerStub = { mode: "openshift", title: "OpenShift", description: "Deploy to OpenShift", available: true, priority: 10, builtIn: false };
+
+describe("DeployForm auto-switch (issue #38)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it("auto-switches when current mode becomes unavailable on refresh", async () => {
+    // Initial: local + kubernetes available; kubernetes has higher priority so it's auto-selected
+    const k8sHighPri = { ...K8S_AVAIL, priority: 5 };
+    const initialData = healthJson([LOCAL, k8sHighPri], { k8sAvailable: true });
+    // After refresh: kubernetes unavailable
+    const refreshData = healthJson([LOCAL, K8S_UNAVAIL], { k8sAvailable: false });
+
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/api/configs")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      callCount++;
+      const data = callCount <= 1 ? initialData : refreshData;
+      return Promise.resolve({ ok: true, json: async () => data });
+    });
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+
+    // Wait for initial render — should show kubernetes as available
+    await screen.findByText("This Machine");
+    await waitFor(() => {
+      expect(screen.getByText("Kubernetes")).toBeTruthy();
+    });
+
+    // Simulate tab focus / refresh by triggering visibilitychange
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", { value: "visible", writable: true, configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Should show auto-switch notification
+    await waitFor(() => {
+      expect(screen.queryByText(/is no longer available/)).toBeTruthy();
+    });
+  });
+
+  it("auto-switches to higher-priority deployer when it becomes available", async () => {
+    // Initial: only local available
+    const initialData = healthJson([LOCAL, K8S_UNAVAIL]);
+    // After refresh: OpenShift becomes available (priority 10)
+    const refreshData = healthJson([LOCAL, K8S_AVAIL, OCP_AVAIL], {
+      k8sAvailable: true,
+      isOpenShift: true,
+    });
+
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/api/configs")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      callCount++;
+      const data = callCount <= 1 ? initialData : refreshData;
+      return Promise.resolve({ ok: true, json: async () => data });
+    });
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+
+    // Wait for initial render — local should be auto-selected
+    await screen.findByText("This Machine");
+
+    // Trigger refresh
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", { value: "visible", writable: true, configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Should show auto-switch notification for OpenShift
+    await waitFor(() => {
+      expect(screen.queryByText(/Switched to OpenShift/)).toBeTruthy();
+    });
+  });
+
+  it("does not auto-switch when user manually selected a mode", async () => {
+    // Initial: local + kubernetes available
+    const initialData = healthJson([LOCAL, K8S_AVAIL], { k8sAvailable: true });
+    // After refresh: OpenShift becomes available (higher priority)
+    const refreshData = healthJson([LOCAL, K8S_AVAIL, OCP_AVAIL], {
+      k8sAvailable: true,
+      isOpenShift: true,
+    });
+
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/api/configs")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      callCount++;
+      const data = callCount <= 1 ? initialData : refreshData;
+      return Promise.resolve({ ok: true, json: async () => data });
+    });
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+
+    // Wait for initial render
+    const localCard = await screen.findByText("This Machine");
+
+    // Manually click "This Machine" to mark as manually selected
+    fireEvent.click(localCard.closest(".mode-card")!);
+
+    // Trigger refresh
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", { value: "visible", writable: true, configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Should NOT show auto-switch notification — user manually selected local
+    await vi.advanceTimersByTimeAsync(100);
+    expect(screen.queryByText(/Switched to/)).toBeNull();
+  });
+
+  it("auto-switches even with manual selection when current mode is unavailable", async () => {
+    // Initial: local + kubernetes available
+    const initialData = healthJson([LOCAL, K8S_AVAIL], { k8sAvailable: true });
+    // After refresh: kubernetes unavailable
+    const refreshData = healthJson([LOCAL, K8S_UNAVAIL], { k8sAvailable: false });
+
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/api/configs")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      callCount++;
+      const data = callCount <= 1 ? initialData : refreshData;
+      return Promise.resolve({ ok: true, json: async () => data });
+    });
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+
+    // Wait for initial render
+    const k8sCard = await screen.findByText("Kubernetes");
+
+    // Manually click Kubernetes
+    fireEvent.click(k8sCard.closest(".mode-card")!);
+
+    // Trigger refresh — kubernetes becomes unavailable
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", { value: "visible", writable: true, configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Should auto-switch to local even though user manually selected kubernetes
+    await waitFor(() => {
+      expect(screen.queryByText(/is no longer available/)).toBeTruthy();
+    });
+  });
+
+  it("dismisses auto-switch notification after timeout", async () => {
+    const k8sHighPri = { ...K8S_AVAIL, priority: 5 };
+    const initialData = healthJson([LOCAL, k8sHighPri], { k8sAvailable: true });
+    const refreshData = healthJson([LOCAL, K8S_UNAVAIL], { k8sAvailable: false });
+
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/api/configs")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      callCount++;
+      const data = callCount <= 1 ? initialData : refreshData;
+      return Promise.resolve({ ok: true, json: async () => data });
+    });
+
+    render(<DeployForm onDeployStarted={() => {}} />);
+    await screen.findByText("This Machine");
+
+    // Trigger refresh
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", { value: "visible", writable: true, configurable: true });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/is no longer available/)).toBeTruthy();
+    });
+
+    // Advance past the 8-second dismiss timer
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/is no longer available/)).toBeNull();
     });
   });
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -38,7 +38,7 @@ registry.register({
   deployer: new KubernetesDeployer(),
   detect: async () => isClusterReachable(),
   unavailableReason: "No Kubernetes cluster detected. Configure kubectl and ensure you are logged in.",
-  priority: 0,
+  priority: 5,
   builtIn: true,
 });
 

--- a/src/server/services/__tests__/k8s.test.ts
+++ b/src/server/services/__tests__/k8s.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetCode } = vi.hoisted(() => ({
+const { mockGetCode, mockCreateSelfSubjectRulesReview } = vi.hoisted(() => ({
   mockGetCode: vi.fn(),
+  mockCreateSelfSubjectRulesReview: vi.fn(),
 }));
 
 vi.mock("@kubernetes/client-node", () => {
@@ -12,17 +13,21 @@ vi.mock("@kubernetes/client-node", () => {
       if (client === VersionApi) {
         return { getCode: mockGetCode };
       }
+      if (client === AuthorizationV1Api) {
+        return { createSelfSubjectRulesReview: mockCreateSelfSubjectRulesReview };
+      }
       return {};
     }
   }
 
   class VersionApi {}
+  class AuthorizationV1Api {}
   class ApisApi {}
   class CoreV1Api {}
   class AppsV1Api {}
   class ApiextensionsV1Api {}
 
-  return { KubeConfig, VersionApi, ApisApi, CoreV1Api, AppsV1Api, ApiextensionsV1Api };
+  return { KubeConfig, VersionApi, AuthorizationV1Api, ApisApi, CoreV1Api, AppsV1Api, ApiextensionsV1Api };
 });
 
 describe("isClusterReachable", () => {
@@ -32,16 +37,29 @@ describe("isClusterReachable", () => {
     mod.resetKubeConfig();
   });
 
-  it("returns true when the apiserver responds to a version probe", async () => {
+  it("returns true when both version probe and auth check succeed", async () => {
     mockGetCode.mockResolvedValue({ gitVersion: "v1.30.0" });
+    mockCreateSelfSubjectRulesReview.mockResolvedValue({ status: {} });
 
     const mod = await import("../k8s.js");
     await expect(mod.isClusterReachable()).resolves.toBe(true);
     expect(mockGetCode).toHaveBeenCalledTimes(1);
+    expect(mockCreateSelfSubjectRulesReview).toHaveBeenCalledTimes(1);
   });
 
-  it("returns false when the version probe fails", async () => {
-    mockGetCode.mockRejectedValue(new Error("forbidden"));
+  it("returns false when the version probe fails (no cluster)", async () => {
+    mockGetCode.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const mod = await import("../k8s.js");
+    await expect(mod.isClusterReachable()).resolves.toBe(false);
+    expect(mockCreateSelfSubjectRulesReview).not.toHaveBeenCalled();
+  });
+
+  it("returns false when version succeeds but auth check fails (logged out)", async () => {
+    mockGetCode.mockResolvedValue({ gitVersion: "v1.30.0" });
+    mockCreateSelfSubjectRulesReview.mockRejectedValue(
+      Object.assign(new Error("Unauthorized"), { code: 401 }),
+    );
 
     const mod = await import("../k8s.js");
     await expect(mod.isClusterReachable()).resolves.toBe(false);

--- a/src/server/services/k8s.ts
+++ b/src/server/services/k8s.ts
@@ -28,14 +28,37 @@ export function appsApi(): k8s.AppsV1Api {
 }
 
 /**
- * Check if we can connect to a K8s cluster at all.
+ * Check if we can connect to a K8s cluster AND the user is authenticated.
+ *
+ * The version endpoint (getCode) doesn't require authentication on most
+ * clusters, so it can't detect `oc logout`. We follow up with a lightweight
+ * authenticated call (SelfSubjectRulesReview) that fails after logout.
  */
 export async function isClusterReachable(): Promise<boolean> {
   try {
-    const client = loadKubeConfig().makeApiClient(k8s.VersionApi);
-    await client.getCode();
+    const kc = loadKubeConfig();
+
+    // 1. Quick connectivity check — can we reach the API server at all?
+    const versionClient = kc.makeApiClient(k8s.VersionApi);
+    await versionClient.getCode();
+
+    // 2. Authentication check — try a lightweight authn-required call.
+    //    SelfSubjectRulesReview is available to every authenticated user and
+    //    doesn't need list-namespace permissions.
+    const authClient = kc.makeApiClient(k8s.AuthorizationV1Api);
+    await authClient.createSelfSubjectRulesReview({
+      body: {
+        apiVersion: "authorization.k8s.io/v1",
+        kind: "SelfSubjectRulesReview",
+        spec: { namespace: "default" },
+      },
+    });
     return true;
-  } catch {
+  } catch (err) {
+    // 401/403 from the auth check means the cluster is reachable but the
+    // user is logged out or the token expired.
+    // Connection-level errors (ECONNREFUSED, DNS) mean no cluster at all.
+    // In both cases we return false — there is no usable cluster session.
     return false;
   }
 }


### PR DESCRIPTION
Auto-switch the selected deployer when the environment changes on refresh or tab focus:

- If the current mode becomes unavailable, switch to the best available deployer (even if the user manually selected it).
- If a higher-priority deployer becomes newly available and the user hasn't manually picked a mode, switch to it (e.g. local → kubernetes after login, kubernetes → openshift when detected).
- Never auto-switch while a deploy is in progress.
- Show a dismissible notification banner explaining what switched and why, auto-dismissed after 8 seconds.

Also improves isClusterReachable() to detect logout: the version endpoint (getCode) doesn't require authentication, so after `oc logout` the cluster still appeared reachable. Now a SelfSubjectRulesReview follow-up confirms the user is actually authenticated.

Deployer priorities are now local=0, kubernetes=5, openshift=10 so that logging into any cluster auto-promotes from local mode.

Fixes #38