### PR TITLE
fix(ui): refresh instance list immediately on tab switch

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -51,7 +51,7 @@ export default function App() {
       </div>
 
       <div style={{ display: tab === "instances" ? "block" : "none" }}>
-        <InstanceList />
+        <InstanceList active={tab === "instances"} />
       </div>
 
       {SHOW_PLUGINS_TAB && (

--- a/src/client/components/InstanceList.tsx
+++ b/src/client/components/InstanceList.tsx
@@ -99,7 +99,7 @@ function K8sProgress({ inst }: { inst: Instance }) {
   );
 }
 
-export default function InstanceList() {
+export default function InstanceList({ active }: { active: boolean }) {
   const [instances, setInstances] = useState<Instance[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -150,6 +150,13 @@ export default function InstanceList() {
     const interval = setInterval(fetchInstances, 5000);
     return () => clearInterval(interval);
   }, [includeK8s]);
+
+  // Fix for #5: fetch immediately when the Instances tab becomes visible
+  useEffect(() => {
+    if (active) {
+      fetchInstances();
+    }
+  }, [active]);
 
   const k8sToggle = k8sAvailable ? (
     <button className="btn btn-ghost" onClick={() => setIncludeK8s((prev) => !prev)}>

--- a/src/client/components/__tests__/InstanceList.test.tsx
+++ b/src/client/components/__tests__/InstanceList.test.tsx
@@ -66,13 +66,13 @@ afterEach(() => {
 describe("InstanceList", () => {
   it("shows loading state initially", () => {
     globalThis.fetch = vi.fn(() => new Promise(() => {})) as unknown as typeof globalThis.fetch;
-    render(<InstanceList />);
+    render(<InstanceList active />);
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("shows empty state when no instances", async () => {
     globalThis.fetch = mockFetchWith([]);
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByText("No OpenClaw instances found")).toBeInTheDocument();
     });
@@ -80,7 +80,7 @@ describe("InstanceList", () => {
 
   it("shows an error state when the instances request fails", async () => {
     globalThis.fetch = vi.fn(() => Promise.reject(new Error("network down"))) as unknown as typeof globalThis.fetch;
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByText("Could not load instances.")).toBeInTheDocument();
     });
@@ -89,7 +89,7 @@ describe("InstanceList", () => {
 
   it("renders running local instance with all expected controls", async () => {
     globalThis.fetch = mockFetchWith([runningInstance]);
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByText("abc123")).toBeInTheDocument();
     });
@@ -106,7 +106,7 @@ describe("InstanceList", () => {
 
   it("renders stopped instance with Start button and no panel buttons", async () => {
     globalThis.fetch = mockFetchWith([stoppedInstance]);
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByText("Start")).toBeInTheDocument();
     });
@@ -117,7 +117,7 @@ describe("InstanceList", () => {
 
   it("renders deploying K8s instance with badge, progress, and Re-deploy", async () => {
     globalThis.fetch = mockFetchWith([deployingK8sInstance]);
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByText("K8s")).toBeInTheDocument();
     });
@@ -127,7 +127,7 @@ describe("InstanceList", () => {
 
   it("renders error K8s instance with restart count and error message", async () => {
     globalThis.fetch = mockFetchWith([errorK8sInstance]);
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByText("CrashLoopBackOff")).toBeInTheDocument();
     });
@@ -138,7 +138,7 @@ describe("InstanceList", () => {
   it("enables Delete Data for running K8s instance", async () => {
     const runningK8s = { ...runningInstance, mode: "kubernetes", id: "k8s-1" };
     globalThis.fetch = mockFetchWith([runningK8s]);
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /delete data/i })).toBeInTheDocument();
     });
@@ -160,7 +160,7 @@ describe("InstanceList", () => {
       return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
     }) as unknown as typeof globalThis.fetch;
 
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /connection info/i })).toBeInTheDocument();
     });
@@ -181,7 +181,7 @@ describe("InstanceList", () => {
     const fetchMock = mockFetchWith([stoppedInstance]);
     globalThis.fetch = fetchMock;
 
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /start/i })).toBeInTheDocument();
     });
@@ -195,7 +195,7 @@ describe("InstanceList", () => {
     const fetchMock = mockFetchWith([runningInstance]);
     globalThis.fetch = fetchMock;
 
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
     });
@@ -210,7 +210,7 @@ describe("InstanceList", () => {
     const fetchMock = mockFetchWith([runningK8s]);
     globalThis.fetch = fetchMock;
 
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /re-deploy/i })).toBeInTheDocument();
     });
@@ -237,7 +237,7 @@ describe("InstanceList", () => {
       return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
     }) as unknown as typeof globalThis.fetch;
 
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByText("http://localhost:18789")).toBeInTheDocument();
     });
@@ -277,7 +277,7 @@ describe("InstanceList", () => {
       return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
     }) as unknown as typeof globalThis.fetch;
 
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByText("https://sam-openclaw.apps.example.com")).toBeInTheDocument();
     });
@@ -298,7 +298,7 @@ describe("InstanceList", () => {
     const fetchMock = mockFetchWith([stoppedInstance]);
     globalThis.fetch = fetchMock;
 
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /delete data/i })).toBeInTheDocument();
     });
@@ -313,7 +313,7 @@ describe("InstanceList", () => {
     const fetchMock = mockFetchWith([stoppedInstance]);
     globalThis.fetch = fetchMock;
 
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /delete data/i })).toBeInTheDocument();
     });
@@ -322,9 +322,59 @@ describe("InstanceList", () => {
     expect(fetchMock).not.toHaveBeenCalledWith("/api/instances/inst-2", { method: "DELETE" });
   });
 
+  // Regression test for #5: stale status when switching tabs
+  it("fetches instances immediately when active prop transitions to true", async () => {
+    const fetchMock = mockFetchWith([stoppedInstance]);
+    globalThis.fetch = fetchMock;
+
+    const { rerender } = render(<InstanceList active={false} />);
+    await waitFor(() => {
+      // Initial mount fetch still fires
+      expect(fetchMock).toHaveBeenCalledWith("/api/instances");
+    });
+
+    const callCountBeforeActivation = fetchMock.mock.calls.filter(
+      (c: unknown[]) => c[0] === "/api/instances",
+    ).length;
+
+    // Simulate tab switch: active transitions from false to true
+    rerender(<InstanceList active />);
+
+    await waitFor(() => {
+      const callCountAfterActivation = fetchMock.mock.calls.filter(
+        (c: unknown[]) => c[0] === "/api/instances",
+      ).length;
+      expect(callCountAfterActivation).toBeGreaterThan(callCountBeforeActivation);
+    });
+  });
+
+  it("does not fetch again when active remains true (no duplicate fetches)", async () => {
+    const fetchMock = mockFetchWith([runningInstance]);
+    globalThis.fetch = fetchMock;
+
+    const { rerender } = render(<InstanceList active />);
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/instances");
+    });
+
+    const callCountBefore = fetchMock.mock.calls.filter(
+      (c: unknown[]) => c[0] === "/api/instances",
+    ).length;
+
+    // Re-render with same active=true — should NOT trigger extra fetch
+    rerender(<InstanceList active />);
+
+    // Give it a tick to ensure no extra fetch fires
+    await new Promise((r) => setTimeout(r, 50));
+    const callCountAfter = fetchMock.mock.calls.filter(
+      (c: unknown[]) => c[0] === "/api/instances",
+    ).length;
+    expect(callCountAfter).toBe(callCountBefore);
+  });
+
   it("renders gracefully when fetch rejects", async () => {
     globalThis.fetch = vi.fn(() => Promise.reject(new Error("network error"))) as unknown as typeof globalThis.fetch;
-    render(<InstanceList />);
+    render(<InstanceList active />);
     // Should not crash — component catches the error and finishes loading
     await waitFor(() => {
       expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
@@ -344,7 +394,7 @@ describe("InstanceList", () => {
     }) as unknown as typeof globalThis.fetch;
     globalThis.fetch = fetchMock;
 
-    render(<InstanceList />);
+    render(<InstanceList active />);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /include k8s/i })).toBeInTheDocument();
     });


### PR DESCRIPTION
InstanceList was always mounted but hidden via display:none while the Deploy tab was active. Its 5-second polling continued in the background, but switching to the Instances tab could show stale data for up to 5 seconds. Add an `active` prop that triggers an immediate fetchInstances() when the tab becomes visible, eliminating the staleness window.

Fixes #5

## Summary

- Pass `active={tab === "instances"}` from App.tsx to InstanceList
- Add useEffect in InstanceList that fetches on active transition to true
- Add 2 regression tests for the new behavior

## Test plan

- [x] Regression test: tab activation triggers immediate fetch
- [x] Regression test: no duplicate fetches when active stays true
- [x] All 169 tests pass (npm test)
- [x] Manual: deploy instance, switch tabs, confirm status shows immediately