### PR TITLE
fix(security): pin LiteLLM container image to v1.82.3-stable.patch.2

### DIFF
--- a/docs/vertex-credentials.md
+++ b/docs/vertex-credentials.md
@@ -144,14 +144,14 @@ API to Vertex AI.
 
 ### LiteLLM container image
 
-The proxy uses `ghcr.io/berriai/litellm:main-latest` (~1.5 GB). The first
+The proxy uses `ghcr.io/berriai/litellm:v1.82.3-stable.patch.2` (~1.5 GB). The first
 deployment will take extra time while this image is pulled. You can
 pre-pull it to speed things up:
 
 ```bash
-podman pull ghcr.io/berriai/litellm:main-latest
+podman pull ghcr.io/berriai/litellm:v1.82.3-stable.patch.2
 # or
-docker pull ghcr.io/berriai/litellm:main-latest
+docker pull ghcr.io/berriai/litellm:v1.82.3-stable.patch.2
 ```
 
 ### Disabling the proxy
@@ -211,6 +211,6 @@ deployment/openclaw -c litellm`. Common issues include an invalid
 credentials file or a missing project/location in the config.
 
 **First deployment is very slow?**
-The LiteLLM image (`ghcr.io/berriai/litellm:main-latest`) is ~1.5 GB.
+The LiteLLM image (`ghcr.io/berriai/litellm:v1.82.3-stable.patch.2`) is ~1.5 GB.
 Pre-pull it before deploying:
-`podman pull ghcr.io/berriai/litellm:main-latest`
+`podman pull ghcr.io/berriai/litellm:v1.82.3-stable.patch.2`

--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -1474,9 +1474,9 @@ export default function DeployForm({ onDeployStarted }: Props) {
                       color: "var(--text-secondary)",
                     }}>
                       The first deployment will pull both the OpenClaw image and the LiteLLM proxy
-                      image (<code>ghcr.io/berriai/litellm:main-latest</code>, ~1.5 GB).
+                      image (<code>ghcr.io/berriai/litellm:v1.82.3-stable.patch.2</code>, ~1.5 GB).
                       This may take several minutes. You can pre-pull
-                      with: <code>{mode === "kubernetes" ? "crictl pull" : "podman pull"} ghcr.io/berriai/litellm:main-latest</code>
+                      with: <code>{mode === "kubernetes" ? "crictl pull" : "podman pull"} ghcr.io/berriai/litellm:v1.82.3-stable.patch.2</code>
                     </div>
                   )}
                 </div>

--- a/src/server/deployers/litellm.ts
+++ b/src/server/deployers/litellm.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import type { DeployConfig } from "./types.js";
 
-export const LITELLM_IMAGE = "ghcr.io/berriai/litellm:main-latest";
+export const LITELLM_IMAGE = "ghcr.io/berriai/litellm:v1.82.3-stable.patch.2";
 export const LITELLM_PORT = 4000;
 
 export function generateLitellmMasterKey(): string {


### PR DESCRIPTION
## Summary

- Pin LiteLLM container image from floating `main-latest` tag to `v1.82.3-stable.patch.2` (latest confirmed-clean stable release)
- LiteLLM PyPI versions 1.82.7 and 1.82.8 were compromised in a supply chain attack ([TeamPCP](https://www.endorlabs.com/learn/teampcp-isnt-done)) that exfiltrates credentials to an attacker-controlled server
- While this project uses the container image (not the PyPI package directly), the floating `main-latest` tag is unsafe — it could pick up builds containing compromised code
- Updated all references across source code (`litellm.ts`), UI (`DeployForm.tsx`), and documentation (`vertex-credentials.md`)

## Files changed

| File | Change |
|------|--------|
| `src/server/deployers/litellm.ts` | Pin `LITELLM_IMAGE` constant |
| `src/client/components/DeployForm.tsx` | Update 2 hardcoded image references |
| `docs/vertex-credentials.md` | Update 5 documentation references |

## Test plan

- [x] All 157 existing tests pass (20 test files, `vitest run`)
- [ ] Verify LiteLLM proxy starts correctly with the pinned image in a local deployment
- [ ] Verify Kubernetes manifest generation uses the pinned tag

## References

- [LiteLLM compromise issue #24512](https://github.com/BerriAI/litellm/issues/24512)
- [Full timeline issue #24518](https://github.com/BerriAI/litellm/issues/24518)
- [TeamPCP threat actor analysis](https://www.endorlabs.com/learn/teampcp-isnt-done)
