### PR TITLE
fix(deployer): add deploy-time model as fallback for bundle subagents

### DIFF
--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildOpenClawConfig,
   deriveModel,
+  detectUnavailableProvider,
   namespaceName,
   normalizeModelRef,
+  resolveSubagentModel,
   sanitizeForRfc1123,
   usesDefaultEnvSecretRef,
 } from "../k8s-helpers.js";
@@ -469,5 +471,102 @@ describe("namespaceName", () => {
   it("falls back to 'agent' when agent name sanitizes to empty", () => {
     const config = makeConfig({ agentName: "___", prefix: "user" });
     expect(namespaceName(config)).toBe("user-agent-openclaw");
+  });
+});
+
+// Regression tests for #67: subagent model fallback
+describe("resolveSubagentModel", () => {
+  it("uses deploy-time model when bundle entry has no model", () => {
+    expect(resolveSubagentModel(undefined, "anthropic/claude-sonnet-4-6")).toEqual({
+      primary: "anthropic/claude-sonnet-4-6",
+    });
+  });
+
+  it("uses deploy-time model when bundle entry has empty model", () => {
+    expect(resolveSubagentModel({}, "anthropic/claude-sonnet-4-6")).toEqual({
+      primary: "anthropic/claude-sonnet-4-6",
+    });
+  });
+
+  it("appends deploy-time model as fallback when bundle declares a different model", () => {
+    expect(resolveSubagentModel(
+      { primary: "openai/gpt-5.4" },
+      "anthropic/claude-sonnet-4-6",
+    )).toEqual({
+      primary: "openai/gpt-5.4",
+      fallbacks: ["anthropic/claude-sonnet-4-6"],
+    });
+  });
+
+  it("appends deploy-time model after existing bundle fallbacks", () => {
+    expect(resolveSubagentModel(
+      { primary: "openai/gpt-5.4", fallbacks: ["openai/gpt-5.4-mini"] },
+      "anthropic-vertex/claude-sonnet-4-6",
+    )).toEqual({
+      primary: "openai/gpt-5.4",
+      fallbacks: ["openai/gpt-5.4-mini", "anthropic-vertex/claude-sonnet-4-6"],
+    });
+  });
+
+  it("does not duplicate deploy-time model when it matches the primary", () => {
+    expect(resolveSubagentModel(
+      { primary: "anthropic/claude-sonnet-4-6" },
+      "anthropic/claude-sonnet-4-6",
+    )).toEqual({
+      primary: "anthropic/claude-sonnet-4-6",
+    });
+  });
+
+  it("does not duplicate deploy-time model when it is already a fallback", () => {
+    expect(resolveSubagentModel(
+      { primary: "anthropic/claude-sonnet-4-6", fallbacks: ["openai/gpt-5.4"] },
+      "openai/gpt-5.4",
+    )).toEqual({
+      primary: "anthropic/claude-sonnet-4-6",
+      fallbacks: ["openai/gpt-5.4"],
+    });
+  });
+});
+
+describe("detectUnavailableProvider", () => {
+  it("detects missing OpenAI provider", () => {
+    const config = makeConfig({ inferenceProvider: "anthropic", anthropicApiKey: "sk-ant" });
+    expect(detectUnavailableProvider("openai/gpt-5.4", config)).toBe(true);
+  });
+
+  it("detects missing Anthropic provider", () => {
+    const config = makeConfig({ inferenceProvider: "openai", openaiApiKey: "sk-oai" });
+    expect(detectUnavailableProvider("anthropic/claude-sonnet-4-6", config)).toBe(true);
+  });
+
+  it("returns false when OpenAI key is configured", () => {
+    const config = makeConfig({ openaiApiKey: "sk-oai" });
+    expect(detectUnavailableProvider("openai/gpt-5.4", config)).toBe(false);
+  });
+
+  it("returns false when Anthropic key is configured", () => {
+    const config = makeConfig({ anthropicApiKey: "sk-ant" });
+    expect(detectUnavailableProvider("anthropic/claude-sonnet-4-6", config)).toBe(false);
+  });
+
+  it("returns false when inference provider matches", () => {
+    const config = makeConfig({ inferenceProvider: "openai" });
+    expect(detectUnavailableProvider("openai/gpt-5.4", config)).toBe(false);
+  });
+
+  it("detects missing vertex-anthropic provider", () => {
+    const config = makeConfig({ inferenceProvider: "openai" });
+    expect(detectUnavailableProvider("anthropic-vertex/claude-sonnet-4-6", config)).toBe(true);
+  });
+
+  it("returns false when vertex-anthropic is configured", () => {
+    const config = makeConfig({ vertexEnabled: true, vertexProvider: "anthropic" });
+    expect(detectUnavailableProvider("anthropic-vertex/claude-sonnet-4-6", config)).toBe(false);
+  });
+
+  it("returns false for unknown provider prefixes", () => {
+    const config = makeConfig({});
+    expect(detectUnavailableProvider("litellm/my-model", config)).toBe(false);
+    expect(detectUnavailableProvider("custom/model", config)).toBe(false);
   });
 });

--- a/src/server/deployers/agent-source.ts
+++ b/src/server/deployers/agent-source.ts
@@ -8,7 +8,7 @@ export interface AgentSourceAgentEntry {
   id: string;
   name?: string;
   workspaceDir?: string;
-  model?: { primary?: string };
+  model?: { primary?: string; fallbacks?: string[] };
   tools?: Record<string, unknown>;
   subagents?: { allowAgents?: string[] };
 }

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -183,6 +183,61 @@ export function deriveModel(config: DeployConfig): string {
   return "anthropic/claude-sonnet-4-6";
 }
 
+/**
+ * Resolve the model config for a bundle subagent.  The bundle's declared model
+ * takes precedence, but the deploy-time model is appended as a fallback so
+ * there is always a working option even when the bundle's preferred provider
+ * isn't configured.  (Fix for #67)
+ */
+export function resolveSubagentModel(
+  entryModel: { primary?: string; fallbacks?: string[] } | undefined,
+  deployModel: string,
+): { primary: string; fallbacks?: string[] } {
+  if (!entryModel?.primary) {
+    return { primary: deployModel };
+  }
+
+  const fallbacks = [...(entryModel.fallbacks || [])];
+
+  if (entryModel.primary !== deployModel && !fallbacks.includes(deployModel)) {
+    fallbacks.push(deployModel);
+  }
+
+  return fallbacks.length > 0
+    ? { primary: entryModel.primary, fallbacks }
+    : { primary: entryModel.primary };
+}
+
+/**
+ * Check whether a model ref's provider appears to be unavailable given the
+ * current deploy config.  Returns true when the provider likely won't work,
+ * used to emit deploy-time warnings.  (Fix for #67)
+ */
+export function detectUnavailableProvider(
+  modelRef: string,
+  config: DeployConfig,
+): boolean {
+  const provider = modelRef.split("/")[0];
+  if (!provider) return false;
+
+  switch (provider) {
+    case "anthropic":
+      return !config.anthropicApiKey && !config.anthropicApiKeyRef
+        && config.inferenceProvider !== "anthropic";
+    case "openai":
+      return !config.openaiApiKey && !config.openaiApiKeyRef
+        && config.inferenceProvider !== "openai";
+    case "anthropic-vertex":
+      return !config.vertexEnabled
+        || (config.vertexProvider !== "anthropic" && config.inferenceProvider !== "vertex-anthropic");
+    case "google-vertex":
+      return !config.vertexEnabled
+        || (config.vertexProvider !== "google" && config.inferenceProvider !== "vertex-google");
+    default:
+      return false;
+  }
+}
+
 function subagentConfig(policy?: string): { allowAgents: string[] } {
   switch (policy) {
     case "self": return { allowAgents: ["self"] };
@@ -374,12 +429,13 @@ export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string):
           subagents: sourceBundle?.mainAgent?.subagents || subagentConfig(config.subagentPolicy),
           ...(sourceBundle?.mainAgent?.tools ? { tools: sourceBundle.mainAgent.tools } : {}),
         },
+        // Fix for #67: append deploy-time model as fallback for bundle subagents
         ...((sourceBundle?.agents || []).map((entry) => ({
           id: entry.id,
           name: entry.name || entry.id,
           ...(entry.name ? { identity: { name: entry.name } } : {}),
           workspace: `~/.openclaw/workspace-${entry.id}`,
-          model: entry.model || { primary: model },
+          model: resolveSubagentModel(entry.model, model),
           ...(entry.subagents ? { subagents: entry.subagents } : {}),
           ...(entry.tools ? { tools: entry.tools } : {}),
         }))),

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -13,7 +13,7 @@ import type {
   DeployResult,
   LogCallback,
 } from "./types.js";
-import { namespaceName, agentId, generateToken, usesDefaultEnvSecretRef } from "./k8s-helpers.js";
+import { namespaceName, agentId, deriveModel, detectUnavailableProvider, generateToken, usesDefaultEnvSecretRef } from "./k8s-helpers.js";
 import { loadWorkspaceFiles } from "./k8s-agent.js";
 import { loadAgentSourceBundle, loadAgentSourceCronJobs, loadAgentSourceWorkspaceTree, mainWorkspaceShellCondition } from "./agent-source.js";
 import {
@@ -229,6 +229,17 @@ export class KubernetesDeployer implements Deployer {
       "ConfigMap openclaw-config",
       log,
     );
+
+    // Fix for #67: warn when bundle subagent models reference unavailable providers
+    const sourceBundle = loadAgentSourceBundle(config);
+    if (sourceBundle?.agents) {
+      const deployModel = deriveModel(config);
+      for (const entry of sourceBundle.agents) {
+        if (entry.model?.primary && detectUnavailableProvider(entry.model.primary, config)) {
+          log(`WARNING: Subagent "${entry.id}" prefers model "${entry.model.primary}" but that provider does not appear to be configured. The deploy-time model "${deployModel}" has been added as a fallback.`);
+        }
+      }
+    }
 
     // 4. ConfigMap (agent workspace files)
     const agentCm = agentConfigMapManifest(ns, config, workspaceFiles);

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -37,8 +37,10 @@ import { agentWorkspaceDir, installerLocalInstanceDir, openclawHomeDir } from ".
 import {
   buildConfiguredAgentModelCatalog,
   CUSTOM_ENDPOINT_PROVIDER,
+  detectUnavailableProvider,
   generateToken,
   normalizeModelRef,
+  resolveSubagentModel,
   usesDefaultEnvSecretRef,
 } from "./k8s-helpers.js";
 import { buildSandboxConfig } from "./sandbox.js";
@@ -481,12 +483,13 @@ function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string
           subagents: sourceBundle?.mainAgent?.subagents || subagentConfig(config.subagentPolicy),
           ...(sourceBundle?.mainAgent?.tools ? { tools: sourceBundle.mainAgent.tools } : {}),
         },
+        // Fix for #67: append deploy-time model as fallback for bundle subagents
         ...((sourceBundle?.agents || []).map((entry) => ({
           id: entry.id,
           name: entry.name || entry.id,
           ...(entry.name ? { identity: { name: entry.name } } : {}),
           workspace: `~/.openclaw/workspace-${entry.id}`,
-          model: entry.model || { primary: model },
+          model: resolveSubagentModel(entry.model, model),
           ...(entry.subagents ? { subagents: entry.subagents } : {}),
           ...(entry.tools ? { tools: entry.tools } : {}),
         }))),
@@ -885,6 +888,17 @@ export class LocalDeployer implements Deployer {
     const gatewayToken = generateToken();
     const localSandboxPrepared = prepareLocalSandboxSshConfig(config);
     const ocConfig = buildOpenClawConfig(localSandboxPrepared.effectiveConfig, gatewayToken);
+
+    // Fix for #67: warn when bundle subagent models reference unavailable providers
+    if (sourceBundle?.agents) {
+      const deployModel = deriveModel(localSandboxPrepared.effectiveConfig);
+      for (const entry of sourceBundle.agents) {
+        if (entry.model?.primary && detectUnavailableProvider(entry.model.primary, localSandboxPrepared.effectiveConfig)) {
+          log(`WARNING: Subagent "${entry.id}" prefers model "${entry.model.primary}" but that provider does not appear to be configured. The deploy-time model "${deployModel}" has been added as a fallback.`);
+        }
+      }
+    }
+
     const agentsMd = buildDefaultAgentsMd(config);
     const agentJson = buildAgentJson(config);
 


### PR DESCRIPTION
When a demo bundle declares per-subagent models with provider-specific prefixes (e.g., openai/gpt-5.4), those models are passed through verbatim. If the deployer only has a different provider configured (e.g., Vertex AI), subagents fail at runtime with auth errors.

The deploy-time model is now appended as a fallback for every bundle subagent that declares its own model. The bundle's preferred models still take precedence, but there is always a working option. A deploy-time warning is also emitted when a subagent's preferred provider does not appear to be configured.

Also fixes AgentSourceAgentEntry type to include the fallbacks field that demo bundles already use.

Fixes #67