### PR TITLE
fix(deployers): use find -L to follow symlinks in K8s init scripts

### DIFF
--- a/docs/examples/deployment.yaml
+++ b/docs/examples/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               cp /agents/AGENTS.md /home/node/.openclaw/workspace-alice_myagent/AGENTS.md 2>/dev/null || true
               cp /agents/agent.json /home/node/.openclaw/workspace-alice_myagent/agent.json 2>/dev/null || true
               cp /agents/SOUL.md /home/node/.openclaw/workspace-alice_myagent/SOUL.md 2>/dev/null || true
-              find /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; dest="/home/node/.openclaw/$base"; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \;
+              find -L /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; dest="/home/node/.openclaw/$base"; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \;
               cp -r /skills-src/. /home/node/.openclaw/skills/ 2>/dev/null || true
               cp /cron-src/jobs.json /home/node/.openclaw/cron/jobs.json 2>/dev/null || true
               echo "Config initialized"

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -49,7 +49,7 @@ describe("k8s state sync manifests", () => {
     );
 
     const initContainer = deployment.spec?.template.spec?.initContainers?.[0];
-    expect(initContainer?.command?.[2]).toContain("find /agents-tree -mindepth 1 -type d -name 'workspace-*'");
+    expect(initContainer?.command?.[2]).toContain("find -L /agents-tree -mindepth 1 -type d -name 'workspace-*'");
     expect(initContainer?.command?.[2]).toContain("cp -r /skills-src/. /home/node/.openclaw/skills/");
     expect(initContainer?.command?.[2]).toContain("cp /cron-src/jobs.json /home/node/.openclaw/cron/jobs.json");
 
@@ -91,7 +91,21 @@ describe("workspace routing in init script", () => {
     const initContainer = deployment.spec?.template.spec?.initContainers?.[0];
     const initScript = initContainer?.command?.[2] ?? "";
 
-    expect(initScript).toContain("find /agents-tree -mindepth 1 -type d -name 'workspace-*'");
+    expect(initScript).toContain("find -L /agents-tree -mindepth 1 -type d -name 'workspace-*'");
+  });
+});
+
+// Regression test for #63: find must use -L to follow symlinks on K8s ConfigMap volumes
+describe("symlink traversal in init script", () => {
+  it("uses find -L to follow symlinks in ConfigMap volume projections", () => {
+    const deployment = deploymentManifest("ns", makeConfig());
+    const initContainer = deployment.spec?.template.spec?.initContainers?.[0];
+    const initScript = initContainer?.command?.[2] ?? "";
+
+    // K8s ConfigMap volumes project entries as symlinks through ..data/.
+    // Without -L, find -type d does not match symlinked directories.
+    expect(initScript).toContain("find -L /agents-tree");
+    expect(initScript).not.toMatch(/(?<!\S)find \/agents-tree/);
   });
 });
 

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -300,7 +300,7 @@ mkdir -p /home/node/.openclaw/skills
 mkdir -p /home/node/.openclaw/cron
 mkdir -p /home/node/.openclaw/workspace-${id}
 ${copyLines}
-find /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; ${workspaceRouting}; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \\;
+find -L /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; ${workspaceRouting}; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \\;
 cp -r /skills-src/. /home/node/.openclaw/skills/ 2>/dev/null || true
 cp /cron-src/jobs.json /home/node/.openclaw/cron/jobs.json 2>/dev/null || true
 chown -R 1000:1000 /home/node/.openclaw 2>/dev/null || true

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -595,7 +595,7 @@ mkdir -p /home/node/.openclaw/skills
 mkdir -p /home/node/.openclaw/cron
 mkdir -p /home/node/.openclaw/workspace-${id}
 ${copyLines}
-find /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; ${workspaceRouting}; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \\;
+find -L /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; ${workspaceRouting}; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \\;
 cp -r /skills-src/. /home/node/.openclaw/skills/ 2>/dev/null || true
 cp /cron-src/jobs.json /home/node/.openclaw/cron/jobs.json 2>/dev/null || true
 chgrp -R 0 /home/node/.openclaw 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Fix `find` command in K8s init scripts to follow symlinks (`find -L`) so ConfigMap-projected workspace directories are correctly traversed
- Add regression test to prevent recurrence
- Update example deployment docs

Fixes #63

## Root Cause

Kubernetes ConfigMap volume projections create directory entries as symlinks through a `..data` directory. The `find` command used `-type d` without `-L`, so it never matched the symlinked workspace directories. All subagent workspaces ended up empty on K8s/OpenShift.

## Changes

| File | Change |
|------|--------|
| `src/server/deployers/k8s-manifests.ts` | `find` → `find -L` in init script |
| `src/server/deployers/kubernetes.ts` | `find` → `find -L` in re-deploy init script |
| `docs/examples/deployment.yaml` | `find` → `find -L` in example |
| `src/server/deployers/__tests__/k8s-manifests.test.ts` | Updated assertions + new regression test |

## Test plan

- [x] Regression test verifies `find -L` is used in the generated init script
- [x] Full test suite passes (200/200)
- [ ] Manual verification on a K8s cluster with a multi-agent source bundle
