### PR TITLE
fix(ui): auto-include K8s instances when cluster is reachable

### DIFF
--- a/adr/0004-auto-k8s-instance-discovery.md
+++ b/adr/0004-auto-k8s-instance-discovery.md
@@ -1,0 +1,55 @@
+# ADR 0004: Automatic K8s Instance Discovery
+
+## Status
+
+Proposed
+
+## Context
+
+The Instances tab in the installer UI has an "Include K8s" toggle that defaults to `false`. When a user deploys an agent to Kubernetes or OpenShift, the deployed instance does not appear in the Instances tab until the user manually clicks this toggle. The toggle state is not persisted across page reloads.
+
+This creates a confusing user experience: a deployment succeeds, but the instance appears to be missing. Users must know to click the toggle — a discovery problem that is especially acute for new users.
+
+### History
+
+The toggle was part of the original code imported from the upstream `claw-installer` repository. It was never introduced via a reviewed PR, so there is no recorded design rationale. Commit `652d9d1` (deployer plugin system) fixed the default to `true`, but commit `e9771ce` (bulk sync from upstream) reverted it to `false`.
+
+### Why the toggle existed
+
+The `includeK8s` query parameter on `/api/instances` gates calls to the Kubernetes API (`discoverK8sInstances`). When no cluster is connected, these calls fail or time out, slowing down the instance list. The toggle gave users a way to skip these calls.
+
+However, the `/api/health` endpoint already reports `k8sAvailable`, which indicates whether a cluster is reachable. This makes the manual toggle redundant — the system already knows whether K8s API calls will succeed.
+
+## Decision
+
+Remove the "Include K8s" toggle and auto-include Kubernetes/OpenShift instances whenever the cluster is reachable.
+
+### Behavior
+
+- On mount, the `InstanceList` component fetches `/api/health` to determine `k8sAvailable`.
+- If `k8sAvailable` is `true`, all subsequent instance fetches include `?includeK8s=1`.
+- If `k8sAvailable` is `false` (no cluster, or health check fails), instance fetches omit the parameter, and no K8s API calls are made server-side.
+- There is no manual toggle. The decision is fully automated.
+
+### Edge cases considered
+
+**Slow clusters:** If the cluster is reachable but API calls are slow, the 5-second polling interval means the UI remains responsive — each poll is independent, and slow responses from one poll don't block the next. The server-side `isClusterReachable()` check at `status.ts:202` provides an additional guard.
+
+**Cluster becomes unreachable after health check:** The health check runs once on mount. If the cluster goes down after that, `k8sAvailable` remains `true`, but the server's `isClusterReachable()` call will fail gracefully (the `catch` block at `status.ts:240` ensures local instances are still returned). A page reload re-runs the health check and corrects the state.
+
+**Mixed local + K8s usage:** Both local and K8s instances appear in the same list, differentiated by badges. No filtering is needed — users benefit from seeing all instances in one view.
+
+**No cluster connected:** When `k8sAvailable` is `false`, the behavior is identical to before: only local instances are shown, and no K8s API calls are made.
+
+## Consequences
+
+### Positive
+
+- Deployed K8s/OpenShift instances are immediately visible without manual intervention.
+- One less UI control to understand and maintain.
+- The performance optimization (skipping K8s API calls when no cluster exists) is preserved automatically.
+
+### Negative
+
+- Users can no longer manually hide K8s instances. If this is needed in the future, it should be implemented as a filter/view option rather than a toggle that gates API calls.
+- The first fetch on page load always uses `k8sAvailable = false` (the default before the health check returns), so there is a brief moment where only local instances are shown. This is identical to the previous behavior.

--- a/adr/README.md
+++ b/adr/README.md
@@ -8,3 +8,4 @@ This directory contains architecture decision records for `openclaw-installer`.
 | --- | --- | --- | --- |
 | [0001](./0001-deployer-plugin-system.md) | Accepted | Deployer Plugin System | Adds the core/provider deployer plugin architecture and runtime plugin loading model. |
 | [0002](./0002-agent-security-surface.md) | Proposed | Agent Security Surface | Establishes `Agent Security` as the installer UX surface for SecretRefs now and future hardening later. |
+| [0004](./0004-auto-k8s-instance-discovery.md) | Proposed | Automatic K8s Instance Discovery | Removes the manual "Include K8s" toggle; auto-includes cluster instances when k8sAvailable is true. |

--- a/src/client/components/InstanceList.tsx
+++ b/src/client/components/InstanceList.tsx
@@ -103,7 +103,6 @@ export default function InstanceList({ active }: { active: boolean }) {
   const [instances, setInstances] = useState<Instance[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [includeK8s, setIncludeK8s] = useState(false);
   const [k8sAvailable, setK8sAvailable] = useState(false);
   const [acting, setActing] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Record<string, ExpandedPanel>>({});
@@ -111,7 +110,8 @@ export default function InstanceList({ active }: { active: boolean }) {
 
   const fetchInstances = async () => {
     try {
-      const res = await fetch(includeK8s ? "/api/instances?includeK8s=1" : "/api/instances");
+      // Fix for #61: auto-include K8s instances when cluster is reachable
+      const res = await fetch(k8sAvailable ? "/api/instances?includeK8s=1" : "/api/instances");
       if (!res.ok) {
         throw new Error(`Failed to load instances (${res.status})`);
       }
@@ -134,22 +134,15 @@ export default function InstanceList({ active }: { active: boolean }) {
       })
       .catch(() => {
         setK8sAvailable(false);
-        setIncludeK8s(false);
       });
   }, []);
-
-  useEffect(() => {
-    if (!k8sAvailable && includeK8s) {
-      setIncludeK8s(false);
-    }
-  }, [k8sAvailable, includeK8s]);
 
   useEffect(() => {
     setLoading(true);
     fetchInstances();
     const interval = setInterval(fetchInstances, 5000);
     return () => clearInterval(interval);
-  }, [includeK8s]);
+  }, [k8sAvailable]);
 
   // Fix for #5: fetch immediately when the Instances tab becomes visible
   useEffect(() => {
@@ -157,12 +150,6 @@ export default function InstanceList({ active }: { active: boolean }) {
       fetchInstances();
     }
   }, [active]);
-
-  const k8sToggle = k8sAvailable ? (
-    <button className="btn btn-ghost" onClick={() => setIncludeK8s((prev) => !prev)}>
-      {includeK8s ? "Hide K8s" : "Include K8s"}
-    </button>
-  ) : null;
 
   const handleStart = async (id: string) => {
     setActing(id);
@@ -255,9 +242,6 @@ export default function InstanceList({ active }: { active: boolean }) {
   if (loading) {
     return (
       <div className="card">
-        <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "0.75rem" }}>
-          {k8sToggle}
-        </div>
         Loading...
       </div>
     );
@@ -266,9 +250,6 @@ export default function InstanceList({ active }: { active: boolean }) {
   if (error) {
     return (
       <div className="card">
-        <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "0.75rem" }}>
-          {k8sToggle}
-        </div>
         <strong>Could not load instances.</strong>
         <div style={{ marginTop: "0.5rem", color: "var(--text-secondary)", fontSize: "0.9rem" }}>
           {error}
@@ -280,9 +261,6 @@ export default function InstanceList({ active }: { active: boolean }) {
   if (instances.length === 0) {
     return (
       <div className="card">
-        <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "0.75rem" }}>
-          {k8sToggle}
-        </div>
         <div className="empty-state">
           <div className="empty-icon">📦</div>
           <p>No OpenClaw instances found</p>
@@ -297,9 +275,6 @@ export default function InstanceList({ active }: { active: boolean }) {
 
   return (
     <div className="card" style={{ padding: 0 }}>
-      <div style={{ display: "flex", justifyContent: "flex-end", padding: "1rem 1rem 0" }}>
-        {k8sToggle}
-      </div>
       {instances.map((inst) => {
         const isActing = acting === inst.id;
         const activePanel = expanded[inst.id];

--- a/src/client/components/__tests__/InstanceList.test.tsx
+++ b/src/client/components/__tests__/InstanceList.test.tsx
@@ -381,8 +381,7 @@ describe("InstanceList", () => {
     });
   });
 
-  it("lets the user opt into cluster instances when k8s is available", async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  it("auto-includes cluster instances when k8s is available (fix for #61)", async () => {
     const fetchMock = vi.fn((url: string, opts?: RequestInit) => {
       if (url === "/api/health") {
         return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ k8sAvailable: true }) });
@@ -396,18 +395,9 @@ describe("InstanceList", () => {
 
     render(<InstanceList active />);
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /include k8s/i })).toBeInTheDocument();
-    });
-    expect(fetchMock).toHaveBeenCalledWith("/api/instances");
-
-    await user.click(screen.getByRole("button", { name: /include k8s/i }));
-    await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/instances?includeK8s=1");
     });
-
-    await user.click(screen.getByRole("button", { name: /hide k8s/i }));
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith("/api/instances");
-    });
+    // Toggle button should no longer exist
+    expect(screen.queryByRole("button", { name: /include k8s/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Removes the "Include K8s" toggle from the Instances tab
- Auto-includes K8s/OpenShift instances when the cluster is reachable (`k8sAvailable` from `/api/health`)
- Adds ADR 0004 documenting the design decision
- Updates regression test to verify auto-inclusion behavior

Fixes #61

## Root Cause

`InstanceList.tsx` initialized `includeK8s` to `false` and required a manual toggle click to show K8s instances. The health check already fetched `k8sAvailable` but never used it to auto-enable K8s discovery.

## Changes

- **`src/client/components/InstanceList.tsx`**: Removed `includeK8s` state, toggle button, and guard effect. `k8sAvailable` now directly drives whether `/api/instances?includeK8s=1` is fetched.
- **`src/client/components/__tests__/InstanceList.test.tsx`**: Updated toggle test to verify auto-inclusion and confirm toggle button is removed.
- **`adr/0004-auto-k8s-instance-discovery.md`**: New ADR documenting the decision, edge cases, and consequences.
- **`adr/README.md`**: Added ADR 0004 to the index.

## Test Plan

- [x] Updated regression test verifies auto-inclusion when `k8sAvailable: true`
- [x] Updated test confirms toggle button no longer renders
- [x] Full test suite passes (200/200 tests, 23 files)
- [x] ESLint clean on modified files
- [x] Manual: deploy to OpenShift, verify instance appears without toggling
