### PR TITLE
redesign: replace inference provider UI with dynamic card-based design

### DIFF
--- a/src/client/components/__tests__/DeployForm.test.tsx
+++ b/src/client/components/__tests__/DeployForm.test.tsx
@@ -225,11 +225,25 @@ describe("DeployForm agent name validation (issue #7)", () => {
 
     await screen.findAllByRole("button", { name: /deploy openclaw/i });
 
-    fireEvent.click(screen.getByText("Additional Providers & Fallbacks"));
-
-    expect(await screen.findByText("OpenAI API Key")).toBeTruthy();
+    // Verify the primary card shows anthropic fields by default
+    expect(screen.getByText("Anthropic API Key")).toBeTruthy();
     expect(screen.getByText("Anthropic Model")).toBeTruthy();
+
+    // Check that add provider button exists
+    const addBtn = screen.getByRole("button", { name: /Add Provider/i });
+    expect(addBtn).toBeTruthy();
+
+    // Switch primary to openai to verify provider-specific fields change
+    // The primary provider select is the one with value="anthropic"
+    const primarySelect = screen.getByDisplayValue("Anthropic");
+    fireEvent.change(primarySelect, { target: { value: "openai" } });
+
+    expect(screen.getByText("OpenAI API Key")).toBeTruthy();
     expect(screen.getByText("OpenAI Model")).toBeTruthy();
+
+    // Switch primary to custom-endpoint
+    fireEvent.change(primarySelect, { target: { value: "custom-endpoint" } });
+
     expect(screen.getByText("OpenAI-Compatible Model Endpoint")).toBeTruthy();
     expect(screen.getByText("OpenAI-Compatible Model Name")).toBeTruthy();
     expect(screen.getByText("OpenAI-Compatible Endpoint API Key (`MODEL_ENDPOINT_API_KEY`)")).toBeTruthy();
@@ -280,16 +294,25 @@ describe("DeployForm agent name validation (issue #7)", () => {
     await screen.findAllByRole("button", { name: /deploy openclaw/i });
 
     fireEvent.change(screen.getAllByPlaceholderText("e.g., lynx")[0], { target: { value: "lynx" } });
+
+    // Primary is anthropic — fill its fields
     fireEvent.change(screen.getByPlaceholderText("sk-ant-..."), { target: { value: "sk-ant-demo" } });
-    fireEvent.change(screen.getByPlaceholderText("sk-..."), { target: { value: "sk-openai-demo" } });
     fireEvent.change(
       screen.getByPlaceholderText("e.g., claude-sonnet-4-6"),
       { target: { value: "claude-sonnet-4-6" } },
     );
+
+    // Switch primary to openai, fill its fields, then switch back
+    const primarySelect = screen.getByDisplayValue("Anthropic");
+    fireEvent.change(primarySelect, { target: { value: "openai" } });
+    fireEvent.change(screen.getByPlaceholderText("sk-..."), { target: { value: "sk-openai-demo" } });
     fireEvent.change(
       screen.getByPlaceholderText("e.g., gpt-5"),
       { target: { value: "gpt-5" } },
     );
+
+    // Switch primary to custom-endpoint, fill its fields, then switch back
+    fireEvent.change(screen.getByDisplayValue("OpenAI"), { target: { value: "custom-endpoint" } });
     fireEvent.change(
       screen.getByPlaceholderText("http://vllm.openclaw-llms.svc.cluster.local/v1"),
       { target: { value: "http://localhost:8000/v1" } },
@@ -302,6 +325,9 @@ describe("DeployForm agent name validation (issue #7)", () => {
       screen.getByPlaceholderText("API key for the OpenAI-compatible endpoint"),
       { target: { value: "endpoint-token" } },
     );
+
+    // Switch back to anthropic as primary
+    fireEvent.change(screen.getByDisplayValue("Model Endpoint"), { target: { value: "anthropic" } });
 
     fireEvent.click(screen.getAllByRole("button", { name: /deploy openclaw/i }).at(-1)!);
 
@@ -502,6 +528,10 @@ describe("DeployForm agent name validation (issue #7)", () => {
     await screen.findAllByRole("button", { name: /deploy openclaw/i });
 
     fireEvent.change(screen.getAllByPlaceholderText("e.g., lynx")[0], { target: { value: "lynx" } });
+
+    // Switch primary to custom-endpoint to access endpoint fields
+    fireEvent.change(screen.getByDisplayValue("Anthropic"), { target: { value: "custom-endpoint" } });
+
     fireEvent.change(
       screen.getByPlaceholderText("http://vllm.openclaw-llms.svc.cluster.local/v1"),
       { target: { value: "https://example.com/v1" } },
@@ -574,6 +604,9 @@ describe("DeployForm agent name validation (issue #7)", () => {
     render(<DeployForm onDeployStarted={() => {}} />);
 
     await screen.findAllByRole("button", { name: /deploy openclaw/i });
+
+    // Switch primary to custom-endpoint to access endpoint fields
+    fireEvent.change(screen.getByDisplayValue("Anthropic"), { target: { value: "custom-endpoint" } });
 
     const endpointInput = screen.getByPlaceholderText("http://vllm.openclaw-llms.svc.cluster.local/v1");
     fireEvent.change(endpointInput, { target: { value: "https://example.com/v1" } });

--- a/src/client/components/deploy-form/ProviderSection.tsx
+++ b/src/client/components/deploy-form/ProviderSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import {
   MODEL_DEFAULTS,
@@ -30,6 +30,19 @@ interface ProviderSectionProps {
   update: (field: string, value: string) => void;
 }
 
+interface AdditionalProvider {
+  id: number;
+  provider: InferenceProvider | "";
+}
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "var(--text-secondary)",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+  marginBottom: "0.5rem",
+};
+
 export function ProviderSection({
   config,
   defaults,
@@ -45,405 +58,501 @@ export function ProviderSection({
   setInferenceProvider,
   update,
 }: ProviderSectionProps) {
-  return (
-    <>
-      <h3 style={{ marginTop: "1.5rem" }}>Inference Provider</h3>
+  const [additionalProviders, setAdditionalProviders] = useState<AdditionalProvider[]>([]);
+  const nextId = useRef(0);
 
-      <div className="form-group">
-        <label>Primary Provider</label>
-        <select
-          value={inferenceProvider}
-          onChange={(e) => {
-            setInferenceProvider(e.target.value as InferenceProvider);
-            update("agentModel", "");
-          }}
-        >
-          {PROVIDER_OPTIONS.map((p) => (
-            <option key={p.id} value={p.id}>{p.label}</option>
-          ))}
-        </select>
-        <div className="hint">
-          {PROVIDER_OPTIONS.find((p) => p.id === inferenceProvider)?.desc}. This controls the default primary route for the deployment.
-        </div>
-      </div>
+  const selectedAdditionalProviders = additionalProviders
+    .map((ap) => ap.provider)
+    .filter((p): p is InferenceProvider => p !== "");
 
-      <div className="form-group" style={{ marginTop: "0.75rem" }}>
-        <label>Primary Model</label>
-        <input
-          type="text"
-          placeholder={
-            isVertex && config.litellmProxy
-              ? (inferenceProvider === "vertex-anthropic" ? "claude-sonnet-4-6" : "gemini-2.5-pro")
-              : (MODEL_DEFAULTS[inferenceProvider] || "model-id")
-          }
-          value={config.agentModel}
-          onChange={(e) => update("agentModel", e.target.value)}
-        />
-        <div className="hint">
-          {config.agentModel
-            ? "Custom primary model override"
-            : isVertex && config.litellmProxy
-              ? `Leave blank for default (routed through LiteLLM proxy). ${PROXY_MODEL_HINTS[inferenceProvider] || MODEL_HINTS[inferenceProvider]}`
-              : `Leave blank for default${MODEL_DEFAULTS[inferenceProvider] ? ` (${MODEL_DEFAULTS[inferenceProvider]})` : ""}. ${MODEL_HINTS[inferenceProvider]}`}
-        </div>
-      </div>
+  const allUsedProviders = [inferenceProvider, ...selectedAdditionalProviders];
 
-      <div className="form-group" style={{ marginTop: "0.75rem" }}>
-        <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-          <input
-            type="checkbox"
-            checked={config.openaiCompatibleEndpointsEnabled}
-            onChange={(e) =>
-              setConfig((prev) => ({ ...prev, openaiCompatibleEndpointsEnabled: e.target.checked }))
-            }
-            style={{ width: "auto" }}
-          />
-          Enable OpenAI-compatible API endpoints
-        </label>
-        <div className="hint">
-          Exposes <code>/v1/chat/completions</code>, <code>/v1/responses</code>, and <code>/v1/models</code> for OpenAI-compatible clients. Disable this to remove those endpoints from the gateway.
-        </div>
-      </div>
+  const allAdded = additionalProviders.length >= PROVIDER_OPTIONS.length - 1;
 
-      <details style={{ marginTop: "0.75rem" }}>
-        <summary style={{ cursor: "pointer", fontWeight: 600 }}>
-          Additional Providers & Fallbacks
-          <span style={{ color: "var(--text-secondary)", fontWeight: "normal" }}>
-            {" "}Additional credentials and endpoint settings
-          </span>
-        </summary>
+  function addProvider() {
+    setAdditionalProviders((prev) => [
+      ...prev,
+      { id: nextId.current++, provider: "" },
+    ]);
+  }
 
-        <div className="card" style={{ marginTop: "0.75rem" }}>
-          <div className="hint" style={{ marginBottom: "0.75rem" }}>
-            The selected primary provider and model above control the default route. The settings below are saved independently so Anthropic, OpenAI, and OpenAI-compatible endpoints can also be used for fallbacks.
-          </div>
-          <div className="hint" style={{ marginBottom: "0.75rem" }}>
-            Configure these independently when you want one deployment to have:
-            {" "}Anthropic (<code>ANTHROPIC_API_KEY</code>),
-            {" "}OpenAI (<code>OPENAI_API_KEY</code>), and
-            {" "}an OpenAI-compatible endpoint with its own token (<code>MODEL_ENDPOINT</code> + <code>MODEL_ENDPOINT_API_KEY</code>).
-          </div>
-          <div className="form-group">
-            <label>Anthropic API Key</label>
-            <input
-              type="password"
-              autoComplete="new-password"
-              placeholder={defaults?.hasAnthropicKey ? "(using key from environment)" : "sk-ant-..."}
-              value={config.anthropicApiKey}
-              onChange={(e) => update("anthropicApiKey", e.target.value)}
-            />
-            <div className="hint">
-              {defaults?.hasAnthropicKey
-                ? "Detected ANTHROPIC_API_KEY from server environment — leave blank to use it"
-                : "Saved for Anthropic primary or fallback usage."}
-            </div>
-          </div>
-          <div className="form-group">
-            <label>Anthropic Model</label>
-            <input
-              type="text"
-              placeholder="e.g., claude-sonnet-4-6"
-              value={config.anthropicModel}
-              onChange={(e) => update("anthropicModel", e.target.value)}
-            />
-            <div className="hint">
-              Adds this Anthropic model to the OpenClaw model picker as <code>anthropic/&lt;model&gt;</code>.
-            </div>
-          </div>
+  function removeProvider(id: number) {
+    setAdditionalProviders((prev) => prev.filter((ap) => ap.id !== id));
+  }
 
-          <div className="form-group">
-            <label>OpenAI API Key</label>
-            <input
-              type="password"
-              autoComplete="new-password"
-              placeholder={defaults?.hasOpenaiKey ? "(using key from environment)" : "sk-..."}
-              value={config.openaiApiKey}
-              onChange={(e) => update("openaiApiKey", e.target.value)}
-            />
-            <div className="hint">
-              {defaults?.hasOpenaiKey
-                ? "Detected OPENAI_API_KEY from server environment — leave blank to use it"
-                : "Saved for OpenAI primary or fallback usage only."}
-            </div>
-          </div>
-          <div className="form-group">
-            <label>OpenAI Model</label>
-            <input
-              type="text"
-              placeholder="e.g., gpt-5"
-              value={config.openaiModel}
-              onChange={(e) => update("openaiModel", e.target.value)}
-            />
-            <div className="hint">
-              Adds this OpenAI model to the OpenClaw model picker as <code>openai/&lt;model&gt;</code>.
-            </div>
-          </div>
+  function setProviderValue(id: number, provider: InferenceProvider | "") {
+    setAdditionalProviders((prev) =>
+      prev.map((ap) => (ap.id === id ? { ...ap, provider } : ap)),
+    );
+  }
 
-          {isVertex && (
-            <>
-              {inferenceProvider === "vertex-google"
-                && gcpDefaults?.credentialType === "authorized_user"
-                && !config.gcpServiceAccountJson && (
-                <div style={{
-                  marginBottom: "1rem",
-                  padding: "0.5rem 0.75rem",
-                  background: "rgba(231, 76, 60, 0.1)",
-                  border: "1px solid rgba(231, 76, 60, 0.3)",
-                  borderRadius: "6px",
-                  fontSize: "0.85rem",
-                  color: "#e74c3c",
-                }}>
-                  Your environment credentials are Application Default Credentials (from <code>gcloud auth</code>),
-                  which are not supported by Gemini on Vertex. Either upload a Service Account JSON below,
-                  or switch to Google Vertex AI (Claude) which works with Application Default Credentials.
-                </div>
-              )}
+  function renderProviderFields(provider: InferenceProvider | "") {
+    if (!provider) return null;
 
-              <div className="form-row">
-                <div className="form-group">
-                  <label>GCP Project ID</label>
-                  <input
-                    type="text"
-                    placeholder="my-gcp-project"
-                    value={config.googleCloudProject}
-                    onChange={(e) => update("googleCloudProject", e.target.value)}
-                  />
-                  {gcpDefaults?.sources.projectId && config.googleCloudProject === gcpDefaults.projectId ? (
-                    <div className="hint">from {gcpDefaults.sources.projectId}</div>
-                  ) : !config.googleCloudProject && (
-                    <div className="hint">Auto-extracted from credentials JSON if not set</div>
-                  )}
-                </div>
-                <div className="form-group">
-                  <label>GCP Region</label>
-                  <input
-                    type="text"
-                    placeholder={inferenceProvider === "vertex-anthropic" ? "us-east5 (default)" : "us-central1 (default)"}
-                    value={config.googleCloudLocation}
-                    onChange={(e) => update("googleCloudLocation", e.target.value)}
-                  />
-                  {gcpDefaults?.sources.location && config.googleCloudLocation === gcpDefaults.location ? (
-                    <div className="hint">from {gcpDefaults.sources.location}</div>
-                  ) : !config.googleCloudLocation && (
-                    <div className="hint">
-                      Defaults to {inferenceProvider === "vertex-anthropic" ? "us-east5" : "us-central1"} if not set
-                    </div>
-                  )}
-                </div>
+    switch (provider) {
+      case "anthropic":
+        return (
+          <>
+            <div className="form-group">
+              <label>Anthropic API Key</label>
+              <input
+                type="password"
+                autoComplete="new-password"
+                placeholder={defaults?.hasAnthropicKey ? "(using key from environment)" : "sk-ant-..."}
+                value={config.anthropicApiKey}
+                onChange={(e) => update("anthropicApiKey", e.target.value)}
+              />
+              <div className="hint">
+                {defaults?.hasAnthropicKey
+                  ? "Detected ANTHROPIC_API_KEY from server environment — leave blank to use it"
+                  : "Saved for Anthropic primary or fallback usage."}
               </div>
-
-              <div className="form-group">
-                <label>Google Cloud Credentials (JSON)</label>
-                <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
-                  {config.gcpServiceAccountJson ? (
-                    <div
-                      style={{
-                        flex: 1,
-                        padding: "0.5rem 0.75rem",
-                        background: "var(--bg-primary)",
-                        border: "1px solid var(--border)",
-                        borderRadius: "6px",
-                        fontFamily: "monospace",
-                        fontSize: "0.85rem",
-                        color: "var(--text-secondary)",
-                      }}
-                    >
-                      {(() => {
-                        try {
-                          const parsed = JSON.parse(config.gcpServiceAccountJson);
-                          return `${parsed.client_email || "service account"} (${parsed.project_id || "unknown project"})`;
-                        } catch {
-                          return "credentials loaded";
-                        }
-                      })()}
-                    </div>
-                  ) : (
-                    <input
-                      type="text"
-                      placeholder={
-                        gcpDefaults?.hasServiceAccountJson
-                          ? `Using credentials from ${gcpDefaults.sources.credentials}`
-                          : "/path/to/service-account.json"
-                      }
-                      value={config.gcpServiceAccountPath}
-                      onChange={(e) => update("gcpServiceAccountPath", e.target.value)}
-                      style={{ flex: 1 }}
-                    />
-                  )}
-                  <label
-                    className="btn btn-ghost"
-                    style={{ cursor: "pointer", whiteSpace: "nowrap" }}
-                  >
-                    {config.gcpServiceAccountJson ? "Change" : "Browse"}
-                    <input
-                      type="file"
-                      accept=".json"
-                      style={{ display: "none" }}
-                      onChange={(e) => {
-                        const file = e.target.files?.[0];
-                        if (!file) return;
-                        const reader = new FileReader();
-                        reader.onload = () => {
-                          const text = reader.result as string;
-                          update("gcpServiceAccountJson", text);
-                          update("gcpServiceAccountPath", "");
-                          if (!config.googleCloudProject) {
-                            try {
-                              const parsed = JSON.parse(text);
-                              if (parsed.project_id) {
-                                update("googleCloudProject", parsed.project_id);
-                              }
-                            } catch {
-                              // Ignore invalid JSON uploads here; validation happens later.
-                            }
-                          }
-                        };
-                        reader.readAsText(file);
-                      }}
-                    />
-                  </label>
-                  {config.gcpServiceAccountJson && (
-                    <button
-                      className="btn btn-ghost"
-                      onClick={() => update("gcpServiceAccountJson", "")}
-                    >
-                      Clear
-                    </button>
-                  )}
-                </div>
-                <div className="hint">
-                  Type a path to a credentials JSON file, or use Browse to upload one.
-                  {gcpDefaults?.hasServiceAccountJson && !config.gcpServiceAccountJson && !config.gcpServiceAccountPath
-                    && " Leave blank to use credentials detected from environment."}
-                </div>
+            </div>
+            <div className="form-group">
+              <label>Anthropic Model</label>
+              <input
+                type="text"
+                placeholder="e.g., claude-sonnet-4-6"
+                value={config.anthropicModel}
+                onChange={(e) => update("anthropicModel", e.target.value)}
+              />
+              <div className="hint">
+                Adds this Anthropic model to the OpenClaw model picker as <code>anthropic/&lt;model&gt;</code>.
               </div>
+            </div>
+          </>
+        );
 
+      case "openai":
+        return (
+          <>
+            <div className="form-group">
+              <label>OpenAI API Key</label>
+              <input
+                type="password"
+                autoComplete="new-password"
+                placeholder={defaults?.hasOpenaiKey ? "(using key from environment)" : "sk-..."}
+                value={config.openaiApiKey}
+                onChange={(e) => update("openaiApiKey", e.target.value)}
+              />
+              <div className="hint">
+                {defaults?.hasOpenaiKey
+                  ? "Detected OPENAI_API_KEY from server environment — leave blank to use it"
+                  : "Saved for OpenAI primary or fallback usage only."}
+              </div>
+            </div>
+            <div className="form-group">
+              <label>OpenAI Model</label>
+              <input
+                type="text"
+                placeholder="e.g., gpt-5"
+                value={config.openaiModel}
+                onChange={(e) => update("openaiModel", e.target.value)}
+              />
+              <div className="hint">
+                Adds this OpenAI model to the OpenClaw model picker as <code>openai/&lt;model&gt;</code>.
+              </div>
+            </div>
+          </>
+        );
+
+      case "vertex-anthropic":
+      case "vertex-google":
+        return (
+          <>
+            {provider === "vertex-google"
+              && gcpDefaults?.credentialType === "authorized_user"
+              && !config.gcpServiceAccountJson && (
+              <div style={{
+                marginBottom: "1rem",
+                padding: "0.5rem 0.75rem",
+                background: "rgba(231, 76, 60, 0.1)",
+                border: "1px solid rgba(231, 76, 60, 0.3)",
+                borderRadius: "6px",
+                fontSize: "0.85rem",
+                color: "#e74c3c",
+              }}>
+                Your environment credentials are Application Default Credentials (from <code>gcloud auth</code>),
+                which are not supported by Gemini on Vertex. Either upload a Service Account JSON below,
+                or switch to Google Vertex AI (Claude) which works with Application Default Credentials.
+              </div>
+            )}
+
+            <div className="form-row">
               <div className="form-group">
-                <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-                  <input
-                    type="checkbox"
-                    checked={config.litellmProxy}
-                    onChange={(e) =>
-                      setConfig((prev) => ({ ...prev, litellmProxy: e.target.checked }))
-                    }
-                    style={{ width: "auto" }}
-                  />
-                  Use LiteLLM proxy (recommended)
-                </label>
-                <div className="hint">
-                  Runs a LiteLLM sidecar that handles Vertex AI authentication.
-                  GCP credentials stay in the proxy container and are never exposed to the agent.
-                  {!config.litellmProxy && (
-                    <span style={{ color: "#e67e22" }}>
-                      {" "}Disabled: credentials will be passed directly to the agent container.
-                    </span>
-                  )}
-                </div>
-                {config.litellmProxy && (
-                  <div style={{
-                    marginTop: "0.5rem",
-                    padding: "0.5rem 0.75rem",
-                    background: "rgba(52, 152, 219, 0.1)",
-                    border: "1px solid rgba(52, 152, 219, 0.3)",
-                    borderRadius: "6px",
-                    fontSize: "0.85rem",
-                    color: "var(--text-secondary)",
-                  }}>
-                    The first deployment will pull both the OpenClaw image and the LiteLLM proxy
-                    image (<code>ghcr.io/berriai/litellm:v1.82.3-stable.patch.2</code>, ~1.5 GB).
-                    This may take several minutes. You can pre-pull
-                    with: <code>{mode === "kubernetes" ? "crictl pull" : "podman pull"} ghcr.io/berriai/litellm:v1.82.3-stable.patch.2</code>
+                <label>GCP Project ID</label>
+                <input
+                  type="text"
+                  placeholder="my-gcp-project"
+                  value={config.googleCloudProject}
+                  onChange={(e) => update("googleCloudProject", e.target.value)}
+                />
+                {gcpDefaults?.sources.projectId && config.googleCloudProject === gcpDefaults.projectId ? (
+                  <div className="hint">from {gcpDefaults.sources.projectId}</div>
+                ) : !config.googleCloudProject && (
+                  <div className="hint">Auto-extracted from credentials JSON if not set</div>
+                )}
+              </div>
+              <div className="form-group">
+                <label>GCP Region</label>
+                <input
+                  type="text"
+                  placeholder={provider === "vertex-anthropic" ? "us-east5 (default)" : "us-central1 (default)"}
+                  value={config.googleCloudLocation}
+                  onChange={(e) => update("googleCloudLocation", e.target.value)}
+                />
+                {gcpDefaults?.sources.location && config.googleCloudLocation === gcpDefaults.location ? (
+                  <div className="hint">from {gcpDefaults.sources.location}</div>
+                ) : !config.googleCloudLocation && (
+                  <div className="hint">
+                    Defaults to {provider === "vertex-anthropic" ? "us-east5" : "us-central1"} if not set
                   </div>
                 )}
               </div>
-            </>
-          )}
+            </div>
 
-          <div className="form-group">
-            <label>OpenAI-Compatible Model Endpoint</label>
-            <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+            <div className="form-group">
+              <label>Google Cloud Credentials (JSON)</label>
+              <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+                {config.gcpServiceAccountJson ? (
+                  <div
+                    style={{
+                      flex: 1,
+                      padding: "0.5rem 0.75rem",
+                      background: "var(--bg-primary)",
+                      border: "1px solid var(--border)",
+                      borderRadius: "6px",
+                      fontFamily: "monospace",
+                      fontSize: "0.85rem",
+                      color: "var(--text-secondary)",
+                    }}
+                  >
+                    {(() => {
+                      try {
+                        const parsed = JSON.parse(config.gcpServiceAccountJson);
+                        return `${parsed.client_email || "service account"} (${parsed.project_id || "unknown project"})`;
+                      } catch {
+                        return "credentials loaded";
+                      }
+                    })()}
+                  </div>
+                ) : (
+                  <input
+                    type="text"
+                    placeholder={
+                      gcpDefaults?.hasServiceAccountJson
+                        ? `Using credentials from ${gcpDefaults.sources.credentials}`
+                        : "/path/to/service-account.json"
+                    }
+                    value={config.gcpServiceAccountPath}
+                    onChange={(e) => update("gcpServiceAccountPath", e.target.value)}
+                    style={{ flex: 1 }}
+                  />
+                )}
+                <label
+                  className="btn btn-ghost"
+                  style={{ cursor: "pointer", whiteSpace: "nowrap" }}
+                >
+                  {config.gcpServiceAccountJson ? "Change" : "Browse"}
+                  <input
+                    type="file"
+                    accept=".json"
+                    style={{ display: "none" }}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      const reader = new FileReader();
+                      reader.onload = () => {
+                        const text = reader.result as string;
+                        update("gcpServiceAccountJson", text);
+                        update("gcpServiceAccountPath", "");
+                        if (!config.googleCloudProject) {
+                          try {
+                            const parsed = JSON.parse(text);
+                            if (parsed.project_id) {
+                              update("googleCloudProject", parsed.project_id);
+                            }
+                          } catch {
+                            // Ignore invalid JSON uploads here; validation happens later.
+                          }
+                        }
+                      };
+                      reader.readAsText(file);
+                    }}
+                  />
+                </label>
+                {config.gcpServiceAccountJson && (
+                  <button
+                    className="btn btn-ghost"
+                    onClick={() => update("gcpServiceAccountJson", "")}
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+              <div className="hint">
+                Type a path to a credentials JSON file, or use Browse to upload one.
+                {gcpDefaults?.hasServiceAccountJson && !config.gcpServiceAccountJson && !config.gcpServiceAccountPath
+                  && " Leave blank to use credentials detected from environment."}
+              </div>
+            </div>
+
+            <div className="form-group">
+              <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                <input
+                  type="checkbox"
+                  checked={config.litellmProxy}
+                  onChange={(e) =>
+                    setConfig((prev) => ({ ...prev, litellmProxy: e.target.checked }))
+                  }
+                  style={{ width: "auto" }}
+                />
+                Use LiteLLM proxy (recommended)
+              </label>
+              <div className="hint">
+                Runs a LiteLLM sidecar that handles Vertex AI authentication.
+                GCP credentials stay in the proxy container and are never exposed to the agent.
+                {!config.litellmProxy && (
+                  <span style={{ color: "#e67e22" }}>
+                    {" "}Disabled: credentials will be passed directly to the agent container.
+                  </span>
+                )}
+              </div>
+              {config.litellmProxy && (
+                <div style={{
+                  marginTop: "0.5rem",
+                  padding: "0.5rem 0.75rem",
+                  background: "rgba(52, 152, 219, 0.1)",
+                  border: "1px solid rgba(52, 152, 219, 0.3)",
+                  borderRadius: "6px",
+                  fontSize: "0.85rem",
+                  color: "var(--text-secondary)",
+                }}>
+                  The first deployment will pull both the OpenClaw image and the LiteLLM proxy
+                  image (<code>ghcr.io/berriai/litellm:v1.82.3-stable.patch.2</code>, ~1.5 GB).
+                  This may take several minutes. You can pre-pull
+                  with: <code>{mode === "kubernetes" ? "crictl pull" : "podman pull"} ghcr.io/berriai/litellm:v1.82.3-stable.patch.2</code>
+                </div>
+              )}
+            </div>
+          </>
+        );
+
+      case "custom-endpoint":
+        return (
+          <>
+            <div className="form-group">
+              <label>OpenAI-Compatible Model Endpoint</label>
+              <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+                <input
+                  type="text"
+                  placeholder="http://vllm.openclaw-llms.svc.cluster.local/v1"
+                  value={config.modelEndpoint}
+                  onChange={(e) => update("modelEndpoint", e.target.value)}
+                  style={{ flex: 1 }}
+                />
+                <button
+                  type="button"
+                  className="btn btn-ghost"
+                  onClick={fetchModelEndpointOptions}
+                  disabled={loadingModelEndpointOptions}
+                >
+                  {loadingModelEndpointOptions ? "Fetching..." : "Fetch Models"}
+                </button>
+              </div>
+              <div className="hint">
+                Optional. Save a local or open-source OpenAI-compatible endpoint here for primary use or fallback routing.
+              </div>
+              <div className="hint" style={{ marginTop: "0.35rem" }}>
+                If you paste just the service URL, the installer will normalize it to a <code>/v1</code> API base for runtime requests.
+              </div>
+              {modelEndpointOptionsError && (
+                <div className="hint" style={{ color: "#e74c3c", marginTop: "0.35rem" }}>
+                  {modelEndpointOptionsError}
+                </div>
+              )}
+            </div>
+            <div className="form-group">
+              <label>OpenAI-Compatible Model Name</label>
+              {modelEndpointOptions.length > 0 ? (
+                <select
+                  value={config.modelEndpointModel}
+                  onChange={(e) => {
+                    const selected = modelEndpointOptions.find((option) => option.id === e.target.value);
+                    setConfig((prev) => ({
+                      ...prev,
+                      modelEndpointModel: e.target.value,
+                      modelEndpointModelLabel: selected?.name || e.target.value,
+                    }));
+                  }}
+                >
+                  {modelEndpointOptions.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.name === option.id ? option.id : `${option.name} (${option.id})`}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  placeholder="e.g., mistral-small-24b-w8a8"
+                  value={config.modelEndpointModel}
+                  onChange={(e) =>
+                    setConfig((prev) => ({
+                      ...prev,
+                      modelEndpointModel: e.target.value,
+                      modelEndpointModelLabel: e.target.value,
+                    }))
+                  }
+                />
+              )}
+              <div className="hint">
+                The model ID served by that endpoint. Use the exact name the endpoint expects, such as <code>mistral-small-24b-w8a8</code>.
+              </div>
+            </div>
+            <div className="form-group">
+              <label>OpenAI-Compatible Endpoint API Key (`MODEL_ENDPOINT_API_KEY`)</label>
               <input
-                type="text"
-                placeholder="http://vllm.openclaw-llms.svc.cluster.local/v1"
-                value={config.modelEndpoint}
-                onChange={(e) => update("modelEndpoint", e.target.value)}
-                style={{ flex: 1 }}
+                type="password"
+                autoComplete="new-password"
+                placeholder="API key for the OpenAI-compatible endpoint"
+                value={config.modelEndpointApiKey}
+                onChange={(e) => update("modelEndpointApiKey", e.target.value)}
               />
+              <div className="hint">
+                Separate from <code>OPENAI_API_KEY</code>. Use this when your OpenAI-compatible endpoint requires its own token.
+              </div>
+            </div>
+          </>
+        );
+
+      default:
+        return null;
+    }
+  }
+
+  return (
+    <>
+      <h3 style={{ marginTop: "1.5rem" }}>Inference Providers</h3>
+
+      {/* Primary Provider Card */}
+      <div className="card" style={{ marginTop: "0.75rem" }}>
+        <div style={LABEL_STYLE}>Primary</div>
+
+        <div className="form-group">
+          <label>Primary Provider</label>
+          <select
+            value={inferenceProvider}
+            onChange={(e) => {
+              setInferenceProvider(e.target.value as InferenceProvider);
+              update("agentModel", "");
+            }}
+          >
+            {PROVIDER_OPTIONS.filter(
+              (p) => p.id === inferenceProvider || !selectedAdditionalProviders.includes(p.id),
+            ).map((p) => (
+              <option key={p.id} value={p.id}>{p.label}</option>
+            ))}
+          </select>
+          <div className="hint">
+            {PROVIDER_OPTIONS.find((p) => p.id === inferenceProvider)?.desc}. This controls the default primary route for the deployment.
+          </div>
+        </div>
+
+        <div className="form-group" style={{ marginTop: "0.75rem" }}>
+          <label>Primary Model</label>
+          <input
+            type="text"
+            placeholder={
+              isVertex && config.litellmProxy
+                ? (inferenceProvider === "vertex-anthropic" ? "claude-sonnet-4-6" : "gemini-2.5-pro")
+                : (MODEL_DEFAULTS[inferenceProvider] || "model-id")
+            }
+            value={config.agentModel}
+            onChange={(e) => update("agentModel", e.target.value)}
+          />
+          <div className="hint">
+            {config.agentModel
+              ? "Custom primary model override"
+              : isVertex && config.litellmProxy
+                ? `Leave blank for default (routed through LiteLLM proxy). ${PROXY_MODEL_HINTS[inferenceProvider] || MODEL_HINTS[inferenceProvider]}`
+                : `Leave blank for default${MODEL_DEFAULTS[inferenceProvider] ? ` (${MODEL_DEFAULTS[inferenceProvider]})` : ""}. ${MODEL_HINTS[inferenceProvider]}`}
+          </div>
+        </div>
+
+        <div className="form-group" style={{ marginTop: "0.75rem" }}>
+          <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            <input
+              type="checkbox"
+              checked={config.openaiCompatibleEndpointsEnabled}
+              onChange={(e) =>
+                setConfig((prev) => ({ ...prev, openaiCompatibleEndpointsEnabled: e.target.checked }))
+              }
+              style={{ width: "auto" }}
+            />
+            Enable OpenAI-compatible API endpoints
+          </label>
+          <div className="hint">
+            Exposes <code>/v1/chat/completions</code>, <code>/v1/responses</code>, and <code>/v1/models</code> for OpenAI-compatible clients. Disable this to remove those endpoints from the gateway.
+          </div>
+        </div>
+
+        {renderProviderFields(inferenceProvider)}
+      </div>
+
+      {/* Additional Provider Cards */}
+      {additionalProviders.map((ap) => {
+        const availableOptions = PROVIDER_OPTIONS.filter(
+          (p) => p.id === ap.provider || !allUsedProviders.includes(p.id),
+        );
+
+        return (
+          <div className="card" style={{ marginTop: "0.75rem" }} key={ap.id}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+              <div style={LABEL_STYLE}>Additional Provider</div>
               <button
-                type="button"
                 className="btn btn-ghost"
-                onClick={fetchModelEndpointOptions}
-                disabled={loadingModelEndpointOptions}
+                onClick={() => removeProvider(ap.id)}
+                style={{ marginTop: "-0.25rem" }}
               >
-                {loadingModelEndpointOptions ? "Fetching..." : "Fetch Models"}
+                Remove
               </button>
             </div>
-            <div className="hint">
-              Optional. Save a local or open-source OpenAI-compatible endpoint here for primary use or fallback routing.
-            </div>
-            <div className="hint" style={{ marginTop: "0.35rem" }}>
-              If you paste just the service URL, the installer will normalize it to a <code>/v1</code> API base for runtime requests.
-            </div>
-            {modelEndpointOptionsError && (
-              <div className="hint" style={{ color: "#e74c3c", marginTop: "0.35rem" }}>
-                {modelEndpointOptionsError}
-              </div>
-            )}
-          </div>
-          <div className="form-group">
-            <label>OpenAI-Compatible Model Name</label>
-            {modelEndpointOptions.length > 0 ? (
+
+            <div className="form-group">
+              <label>Provider</label>
               <select
-                value={config.modelEndpointModel}
-                onChange={(e) => {
-                  const selected = modelEndpointOptions.find((option) => option.id === e.target.value);
-                  setConfig((prev) => ({
-                    ...prev,
-                    modelEndpointModel: e.target.value,
-                    modelEndpointModelLabel: selected?.name || e.target.value,
-                  }));
-                }}
+                value={ap.provider}
+                onChange={(e) => setProviderValue(ap.id, e.target.value as InferenceProvider | "")}
               >
-                {modelEndpointOptions.map((option) => (
-                  <option key={option.id} value={option.id}>
-                    {option.name === option.id ? option.id : `${option.name} (${option.id})`}
-                  </option>
+                <option value="">Select a provider...</option>
+                {availableOptions.map((p) => (
+                  <option key={p.id} value={p.id}>{p.label}</option>
                 ))}
               </select>
-            ) : (
-              <input
-                type="text"
-                placeholder="e.g., mistral-small-24b-w8a8"
-                value={config.modelEndpointModel}
-                onChange={(e) =>
-                  setConfig((prev) => ({
-                    ...prev,
-                    modelEndpointModel: e.target.value,
-                    modelEndpointModelLabel: e.target.value,
-                  }))
-                }
-              />
-            )}
-            <div className="hint">
-              The model ID served by that endpoint. Use the exact name the endpoint expects, such as <code>mistral-small-24b-w8a8</code>.
             </div>
-          </div>
-          <div className="form-group">
-            <label>OpenAI-Compatible Endpoint API Key (`MODEL_ENDPOINT_API_KEY`)</label>
-            <input
-              type="password"
-              autoComplete="new-password"
-              placeholder="API key for the OpenAI-compatible endpoint"
-              value={config.modelEndpointApiKey}
-              onChange={(e) => update("modelEndpointApiKey", e.target.value)}
-            />
-            <div className="hint">
-              Separate from <code>OPENAI_API_KEY</code>. Use this when your OpenAI-compatible endpoint requires its own token.
-            </div>
-          </div>
 
-        </div>
-      </details>
+            {renderProviderFields(ap.provider)}
+          </div>
+        );
+      })}
+
+      {/* Add Provider Button */}
+      <div style={{ marginTop: "0.75rem" }}>
+        <button
+          type="button"
+          className="btn btn-ghost"
+          onClick={addProvider}
+          disabled={allAdded}
+        >
+          + Add Provider
+        </button>
+        {allAdded && (
+          <span style={{ marginLeft: "0.5rem", fontSize: "0.85rem", color: "var(--text-secondary)" }}>
+            All available providers have been added
+          </span>
+        )}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
Replace the flat "Additional Providers & Fallbacks" collapsible section with a card-based UI where each provider gets its own card with a dropdown and provider-specific configuration fields.

- Rename heading to "Inference Providers"
- Primary provider card with dropdown, model, and OpenAI-compatible toggle
- "+ Add Provider" button for additional provider cards
- Provider dropdowns exclude already-selected providers (no duplicates)
- Remove button on additional cards (primary card cannot be removed)
- Button disables when all providers are added
- All existing config fields and serialization unchanged