### PR TITLE
fix(deploy): detect port conflicts before creating containers

### DIFF
--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -739,6 +739,9 @@ export class LocalDeployer implements Deployer {
 
     // Check for port conflicts before attempting to create containers (Fix for #12)
     await checkPortAvailable(port, runtime);
+    if (shouldUseLitellmProxy(config)) {
+      await checkPortAvailable(port + 1, runtime);
+    }
 
     // Remove existing container with same name (in case --rm didn't fire)
     await removeContainer(runtime, name);
@@ -1289,6 +1292,9 @@ something that requires the user's attention.`;
 
     // Check for port conflicts before attempting to create containers (Fix for #12)
     await checkPortAvailable(port, runtime);
+    if (shouldUseLitellmProxy(effectiveConfig)) {
+      await checkPortAvailable(port + 1, runtime);
+    }
 
     // Remove old container if it exists (stop may not have fully cleaned up)
     await removeContainer(runtime, name);

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -17,6 +17,7 @@ import {
   detectRuntime,
   removeContainer,
   removeVolume,
+  checkPortAvailable,
   OPENCLAW_LABELS,
   type ContainerRuntime,
 } from "../services/container.js";
@@ -736,6 +737,9 @@ export class LocalDeployer implements Deployer {
     }
     log(`Using container runtime: ${runtime}`);
 
+    // Check for port conflicts before attempting to create containers (Fix for #12)
+    await checkPortAvailable(port, runtime);
+
     // Remove existing container with same name (in case --rm didn't fire)
     await removeContainer(runtime, name);
 
@@ -1282,6 +1286,9 @@ something that requires the user's attention.`;
     if (sshMaterialResult.code !== 0) {
       throw new Error("Failed to stage SSH sandbox material into local runtime state");
     }
+
+    // Check for port conflicts before attempting to create containers (Fix for #12)
+    await checkPortAvailable(port, runtime);
 
     // Remove old container if it exists (stop may not have fully cleaned up)
     await removeContainer(runtime, name);

--- a/src/server/services/__tests__/port-check.test.ts
+++ b/src/server/services/__tests__/port-check.test.ts
@@ -40,7 +40,7 @@ describe("checkPortAvailable", () => {
     });
 
     // Mock the runtime ps command to return a container using this port
-    mockExecFile.mockImplementation((_file: string, _args: string[], cb: Function) => {
+    mockExecFile.mockImplementation((_file: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
       cb(null, {
         stdout: `openclaw-bob-agent\t0.0.0.0:${boundPort}->18789/tcp`,
         stderr: "",
@@ -63,7 +63,7 @@ describe("checkPortAvailable", () => {
     });
 
     // Mock the runtime ps command to fail
-    mockExecFile.mockImplementation((_file: string, _args: string[], cb: Function) => {
+    mockExecFile.mockImplementation((_file: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
       cb(new Error("podman not found"), { stdout: "", stderr: "" });
     });
 
@@ -83,7 +83,7 @@ describe("checkPortAvailable", () => {
     });
 
     // Mock: runtime returns containers but none match this port
-    mockExecFile.mockImplementation((_file: string, _args: string[], cb: Function) => {
+    mockExecFile.mockImplementation((_file: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
       cb(null, {
         stdout: "some-container\t0.0.0.0:9999->80/tcp",
         stderr: "",

--- a/src/server/services/__tests__/port-check.test.ts
+++ b/src/server/services/__tests__/port-check.test.ts
@@ -1,0 +1,98 @@
+import { createServer, type Server } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: mockExecFile,
+}));
+
+describe("checkPortAvailable", () => {
+  let blockingServer: Server | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (blockingServer) {
+      await new Promise<void>((resolve) => blockingServer!.close(() => resolve()));
+      blockingServer = null;
+    }
+  });
+
+  it("resolves when port is free", async () => {
+    const { checkPortAvailable } = await import("../container.js");
+    // Use a random high port that is very unlikely to be in use
+    await expect(checkPortAvailable(0, "podman")).resolves.toBeUndefined();
+  });
+
+  it("throws when port is in use, including container name from runtime", async () => {
+    // Bind a port to simulate an occupied port
+    blockingServer = createServer();
+    const boundPort = await new Promise<number>((resolve) => {
+      blockingServer!.listen(0, "0.0.0.0", () => {
+        const addr = blockingServer!.address();
+        resolve(typeof addr === "object" && addr ? addr.port : 0);
+      });
+    });
+
+    // Mock the runtime ps command to return a container using this port
+    mockExecFile.mockImplementation((_file: string, _args: string[], cb: Function) => {
+      cb(null, {
+        stdout: `openclaw-bob-agent\t0.0.0.0:${boundPort}->18789/tcp`,
+        stderr: "",
+      });
+    });
+
+    const { checkPortAvailable } = await import("../container.js");
+    await expect(checkPortAvailable(boundPort, "podman")).rejects.toThrow(
+      `Port ${boundPort} is already in use by container openclaw-bob-agent`,
+    );
+  });
+
+  it("throws with generic message when runtime query fails", async () => {
+    blockingServer = createServer();
+    const boundPort = await new Promise<number>((resolve) => {
+      blockingServer!.listen(0, "0.0.0.0", () => {
+        const addr = blockingServer!.address();
+        resolve(typeof addr === "object" && addr ? addr.port : 0);
+      });
+    });
+
+    // Mock the runtime ps command to fail
+    mockExecFile.mockImplementation((_file: string, _args: string[], cb: Function) => {
+      cb(new Error("podman not found"), { stdout: "", stderr: "" });
+    });
+
+    const { checkPortAvailable } = await import("../container.js");
+    await expect(checkPortAvailable(boundPort, "podman")).rejects.toThrow(
+      `Port ${boundPort} is already in use. Stop the existing instance first or choose a different port.`,
+    );
+  });
+
+  it("throws with generic message when no container matches the port", async () => {
+    blockingServer = createServer();
+    const boundPort = await new Promise<number>((resolve) => {
+      blockingServer!.listen(0, "0.0.0.0", () => {
+        const addr = blockingServer!.address();
+        resolve(typeof addr === "object" && addr ? addr.port : 0);
+      });
+    });
+
+    // Mock: runtime returns containers but none match this port
+    mockExecFile.mockImplementation((_file: string, _args: string[], cb: Function) => {
+      cb(null, {
+        stdout: "some-container\t0.0.0.0:9999->80/tcp",
+        stderr: "",
+      });
+    });
+
+    const { checkPortAvailable } = await import("../container.js");
+    await expect(checkPortAvailable(boundPort, "podman")).rejects.toThrow(
+      `Port ${boundPort} is already in use. Stop the existing instance first or choose a different port.`,
+    );
+  });
+});

--- a/src/server/services/container.ts
+++ b/src/server/services/container.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createServer } from "node:net";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -134,6 +135,52 @@ function isOpenClawRuntimeImage(image: string): boolean {
   const repoName = lastSegment.split(":")[0];
 
   return repoName === "openclaw";
+}
+
+/**
+ * Check whether a host port is available for binding.
+ * If the port is already in use, tries to identify the container using it
+ * and throws an error with a helpful message.
+ */
+export async function checkPortAvailable(
+  port: number,
+  runtime: ContainerRuntime,
+): Promise<void> {
+  const portFree = await new Promise<boolean>((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.listen(port, "0.0.0.0", () => {
+      server.close(() => resolve(true));
+    });
+  });
+
+  if (portFree) return;
+
+  // Port is in use — try to find which container is using it
+  let occupant = "";
+  try {
+    const { stdout } = await execFileAsync(runtime, [
+      "ps",
+      "--format",
+      "{{.Names}}\t{{.Ports}}",
+    ]);
+    for (const line of stdout.trim().split("\n")) {
+      if (!line.trim()) continue;
+      if (line.includes(`:${port}->`)) {
+        const name = line.split("\t")[0];
+        if (name) {
+          occupant = ` by container ${name.trim()}`;
+          break;
+        }
+      }
+    }
+  } catch {
+    // Container runtime query failed — still report the port conflict
+  }
+
+  throw new Error(
+    `Port ${port} is already in use${occupant}. Stop the existing instance first or choose a different port.`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add pre-flight port availability check in the local deployer to detect port conflicts before attempting to create pods/containers
- When a port is in use, the error now identifies the occupying container by name (e.g., "Port 18789 is already in use by container openclaw-bob-agent")
- Check runs in both deploy() and start() flows
- Also checks port + 1 when LiteLLM proxy is enabled (the sidecar binds that port for its API)

Fixes #12

## Test plan
- [x] New unit tests for checkPortAvailable covering: free port, occupied port with container identification, runtime query failure, and no-match fallback
- [x] All 173 existing tests pass with no regressions
- [x] npm run build passes with no type errors

## Rollback
Remove the checkPortAvailable calls from local.ts and the function + import from container.ts.
