### PR TITLE
fix(ui): add instance ID to gateway URLs to detect new instances on same port

### DIFF
--- a/src/client/components/InstanceList.tsx
+++ b/src/client/components/InstanceList.tsx
@@ -239,7 +239,10 @@ export default function InstanceList({ active }: { active: boolean }) {
   };
 
   const handleOpenWithToken = async (inst: Instance) => {
-    const targetUrl = inst.url ? `${inst.url}?session=${encodeURIComponent(defaultSessionKey(inst))}` : inst.url;
+    // Fix for #44: Add instance ID to URL so gateway can detect new instances on same port
+    const targetUrl = inst.url
+      ? `${inst.url}?session=${encodeURIComponent(defaultSessionKey(inst))}&instance=${encodeURIComponent(inst.id)}`
+      : inst.url;
     try {
       const res = await fetch(`/api/instances/${inst.id}/token`);
       const data = await res.json();
@@ -439,7 +442,7 @@ export default function InstanceList({ active }: { active: boolean }) {
                 {[
                   {
                     label: "URL",
-                    value: `${inst.url}?session=${encodeURIComponent(defaultSessionKey(inst))}#token=${encodeURIComponent(panelContent)}`,
+                    value: `${inst.url}?session=${encodeURIComponent(defaultSessionKey(inst))}&instance=${encodeURIComponent(inst.id)}#token=${encodeURIComponent(panelContent)}`,
                   },
                   { label: "Token", value: panelContent },
                 ].map(({ label, value }) => (

--- a/src/client/components/__tests__/InstanceList.test.tsx
+++ b/src/client/components/__tests__/InstanceList.test.tsx
@@ -170,7 +170,7 @@ describe("InstanceList", () => {
       // Connection info shows both URL with token and raw token
       expect(screen.getByText("secret-token-123")).toBeInTheDocument();
       expect(
-        screen.getByText(/http:\/\/localhost:18789\?session=agent%3Auser_lynx%3Amain#token=secret-token-123/),
+        screen.getByText(/http:\/\/localhost:18789\?session=agent%3Auser_lynx%3Amain&instance=inst-1#token=secret-token-123/),
       ).toBeInTheDocument();
     });
     expect(screen.getByRole("button", { name: /^hide$/i })).toBeInTheDocument();
@@ -245,7 +245,7 @@ describe("InstanceList", () => {
     await user.click(screen.getByText("http://localhost:18789"));
     await waitFor(() => {
       expect(openSpy).toHaveBeenCalledWith(
-        "http://localhost:18789?session=agent%3Auser_lynx%3Amain#token=my-token",
+        "http://localhost:18789?session=agent%3Auser_lynx%3Amain&instance=inst-1#token=my-token",
         "_blank",
         "noopener",
       );
@@ -285,7 +285,47 @@ describe("InstanceList", () => {
     await user.click(screen.getByText("https://sam-openclaw.apps.example.com"));
     await waitFor(() => {
       expect(openSpy).toHaveBeenCalledWith(
-        "https://sam-openclaw.apps.example.com?session=agent%3Auser_lynx%3Amain#token=cluster-token",
+        "https://sam-openclaw.apps.example.com?session=agent%3Auser_lynx%3Amain&instance=k8s-1#token=cluster-token",
+        "_blank",
+        "noopener",
+      );
+    });
+  });
+
+  // Regression test for #44: instance ID should be in URL to prevent browser cache collisions
+  it("includes instance ID in gateway URL to detect new instances on same port", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimers});
+    const openSpy = vi.fn();
+    vi.stubGlobal("open", openSpy);
+
+    globalThis.fetch = vi.fn((url: string) => {
+      if (url === "/api/health") {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ k8sAvailable: false }) });
+      }
+      if (url === "/api/instances" || url === "/api/instances?includeK8s=1") {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([runningInstance]) });
+      }
+      if (url === "/api/instances/inst-1/token") {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ token: "my-token" }) });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    }) as unknown as typeof globalThis.fetch;
+
+    render(<InstanceList active />);
+    await waitFor(() => {
+      expect(screen.getByText("http://localhost:18789")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("http://localhost:18789"));
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.stringContaining("&instance=inst-1"),
+        "_blank",
+        "noopener",
+      );
+      // Verify full URL structure includes instance ID between session and token
+      expect(openSpy).toHaveBeenCalledWith(
+        "http://localhost:18789?session=agent%3Auser_lynx%3Amain&instance=inst-1#token=my-token",
         "_blank",
         "noopener",
       );


### PR DESCRIPTION
Fixes #44

## Problem

When deploying a new local OpenClaw instance on the same port as a previously deleted instance (e.g., localhost:18789), the gateway UI displays the old agent's name and identity instead of the new one.

Root cause: Browser caches session state (localStorage/sessionStorage) keyed to the URL origin. When a new instance starts on the same port, the gateway UI loads the cached data before processing URL parameters, displaying stale agent identity.

## Solution (Part 1 of 2)

This PR implements the installer-side fix: include a unique instance ID in gateway URLs so the gateway can detect new instances.

URL format change:
- Before: http://localhost:18789?session=agent:user_lynx:main#token=abc123xyz
- After: http://localhost:18789?session=agent:user_lynx:main&instance=550e8400-e29b-41d4-a716-446655440000#token=abc123xyz

Files modified:
- src/client/components/InstanceList.tsx (7 lines changed)
- src/client/components/__tests__/InstanceList.test.tsx (46 lines changed)

Implementation:
1. handleOpenWithToken() (line 242-244): Add &instance=\${encodeURIComponent(inst.id)} to URL
2. Connection Info panel (line 445): Add instance ID to displayed URL

Testing:
- New regression test added: "includes instance ID in gateway URL to detect new instances on same port"
- 3 existing tests updated to expect instance ID in URLs

## Solution (Part 2 of 2) — Gateway Update Required

⚠️ This PR alone does NOT fully fix the issue. The gateway application (separate repository) must be updated to read and use the instance parameter to clear stale cache.

Required gateway changes:
1. Read instance parameter from URL on initialization
2. Compare to cached instance ID in localStorage
3. Clear localStorage/sessionStorage if mismatch detected
4. Store new instance ID in cache

## Backward Compatibility

✅ Fully backward compatible
- Existing gateway versions safely ignore unknown parameters
- URLs without instance ID continue to work
- No breaking changes to API or data structures