### PR TITLE
fix(deployers): stop hard-coding workspace-main

### DIFF
--- a/src/server/deployers/__tests__/agent-source.test.ts
+++ b/src/server/deployers/__tests__/agent-source.test.ts
@@ -2,7 +2,8 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
-import { loadAgentSourceCronJobs } from "../agent-source.js";
+import { loadAgentSourceCronJobs, subagentIds, mainWorkspaceShellCondition } from "../agent-source.js";
+import type { AgentSourceBundle } from "../agent-source.js";
 
 const tempDirs: string[] = [];
 
@@ -31,5 +32,89 @@ describe("loadAgentSourceCronJobs", () => {
     tempDirs.push(dir);
 
     expect(loadAgentSourceCronJobs(dir)).toBeUndefined();
+  });
+});
+
+describe("subagentIds", () => {
+  it("returns empty array for undefined bundle", () => {
+    expect(subagentIds(undefined)).toEqual([]);
+  });
+
+  it("returns empty array when bundle has no agents", () => {
+    expect(subagentIds({ mainAgent: {} })).toEqual([]);
+  });
+
+  it("extracts IDs from bundle agents", () => {
+    const bundle: AgentSourceBundle = {
+      agents: [
+        { id: "builder" },
+        { id: "research" },
+        { id: "ops" },
+      ],
+    };
+    expect(subagentIds(bundle)).toEqual(["builder", "research", "ops"]);
+  });
+});
+
+// Regression tests for #62: workspace-shadowman not recognized as main agent workspace
+describe("mainWorkspaceShellCondition", () => {
+  const mainDest = "/home/node/.openclaw/workspace-openclaw_shadowman";
+
+  it("maps all workspace-* dirs to main when bundle is undefined", () => {
+    const result = mainWorkspaceShellCondition(mainDest, undefined);
+    expect(result).toBe(`dest="${mainDest}"`);
+  });
+
+  it("maps all workspace-* dirs to main when bundle has no subagents", () => {
+    const bundle: AgentSourceBundle = { mainAgent: {} };
+    const result = mainWorkspaceShellCondition(mainDest, bundle);
+    expect(result).toBe(`dest="${mainDest}"`);
+  });
+
+  it("routes subagent workspaces to their own paths and everything else to main", () => {
+    const bundle: AgentSourceBundle = {
+      agents: [
+        { id: "builder" },
+        { id: "research" },
+        { id: "ops" },
+      ],
+    };
+    const result = mainWorkspaceShellCondition(mainDest, bundle);
+
+    // Subagent dirs should be routed to /home/node/.openclaw/$base
+    expect(result).toContain('[ "$base" = "workspace-builder" ]');
+    expect(result).toContain('[ "$base" = "workspace-research" ]');
+    expect(result).toContain('[ "$base" = "workspace-ops" ]');
+    expect(result).toContain('dest="/home/node/.openclaw/$base"');
+
+    // Non-subagent dirs (workspace-shadowman, workspace-main, etc.) go to main
+    expect(result).toContain(`dest="${mainDest}"`);
+
+    // The subagent check is in the "then" branch, main is in the "else" branch
+    expect(result).toMatch(/^if .+ then dest="\/home\/node\/.openclaw\/\$base"; else dest=".*"; fi$/);
+  });
+
+  it("handles single subagent", () => {
+    const bundle: AgentSourceBundle = {
+      agents: [{ id: "builder" }],
+    };
+    const result = mainWorkspaceShellCondition(mainDest, bundle);
+    expect(result).toBe(
+      `if [ "$base" = "workspace-builder" ]; then dest="/home/node/.openclaw/$base"; else dest="${mainDest}"; fi`,
+    );
+  });
+
+  it("workspace-main still works (never matches a subagent ID)", () => {
+    // workspace-main would have base="workspace-main", which won't match
+    // workspace-builder, workspace-research, or workspace-ops — so it falls
+    // through to the else branch (main dest). Backwards compatible.
+    const bundle: AgentSourceBundle = {
+      agents: [{ id: "builder" }, { id: "research" }],
+    };
+    const result = mainWorkspaceShellCondition(mainDest, bundle);
+    // "workspace-main" doesn't appear in any check condition
+    expect(result).not.toContain('"workspace-main"');
+    // It will fall to the else branch → main dest
+    expect(result).toContain(`else dest="${mainDest}"`);
   });
 });

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -72,6 +72,29 @@ describe("k8s state sync manifests", () => {
   });
 });
 
+// Regression test for #62: workspace-shadowman not recognized as main agent workspace
+describe("workspace routing in init script", () => {
+  it("does not hard-code workspace-main in the init script", () => {
+    const deployment = deploymentManifest("ns", makeConfig());
+    const initContainer = deployment.spec?.template.spec?.initContainers?.[0];
+    const initScript = initContainer?.command?.[2] ?? "";
+
+    // The old bug: init script contained a hard-coded check for "workspace-main"
+    // which caused persona-named workspaces (e.g. workspace-shadowman) to be
+    // copied to dead paths. The fix uses bundle-aware routing instead.
+    expect(initScript).not.toContain('"workspace-main"');
+    expect(initScript).not.toContain("= \"workspace-main\"");
+  });
+
+  it("still copies workspace-* directories via find", () => {
+    const deployment = deploymentManifest("ns", makeConfig());
+    const initContainer = deployment.spec?.template.spec?.initContainers?.[0];
+    const initScript = initContainer?.command?.[2] ?? "";
+
+    expect(initScript).toContain("find /agents-tree -mindepth 1 -type d -name 'workspace-*'");
+  });
+});
+
 // Regression tests for #6: API keys must not leak to the gateway in proxy mode
 describe("gateway env vars in proxy mode", () => {
   it("excludes ANTHROPIC_API_KEY and OPENAI_API_KEY when litellm proxy is active", () => {

--- a/src/server/deployers/agent-source.ts
+++ b/src/server/deployers/agent-source.ts
@@ -37,6 +37,44 @@ export async function loadAgentSourceWorkspaceTree(agentSourceDir?: string): Pro
   return await loadTextTree(agentSourceDir);
 }
 
+/**
+ * Extract subagent IDs from a loaded bundle.
+ */
+export function subagentIds(bundle: AgentSourceBundle | undefined): string[] {
+  return (bundle?.agents || []).map((a) => a.id);
+}
+
+/**
+ * Build a shell snippet that routes workspace-* directories during copy.
+ *
+ * Directories whose basename matches a known subagent ID (e.g. workspace-builder)
+ * are copied to their own path.  The remaining workspace-* directory — regardless
+ * of its name — is treated as the main agent workspace.  This allows bundles to
+ * use persona names like workspace-shadowman instead of the rigid workspace-main.
+ *
+ * `workspace-main` continues to work because it will never collide with a
+ * subagent ID.
+ *
+ * @param mainDest  Shell expression for the main agent workspace path
+ *                  (may contain shell variables, e.g. '${workspaceDir}')
+ * @param bundle    The loaded agent source bundle (may be undefined)
+ * @returns         A shell `if` statement body suitable for embedding
+ */
+export function mainWorkspaceShellCondition(
+  mainDest: string,
+  bundle: AgentSourceBundle | undefined,
+): string {
+  const ids = subagentIds(bundle);
+  if (ids.length === 0) {
+    // No subagents — every workspace-* directory is the main workspace
+    // (preserves legacy workspace-main behaviour too).
+    return `dest="${mainDest}"`;
+  }
+  // Build: if [ "$base" = "workspace-builder" ] || [ "$base" = "workspace-research" ] ...
+  const checks = ids.map((id) => `[ "$base" = "workspace-${id}" ]`).join(" || ");
+  return `if ${checks}; then dest="/home/node/.openclaw/$base"; else dest="${mainDest}"; fi`;
+}
+
 export function loadAgentSourceCronJobs(agentSourceDir?: string): string | undefined {
   if (!agentSourceDir) return undefined;
   const cronPath = join(agentSourceDir, "cron", "jobs.json");

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -10,6 +10,7 @@ import type { DeployConfig } from "./types.js";
 import { shouldUseLitellmProxy, LITELLM_IMAGE, LITELLM_PORT } from "./litellm.js";
 import { shouldUseOtel, OTEL_COLLECTOR_IMAGE, OTEL_GRPC_PORT, OTEL_HTTP_PORT, otelAgentEnv } from "./otel.js";
 import type { TreeEntry } from "../state-tree.js";
+import { loadAgentSourceBundle, mainWorkspaceShellCondition } from "./agent-source.js";
 
 export function namespaceManifest(ns: string): k8s.V1Namespace {
   return {
@@ -287,6 +288,10 @@ export function deploymentManifest(
     .map((f) => `  cp /agents/${f} /home/node/.openclaw/workspace-${id}/${f} 2>/dev/null || true`)
     .join("\n");
 
+  // Fix for #62: use bundle-aware routing so persona-named workspaces map to the main agent
+  const mainWorkspaceDest = `/home/node/.openclaw/workspace-${id}`;
+  const workspaceRouting = mainWorkspaceShellCondition(mainWorkspaceDest, loadAgentSourceBundle(config));
+
   const initScript = `
 cp /config/openclaw.json /home/node/.openclaw/openclaw.json
 chmod 644 /home/node/.openclaw/openclaw.json
@@ -295,7 +300,7 @@ mkdir -p /home/node/.openclaw/skills
 mkdir -p /home/node/.openclaw/cron
 mkdir -p /home/node/.openclaw/workspace-${id}
 ${copyLines}
-find /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; if [ "$base" = "workspace-main" ]; then dest="/home/node/.openclaw/workspace-${id}"; else dest="/home/node/.openclaw/$base"; fi; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \\;
+find /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; ${workspaceRouting}; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \\;
 cp -r /skills-src/. /home/node/.openclaw/skills/ 2>/dev/null || true
 cp /cron-src/jobs.json /home/node/.openclaw/cron/jobs.json 2>/dev/null || true
 chown -R 1000:1000 /home/node/.openclaw 2>/dev/null || true

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -15,7 +15,7 @@ import type {
 } from "./types.js";
 import { namespaceName, agentId, generateToken, usesDefaultEnvSecretRef } from "./k8s-helpers.js";
 import { loadWorkspaceFiles } from "./k8s-agent.js";
-import { loadAgentSourceCronJobs, loadAgentSourceWorkspaceTree } from "./agent-source.js";
+import { loadAgentSourceBundle, loadAgentSourceCronJobs, loadAgentSourceWorkspaceTree, mainWorkspaceShellCondition } from "./agent-source.js";
 import {
   namespaceManifest,
   pvcManifest,
@@ -583,6 +583,10 @@ export class KubernetesDeployer implements Deployer {
       .map((f) => `cp /agents/${f} /home/node/.openclaw/workspace-${id}/${f} 2>/dev/null || true`)
       .join("\n");
 
+    // Fix for #62: use bundle-aware routing so persona-named workspaces map to the main agent
+    const mainWorkspaceDest = `/home/node/.openclaw/workspace-${id}`;
+    const workspaceRouting = mainWorkspaceShellCondition(mainWorkspaceDest, loadAgentSourceBundle(result.config));
+
     const initScript = `
 cp /config/openclaw.json /home/node/.openclaw/openclaw.json
 chmod 644 /home/node/.openclaw/openclaw.json
@@ -591,7 +595,7 @@ mkdir -p /home/node/.openclaw/skills
 mkdir -p /home/node/.openclaw/cron
 mkdir -p /home/node/.openclaw/workspace-${id}
 ${copyLines}
-find /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; if [ "$base" = "workspace-main" ]; then dest="/home/node/.openclaw/workspace-${id}"; else dest="/home/node/.openclaw/$base"; fi; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \\;
+find /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; ${workspaceRouting}; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \\;
 cp -r /skills-src/. /home/node/.openclaw/skills/ 2>/dev/null || true
 cp /cron-src/jobs.json /home/node/.openclaw/cron/jobs.json 2>/dev/null || true
 chgrp -R 0 /home/node/.openclaw 2>/dev/null || true

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -2,7 +2,7 @@ import { spawn, execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { v4 as uuid } from "uuid";
 import type {
   Deployer,
@@ -43,7 +43,7 @@ import {
 } from "./k8s-helpers.js";
 import { buildSandboxConfig } from "./sandbox.js";
 import { buildSandboxToolPolicy } from "./tool-policy.js";
-import { loadAgentSourceBundle } from "./agent-source.js";
+import { loadAgentSourceBundle, mainWorkspaceShellCondition } from "./agent-source.js";
 
 const DEFAULT_IMAGE = process.env.OPENCLAW_IMAGE || "ghcr.io/openclaw/openclaw:latest";
 const DEFAULT_VERTEX_IMAGE = process.env.OPENCLAW_VERTEX_IMAGE || DEFAULT_IMAGE;
@@ -879,6 +879,7 @@ export class LocalDeployer implements Deployer {
 
     const agentId = `${config.prefix || "openclaw"}_${config.agentName}`;
     const workspaceDir = `/home/node/.openclaw/workspace-${agentId}`;
+    const sourceBundle = loadAgentSourceBundle(config);
 
     // Build init script: write config + workspace files on first deploy
     const gatewayToken = generateToken();
@@ -1011,8 +1012,10 @@ Use this table to track verified peer OpenClaw instances.
       `test -f '${workspaceDir}/USER.md' || cat > '${workspaceDir}/USER.md' << 'USEREOF'\n${userMd}\nUSEREOF`,
       `test -f '${workspaceDir}/HEARTBEAT.md' || cat > '${workspaceDir}/HEARTBEAT.md' << 'HBEOF'\n${heartbeatMd}\nHBEOF`,
       `test -f '${workspaceDir}/MEMORY.md' || cat > '${workspaceDir}/MEMORY.md' << 'MEMEOF'\n${memoryMd}\nMEMEOF`,
-      // If user provided agent source files via mount, copy them in (overrides defaults)
-      `for d in /tmp/agent-source/workspace-*; do if [ -d "$d" ]; then base="$(basename "$d")"; if [ "$base" = "workspace-main" ]; then dest='${workspaceDir}'; else dest="/home/node/.openclaw/$base"; fi; mkdir -p "$dest"; cp -r "$d"/* "$dest"/ 2>/dev/null || true; fi; done`,
+      // If user provided agent source files via mount, copy them in (overrides defaults).
+      // Fix for #62: infer the main agent workspace by elimination — any workspace-*
+      // directory that doesn't match a subagent ID is the main agent's workspace.
+      `for d in /tmp/agent-source/workspace-*; do if [ -d "$d" ]; then base="$(basename "$d")"; ${mainWorkspaceShellCondition(workspaceDir, sourceBundle)}; mkdir -p "$dest"; cp -r "$d"/* "$dest"/ 2>/dev/null || true; fi; done`,
       `if [ -d /tmp/agent-source/skills ]; then cp -r /tmp/agent-source/skills/* /home/node/.openclaw/skills/ 2>/dev/null || true; fi`,
       `if [ -f /tmp/agent-source/cron/jobs.json ]; then mkdir -p /home/node/.openclaw/cron && cp /tmp/agent-source/cron/jobs.json /home/node/.openclaw/cron/jobs.json 2>/dev/null || true; fi`,
       runtimeOwnershipFixupCommand(),
@@ -1344,19 +1347,19 @@ Use this table to track verified peer OpenClaw instances.
       }
     }
 
-    if (
-      agentSourceDir && (
-        existsSync(join(agentSourceDir, `workspace-${agentId}`))
-        || existsSync(join(agentSourceDir, "workspace-main"))
-      )
-    ) {
+    // Fix for #62: detect any workspace-* directory, not just workspace-main or workspace-${agentId}
+    const hasWorkspaceDirs = agentSourceDir && existsSync(agentSourceDir)
+      && readdirSync(agentSourceDir).some((e) => e.startsWith("workspace-"));
+
+    if (hasWorkspaceDirs) {
       log("Updating agent files from host...");
       const workspaceDir = `/home/node/.openclaw/workspace-${agentId}`;
+      const bundleForCopy = loadAgentSourceBundle(effectiveConfig);
       const copyScript = [
         `for d in /tmp/agent-source/workspace-*; do`,
         `  if [ -d "$d" ]; then`,
         `    base="$(basename "$d")"`,
-        `    if [ "$base" = "workspace-main" ]; then dest='${workspaceDir}'; else dest="/home/node/.openclaw/$base"; fi`,
+        `    ${mainWorkspaceShellCondition(workspaceDir, bundleForCopy)}`,
         `    mkdir -p "$dest"`,
         `    cp -r "$d"/* "$dest"/ 2>/dev/null || true`,
         `  fi`,
@@ -1816,11 +1819,14 @@ Use this table to track verified peer OpenClaw instances.
     log(`Re-deploying agent files from ${agentSourceDir}...`);
 
     // Copy updated agent files into the volume
+    // Fix for #62: use bundle-aware routing so persona-named workspaces
+    // (e.g. workspace-shadowman) map to the main agent workspace.
+    const redeployBundle = loadAgentSourceBundle(result.config);
     const copyScript = [
       `for d in /tmp/agent-source/workspace-*; do`,
       `  if [ -d "$d" ]; then`,
       `    base="$(basename "$d")"`,
-      `    if [ "$base" = "workspace-main" ]; then dest='${workspaceDir}'; else dest="/home/node/.openclaw/$base"; fi`,
+      `    ${mainWorkspaceShellCondition(workspaceDir, redeployBundle)}`,
       `    mkdir -p "$dest"`,
       `    cp -vr "$d"/* "$dest"/ 2>/dev/null || true`,
       `  fi`,


### PR DESCRIPTION
The deployers hard-coded "workspace-main" as the only directory name that maps to the main agent's workspace. Agent bundles using persona names like workspace-shadowman were silently copied to dead paths, breaking multi-agent delegation.

## Problem

Both local and K8s deployers check `if [ "$base" = "workspace-main" ]` to decide which workspace-* directory maps to the main agent. The demo bundles use `workspace-shadowman/` for the main agent, so it falls through to the else branch and gets copied to `/home/node/.openclaw/workspace-shadowman/` — a path no agent uses.

## Solution

Added `mainWorkspaceShellCondition()` helper in `agent-source.ts` that routes workspace-* directories by elimination: any directory matching a known subagent ID (from `openclaw-agents.json`) goes to its subagent path; everything else goes to the main agent workspace.

This is backwards-compatible — `workspace-main` still works because it never matches a subagent ID.

## Changes

- `agent-source.ts`: Added `subagentIds()` and `mainWorkspaceShellCondition()`
- `local.ts`: Updated 3 copy locations + fixed guard check to detect any workspace-* directory
- `k8s-manifests.ts`: Updated init script
- `kubernetes.ts`: Updated re-deploy init script
- 10 new regression tests

Fixes #62