### PR TITLE
fix(deployers): pass secondary provider API keys to LiteLLM sidecar

### DIFF
--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -446,6 +446,46 @@ describe("model config generation", () => {
   });
 });
 
+// Regression tests for #78: LiteLLM model catalog should include secondary providers
+// and not duplicate the primary model
+describe("litellm model catalog in proxy mode (#78)", () => {
+  it("lists secondary OpenAI model in models.providers.litellm when openaiApiKey is set", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      litellmProxy: true,
+      gcpServiceAccountJson: '{"project_id":"test"}',
+      openaiApiKey: "sk-oai-test",
+    });
+
+    const rendered = buildOpenClawConfig(config, "gateway-token") as {
+      models?: { providers?: { litellm?: { models?: Array<{ id: string; name: string }> } } };
+    };
+
+    const litellmModels = rendered.models?.providers?.litellm?.models ?? [];
+    const modelIds = litellmModels.map((m) => m.id);
+    expect(modelIds).toContain("gpt-5.4");
+  });
+
+  it("does not duplicate the primary model in models.providers.litellm", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      litellmProxy: true,
+      gcpServiceAccountJson: '{"project_id":"test"}',
+      openaiApiKey: "sk-oai-test",
+    });
+
+    const rendered = buildOpenClawConfig(config, "gateway-token") as {
+      models?: { providers?: { litellm?: { models?: Array<{ id: string; name: string }> } } };
+    };
+
+    const litellmModels = rendered.models?.providers?.litellm?.models ?? [];
+    const modelIds = litellmModels.map((m) => m.id);
+    // Primary model (claude-sonnet-4-6) should NOT be in the provider listing
+    // because it is already in agents.defaults.models via buildDefaultAgentModelCatalog
+    expect(modelIds).not.toContain("claude-sonnet-4-6");
+  });
+});
+
 // Regression tests for #7: agent names with underscores must produce valid namespaces
 describe("sanitizeForRfc1123", () => {
   it("replaces underscores with hyphens", () => {

--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -446,10 +446,9 @@ describe("model config generation", () => {
   });
 });
 
-// Regression tests for #78: LiteLLM model catalog should include secondary providers
-// and not duplicate the primary model
-describe("litellm model catalog in proxy mode (#78)", () => {
-  it("lists secondary OpenAI model in models.providers.litellm when openaiApiKey is set", () => {
+// LiteLLM model catalog only lists Vertex models, not secondary providers
+describe("litellm model catalog in proxy mode", () => {
+  it("does not list secondary OpenAI model in litellm provider", () => {
     const config = makeConfig({
       inferenceProvider: "vertex-anthropic",
       litellmProxy: true,
@@ -463,7 +462,8 @@ describe("litellm model catalog in proxy mode (#78)", () => {
 
     const litellmModels = rendered.models?.providers?.litellm?.models ?? [];
     const modelIds = litellmModels.map((m) => m.id);
-    expect(modelIds).toContain("gpt-5.4");
+    // OpenAI models go direct via gateway, not through LiteLLM
+    expect(modelIds).not.toContain("gpt-5.4");
   });
 
   it("does not duplicate the primary model in models.providers.litellm", () => {

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -178,3 +178,76 @@ describe("gateway env vars in proxy mode", () => {
     expect(envNames).not.toContain("GOOGLE_CLOUD_LOCATION");
   });
 });
+
+/** Extract env var names from the LiteLLM sidecar container in a deployment manifest. */
+function litellmEnvNames(deployment: k8s.V1Deployment): string[] {
+  const container = deployment.spec?.template.spec?.containers?.find((c) => c.name === "litellm");
+  return (container?.env ?? []).map((e) => e.name);
+}
+
+// Regression tests for #78: LiteLLM sidecar must receive secondary provider API keys
+describe("litellm sidecar env vars in proxy mode (#78)", () => {
+  it("injects OPENAI_API_KEY into litellm sidecar when configured", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      litellmProxy: true,
+      gcpServiceAccountJson: '{"project_id":"test"}',
+      openaiApiKey: "sk-oai-test",
+    });
+
+    const deployment = deploymentManifest("ns", config);
+    const envNames = litellmEnvNames(deployment);
+
+    expect(envNames).toContain("OPENAI_API_KEY");
+  });
+
+  it("injects ANTHROPIC_API_KEY into litellm sidecar when configured", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-google",
+      litellmProxy: true,
+      gcpServiceAccountJson: '{"project_id":"test"}',
+      vertexProvider: "google",
+      anthropicApiKey: "sk-ant-test",
+    });
+
+    const deployment = deploymentManifest("ns", config);
+    const envNames = litellmEnvNames(deployment);
+
+    expect(envNames).toContain("ANTHROPIC_API_KEY");
+  });
+
+  it("does not inject secondary keys when they are not configured", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      litellmProxy: true,
+      gcpServiceAccountJson: '{"project_id":"test"}',
+    });
+
+    const deployment = deploymentManifest("ns", config);
+    const envNames = litellmEnvNames(deployment);
+
+    expect(envNames).not.toContain("OPENAI_API_KEY");
+    expect(envNames).not.toContain("ANTHROPIC_API_KEY");
+  });
+
+  it("still excludes secondary keys from the gateway container", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      litellmProxy: true,
+      gcpServiceAccountJson: '{"project_id":"test"}',
+      openaiApiKey: "sk-oai-test",
+      anthropicApiKey: "sk-ant-test",
+    });
+
+    const deployment = deploymentManifest("ns", config);
+    const gwEnvNames = gatewayEnvNames(deployment);
+    const sidecarEnvNames = litellmEnvNames(deployment);
+
+    // Gateway should NOT have the keys (Fix for #6 still holds)
+    expect(gwEnvNames).not.toContain("OPENAI_API_KEY");
+    expect(gwEnvNames).not.toContain("ANTHROPIC_API_KEY");
+    // Sidecar SHOULD have the keys (Fix for #78)
+    expect(sidecarEnvNames).toContain("OPENAI_API_KEY");
+    expect(sidecarEnvNames).toContain("ANTHROPIC_API_KEY");
+  });
+});

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -109,9 +109,10 @@ describe("symlink traversal in init script", () => {
   });
 });
 
-// Regression tests for #6: API keys must not leak to the gateway in proxy mode
+// Gateway always gets provider API keys — LiteLLM only handles Vertex,
+// secondary providers (OpenAI, Anthropic) are routed directly by the gateway.
 describe("gateway env vars in proxy mode", () => {
-  it("excludes ANTHROPIC_API_KEY and OPENAI_API_KEY when litellm proxy is active", () => {
+  it("includes ANTHROPIC_API_KEY and OPENAI_API_KEY even when litellm proxy is active", () => {
     const proxyConfig = makeConfig({
       inferenceProvider: "vertex-anthropic",
       litellmProxy: true,
@@ -123,8 +124,8 @@ describe("gateway env vars in proxy mode", () => {
     const deployment = deploymentManifest("ns", proxyConfig);
     const envNames = gatewayEnvNames(deployment);
 
-    expect(envNames).not.toContain("ANTHROPIC_API_KEY");
-    expect(envNames).not.toContain("OPENAI_API_KEY");
+    expect(envNames).toContain("ANTHROPIC_API_KEY");
+    expect(envNames).toContain("OPENAI_API_KEY");
   });
 
   it("includes ANTHROPIC_API_KEY and OPENAI_API_KEY when proxy is not active", () => {
@@ -185,52 +186,27 @@ function litellmEnvNames(deployment: k8s.V1Deployment): string[] {
   return (container?.env ?? []).map((e) => e.name);
 }
 
-// Regression tests for #78: LiteLLM sidecar must receive secondary provider API keys
-describe("litellm sidecar env vars in proxy mode (#78)", () => {
-  it("injects OPENAI_API_KEY into litellm sidecar when configured", () => {
+// LiteLLM sidecar only handles Vertex — no secondary provider keys needed
+describe("litellm sidecar env vars in proxy mode", () => {
+  it("does not inject secondary provider keys into litellm sidecar", () => {
     const config = makeConfig({
       inferenceProvider: "vertex-anthropic",
       litellmProxy: true,
       gcpServiceAccountJson: '{"project_id":"test"}',
       openaiApiKey: "sk-oai-test",
-    });
-
-    const deployment = deploymentManifest("ns", config);
-    const envNames = litellmEnvNames(deployment);
-
-    expect(envNames).toContain("OPENAI_API_KEY");
-  });
-
-  it("injects ANTHROPIC_API_KEY into litellm sidecar when configured", () => {
-    const config = makeConfig({
-      inferenceProvider: "vertex-google",
-      litellmProxy: true,
-      gcpServiceAccountJson: '{"project_id":"test"}',
-      vertexProvider: "google",
       anthropicApiKey: "sk-ant-test",
     });
 
     const deployment = deploymentManifest("ns", config);
     const envNames = litellmEnvNames(deployment);
 
-    expect(envNames).toContain("ANTHROPIC_API_KEY");
-  });
-
-  it("does not inject secondary keys when they are not configured", () => {
-    const config = makeConfig({
-      inferenceProvider: "vertex-anthropic",
-      litellmProxy: true,
-      gcpServiceAccountJson: '{"project_id":"test"}',
-    });
-
-    const deployment = deploymentManifest("ns", config);
-    const envNames = litellmEnvNames(deployment);
-
+    // LiteLLM only needs GCP creds for Vertex
+    expect(envNames).toContain("GOOGLE_APPLICATION_CREDENTIALS");
     expect(envNames).not.toContain("OPENAI_API_KEY");
     expect(envNames).not.toContain("ANTHROPIC_API_KEY");
   });
 
-  it("still excludes secondary keys from the gateway container", () => {
+  it("gateway gets secondary keys even in proxy mode", () => {
     const config = makeConfig({
       inferenceProvider: "vertex-anthropic",
       litellmProxy: true,
@@ -241,13 +217,9 @@ describe("litellm sidecar env vars in proxy mode (#78)", () => {
 
     const deployment = deploymentManifest("ns", config);
     const gwEnvNames = gatewayEnvNames(deployment);
-    const sidecarEnvNames = litellmEnvNames(deployment);
 
-    // Gateway should NOT have the keys (Fix for #6 still holds)
-    expect(gwEnvNames).not.toContain("OPENAI_API_KEY");
-    expect(gwEnvNames).not.toContain("ANTHROPIC_API_KEY");
-    // Sidecar SHOULD have the keys (Fix for #78)
-    expect(sidecarEnvNames).toContain("OPENAI_API_KEY");
-    expect(sidecarEnvNames).toContain("ANTHROPIC_API_KEY");
+    // Gateway routes to OpenAI/Anthropic directly
+    expect(gwEnvNames).toContain("OPENAI_API_KEY");
+    expect(gwEnvNames).toContain("ANTHROPIC_API_KEY");
   });
 });

--- a/src/server/deployers/__tests__/litellm.test.ts
+++ b/src/server/deployers/__tests__/litellm.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateLitellmConfig,
+  litellmSidecarEnvVars,
+  litellmRegisteredModelNames,
+  litellmModelName,
+} from "../litellm.js";
+import type { DeployConfig } from "../types.js";
+
+function makeConfig(overrides: Partial<DeployConfig> = {}): DeployConfig {
+  return {
+    mode: "kubernetes",
+    agentName: "test",
+    agentDisplayName: "Test",
+    vertexEnabled: true,
+    gcpServiceAccountJson: '{"project_id":"test-project"}',
+    googleCloudProject: "test-project",
+    googleCloudLocation: "us-central1",
+    ...overrides,
+  };
+}
+
+// Regression tests for #78: secondary provider API keys and models in LiteLLM proxy
+describe("litellm multi-provider support (#78)", () => {
+  describe("generateLitellmConfig", () => {
+    it("includes OpenAI model entry when openaiApiKey is configured", () => {
+      const config = makeConfig({ openaiApiKey: "sk-oai-test" });
+      const yaml = generateLitellmConfig(config, "sk-master");
+
+      expect(yaml).toContain("model_name: gpt-5.4");
+      expect(yaml).toContain("model: openai/gpt-5.4");
+      // OpenAI models should not have vertex params
+      const lines = yaml.split("\n");
+      const gptLine = lines.findIndex((l) => l.includes("model_name: gpt-5.4"));
+      const paramsSection = lines.slice(gptLine, gptLine + 5).join("\n");
+      expect(paramsSection).not.toContain("vertex_project");
+    });
+
+    it("includes Anthropic model entry when anthropicApiKey is configured", () => {
+      // With vertex-google as primary, adding direct Anthropic as secondary
+      const config = makeConfig({
+        vertexProvider: "google",
+        anthropicApiKey: "sk-ant-test",
+      });
+      const yaml = generateLitellmConfig(config, "sk-master");
+
+      expect(yaml).toContain("model_name: claude-sonnet-4-6");
+      expect(yaml).toContain("model: anthropic/claude-sonnet-4-6");
+    });
+
+    it("does not duplicate model_name when secondary matches existing Vertex model", () => {
+      // Vertex Anthropic primary already has claude-sonnet-4-6; adding direct
+      // Anthropic with same model name should not create a duplicate entry.
+      const config = makeConfig({
+        vertexProvider: "anthropic",
+        anthropicApiKey: "sk-ant-test",
+      });
+      const yaml = generateLitellmConfig(config, "sk-master");
+
+      const matches = yaml.match(/model_name: claude-sonnet-4-6/g);
+      expect(matches).toHaveLength(1);
+    });
+
+    it("uses custom openaiModel name when specified", () => {
+      const config = makeConfig({
+        openaiApiKey: "sk-oai-test",
+        openaiModel: "gpt-4.1",
+      });
+      const yaml = generateLitellmConfig(config, "sk-master");
+
+      expect(yaml).toContain("model_name: gpt-4.1");
+      expect(yaml).toContain("model: openai/gpt-4.1");
+    });
+
+    it("still includes Vertex models alongside secondary providers", () => {
+      const config = makeConfig({
+        vertexProvider: "anthropic",
+        openaiApiKey: "sk-oai-test",
+      });
+      const yaml = generateLitellmConfig(config, "sk-master");
+
+      // Vertex primary models
+      expect(yaml).toContain("model: vertex_ai/claude-sonnet-4-6");
+      expect(yaml).toContain("model: vertex_ai/claude-haiku-4-5");
+      // Secondary OpenAI model
+      expect(yaml).toContain("model: openai/gpt-5.4");
+    });
+
+    it("includes secondary models when openaiApiKeyRef is set instead of raw key", () => {
+      const config = makeConfig({
+        openaiApiKeyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+      });
+      const yaml = generateLitellmConfig(config, "sk-master");
+
+      expect(yaml).toContain("model_name: gpt-5.4");
+    });
+
+    it("omits secondary models when no secondary provider keys are configured", () => {
+      const config = makeConfig();
+      const yaml = generateLitellmConfig(config, "sk-master");
+
+      expect(yaml).not.toContain("model: openai/");
+      expect(yaml).not.toContain("model: anthropic/");
+    });
+  });
+
+  describe("litellmSidecarEnvVars", () => {
+    it("returns OPENAI_API_KEY when configured", () => {
+      const config = makeConfig({ openaiApiKey: "sk-oai-test" });
+      const env = litellmSidecarEnvVars(config);
+
+      expect(env).toEqual({ OPENAI_API_KEY: "sk-oai-test" });
+    });
+
+    it("returns ANTHROPIC_API_KEY when configured", () => {
+      const config = makeConfig({ anthropicApiKey: "sk-ant-test" });
+      const env = litellmSidecarEnvVars(config);
+
+      expect(env).toEqual({ ANTHROPIC_API_KEY: "sk-ant-test" });
+    });
+
+    it("returns both keys when both are configured", () => {
+      const config = makeConfig({
+        openaiApiKey: "sk-oai-test",
+        anthropicApiKey: "sk-ant-test",
+      });
+      const env = litellmSidecarEnvVars(config);
+
+      expect(env).toEqual({
+        OPENAI_API_KEY: "sk-oai-test",
+        ANTHROPIC_API_KEY: "sk-ant-test",
+      });
+    });
+
+    it("returns empty object when no secondary keys are configured", () => {
+      const config = makeConfig();
+      const env = litellmSidecarEnvVars(config);
+
+      expect(env).toEqual({});
+    });
+  });
+
+  describe("litellmRegisteredModelNames", () => {
+    it("returns Vertex models plus secondary OpenAI model", () => {
+      const config = makeConfig({
+        vertexProvider: "anthropic",
+        openaiApiKey: "sk-oai-test",
+      });
+      const names = litellmRegisteredModelNames(config);
+
+      expect(names).toContain("claude-sonnet-4-6");
+      expect(names).toContain("claude-haiku-4-5");
+      expect(names).toContain("gpt-5.4");
+    });
+
+    it("returns only Vertex models when no secondary providers", () => {
+      const config = makeConfig({ vertexProvider: "anthropic" });
+      const names = litellmRegisteredModelNames(config);
+
+      expect(names).toEqual(["claude-sonnet-4-6", "claude-haiku-4-5"]);
+    });
+
+    it("returns Google Vertex models when vertexProvider is google", () => {
+      const config = makeConfig({ vertexProvider: "google" });
+      const names = litellmRegisteredModelNames(config);
+
+      expect(names).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
+    });
+  });
+});

--- a/src/server/deployers/__tests__/litellm.test.ts
+++ b/src/server/deployers/__tests__/litellm.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   generateLitellmConfig,
-  litellmSidecarEnvVars,
   litellmRegisteredModelNames,
   litellmModelName,
 } from "../litellm.js";
@@ -20,151 +19,98 @@ function makeConfig(overrides: Partial<DeployConfig> = {}): DeployConfig {
   };
 }
 
-// Regression tests for #78: secondary provider API keys and models in LiteLLM proxy
-describe("litellm multi-provider support (#78)", () => {
+describe("litellm — Vertex-only proxy", () => {
   describe("generateLitellmConfig", () => {
-    it("includes OpenAI model entry when openaiApiKey is configured", () => {
-      const config = makeConfig({ openaiApiKey: "sk-oai-test" });
+    it("includes Vertex Anthropic models for anthropic provider", () => {
+      const config = makeConfig({ vertexProvider: "anthropic" });
       const yaml = generateLitellmConfig(config, "sk-master");
 
-      expect(yaml).toContain("model_name: gpt-5.4");
-      expect(yaml).toContain("model: openai/gpt-5.4");
-      // OpenAI models should not have vertex params
-      const lines = yaml.split("\n");
-      const gptLine = lines.findIndex((l) => l.includes("model_name: gpt-5.4"));
-      const paramsSection = lines.slice(gptLine, gptLine + 5).join("\n");
-      expect(paramsSection).not.toContain("vertex_project");
+      expect(yaml).toContain("model: vertex_ai/claude-sonnet-4-6");
+      expect(yaml).toContain("model: vertex_ai/claude-haiku-4-5");
     });
 
-    it("includes Anthropic model entry when anthropicApiKey is configured", () => {
-      // With vertex-google as primary, adding direct Anthropic as secondary
+    it("includes Vertex Google models for google provider", () => {
+      const config = makeConfig({ vertexProvider: "google" });
+      const yaml = generateLitellmConfig(config, "sk-master");
+
+      expect(yaml).toContain("model: vertex_ai/gemini-2.5-pro");
+      expect(yaml).toContain("model: vertex_ai/gemini-2.5-flash");
+    });
+
+    it("does not include secondary provider models even when keys are configured", () => {
+      const config = makeConfig({
+        vertexProvider: "anthropic",
+        openaiApiKey: "sk-oai-test",
+      });
+      const yaml = generateLitellmConfig(config, "sk-master");
+
+      // LiteLLM only handles Vertex — secondary providers go direct via gateway
+      expect(yaml).not.toContain("model: openai/");
+      expect(yaml).not.toContain("model_name: gpt-5.4");
+    });
+
+    it("does not include direct Anthropic models even when anthropicApiKey is set", () => {
       const config = makeConfig({
         vertexProvider: "google",
         anthropicApiKey: "sk-ant-test",
       });
       const yaml = generateLitellmConfig(config, "sk-master");
 
-      expect(yaml).toContain("model_name: claude-sonnet-4-6");
-      expect(yaml).toContain("model: anthropic/claude-sonnet-4-6");
-    });
-
-    it("does not duplicate model_name when secondary matches existing Vertex model", () => {
-      // Vertex Anthropic primary already has claude-sonnet-4-6; adding direct
-      // Anthropic with same model name should not create a duplicate entry.
-      const config = makeConfig({
-        vertexProvider: "anthropic",
-        anthropicApiKey: "sk-ant-test",
-      });
-      const yaml = generateLitellmConfig(config, "sk-master");
-
-      const matches = yaml.match(/model_name: claude-sonnet-4-6/g);
-      expect(matches).toHaveLength(1);
-    });
-
-    it("uses custom openaiModel name when specified", () => {
-      const config = makeConfig({
-        openaiApiKey: "sk-oai-test",
-        openaiModel: "gpt-4.1",
-      });
-      const yaml = generateLitellmConfig(config, "sk-master");
-
-      expect(yaml).toContain("model_name: gpt-4.1");
-      expect(yaml).toContain("model: openai/gpt-4.1");
-    });
-
-    it("still includes Vertex models alongside secondary providers", () => {
-      const config = makeConfig({
-        vertexProvider: "anthropic",
-        openaiApiKey: "sk-oai-test",
-      });
-      const yaml = generateLitellmConfig(config, "sk-master");
-
-      // Vertex primary models
-      expect(yaml).toContain("model: vertex_ai/claude-sonnet-4-6");
-      expect(yaml).toContain("model: vertex_ai/claude-haiku-4-5");
-      // Secondary OpenAI model
-      expect(yaml).toContain("model: openai/gpt-5.4");
-    });
-
-    it("includes secondary models when openaiApiKeyRef is set instead of raw key", () => {
-      const config = makeConfig({
-        openaiApiKeyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-      });
-      const yaml = generateLitellmConfig(config, "sk-master");
-
-      expect(yaml).toContain("model_name: gpt-5.4");
-    });
-
-    it("omits secondary models when no secondary provider keys are configured", () => {
-      const config = makeConfig();
-      const yaml = generateLitellmConfig(config, "sk-master");
-
-      expect(yaml).not.toContain("model: openai/");
       expect(yaml).not.toContain("model: anthropic/");
     });
-  });
 
-  describe("litellmSidecarEnvVars", () => {
-    it("returns OPENAI_API_KEY when configured", () => {
-      const config = makeConfig({ openaiApiKey: "sk-oai-test" });
-      const env = litellmSidecarEnvVars(config);
-
-      expect(env).toEqual({ OPENAI_API_KEY: "sk-oai-test" });
-    });
-
-    it("returns ANTHROPIC_API_KEY when configured", () => {
-      const config = makeConfig({ anthropicApiKey: "sk-ant-test" });
-      const env = litellmSidecarEnvVars(config);
-
-      expect(env).toEqual({ ANTHROPIC_API_KEY: "sk-ant-test" });
-    });
-
-    it("returns both keys when both are configured", () => {
-      const config = makeConfig({
-        openaiApiKey: "sk-oai-test",
-        anthropicApiKey: "sk-ant-test",
-      });
-      const env = litellmSidecarEnvVars(config);
-
-      expect(env).toEqual({
-        OPENAI_API_KEY: "sk-oai-test",
-        ANTHROPIC_API_KEY: "sk-ant-test",
-      });
-    });
-
-    it("returns empty object when no secondary keys are configured", () => {
+    it("omits vertex_project/location for non-vertex entries", () => {
       const config = makeConfig();
-      const env = litellmSidecarEnvVars(config);
+      const yaml = generateLitellmConfig(config, "sk-master");
 
-      expect(env).toEqual({});
+      // All entries should have vertex params since LiteLLM only has Vertex models
+      const lines = yaml.split("\n");
+      const modelEntries = lines.filter((l) => l.includes("model_name:"));
+      expect(modelEntries.length).toBeGreaterThan(0);
     });
   });
 
   describe("litellmRegisteredModelNames", () => {
-    it("returns Vertex models plus secondary OpenAI model", () => {
-      const config = makeConfig({
-        vertexProvider: "anthropic",
-        openaiApiKey: "sk-oai-test",
-      });
-      const names = litellmRegisteredModelNames(config);
-
-      expect(names).toContain("claude-sonnet-4-6");
-      expect(names).toContain("claude-haiku-4-5");
-      expect(names).toContain("gpt-5.4");
-    });
-
-    it("returns only Vertex models when no secondary providers", () => {
+    it("returns only Vertex Anthropic models", () => {
       const config = makeConfig({ vertexProvider: "anthropic" });
       const names = litellmRegisteredModelNames(config);
 
       expect(names).toEqual(["claude-sonnet-4-6", "claude-haiku-4-5"]);
     });
 
-    it("returns Google Vertex models when vertexProvider is google", () => {
+    it("returns only Vertex Google models", () => {
       const config = makeConfig({ vertexProvider: "google" });
       const names = litellmRegisteredModelNames(config);
 
       expect(names).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
+    });
+
+    it("does not include secondary provider models", () => {
+      const config = makeConfig({
+        vertexProvider: "anthropic",
+        openaiApiKey: "sk-oai-test",
+      });
+      const names = litellmRegisteredModelNames(config);
+
+      expect(names).not.toContain("gpt-5.4");
+      expect(names).toEqual(["claude-sonnet-4-6", "claude-haiku-4-5"]);
+    });
+  });
+
+  describe("litellmModelName", () => {
+    it("returns claude-sonnet-4-6 for anthropic provider", () => {
+      const config = makeConfig({ vertexProvider: "anthropic" });
+      expect(litellmModelName(config)).toBe("claude-sonnet-4-6");
+    });
+
+    it("returns gemini-2.5-pro for google provider", () => {
+      const config = makeConfig({ vertexProvider: "google" });
+      expect(litellmModelName(config)).toBe("gemini-2.5-pro");
+    });
+
+    it("returns custom agentModel when specified", () => {
+      const config = makeConfig({ agentModel: "claude-opus-4-6" });
+      expect(litellmModelName(config)).toBe("claude-opus-4-6");
     });
   });
 });

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
 import { randomBytes } from "node:crypto";
 import type { DeployConfig, DeployModelOption, DeploySecretRef } from "./types.js";
-import { shouldUseLitellmProxy, litellmModelName, LITELLM_PORT } from "./litellm.js";
+import { shouldUseLitellmProxy, litellmModelName, litellmRegisteredModelNames, LITELLM_PORT } from "./litellm.js";
 import { shouldUseOtel, OTEL_HTTP_PORT } from "./otel.js";
 import { buildSandboxConfig } from "./sandbox.js";
 import { buildSandboxToolPolicy } from "./tool-policy.js";
@@ -445,15 +445,19 @@ export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string):
         }))),
       ],
     },
+    // Fix for #78: register all LiteLLM models (primary + secondary providers)
+    // in the provider listing.  Exclude the primary model since it is already
+    // in agents.defaults.models via buildDefaultAgentModelCatalog, avoiding a
+    // duplicate entry in the UI dropdown.
     ...(shouldUseLitellmProxy(config) ? {
       models: {
         providers: {
           litellm: {
             baseUrl: `http://localhost:${LITELLM_PORT}/v1`,
             api: "openai-completions",
-            models: [
-              { id: litellmModelName(config), name: litellmModelName(config) },
-            ],
+            models: litellmRegisteredModelNames(config)
+              .filter((name) => name !== litellmModelName(config))
+              .map((name) => ({ id: name, name })),
           },
         },
       },

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -437,6 +437,8 @@ echo "Config initialized"
               },
             },
             // LiteLLM proxy sidecar: holds GCP creds, exposes OpenAI-compatible API
+            // Fix for #78: also inject secondary provider API keys so LiteLLM
+            // can route to all configured providers (OpenAI, direct Anthropic).
             ...(useProxy ? [{
               name: "litellm",
               image: config.litellmImage || LITELLM_IMAGE,
@@ -445,6 +447,12 @@ echo "Config initialized"
               env: [
                 ...(config.gcpServiceAccountJson
                   ? [{ name: "GOOGLE_APPLICATION_CREDENTIALS", value: "/home/node/gcp/sa.json" }]
+                  : []),
+                ...(config.openaiApiKey || config.openaiApiKeyRef
+                  ? [{ name: "OPENAI_API_KEY", valueFrom: { secretKeyRef: { name: "openclaw-secrets", key: "OPENAI_API_KEY", optional: true } } }]
+                  : []),
+                ...(config.anthropicApiKey || config.anthropicApiKeyRef
+                  ? [{ name: "ANTHROPIC_API_KEY", valueFrom: { secretKeyRef: { name: "openclaw-secrets", key: "ANTHROPIC_API_KEY", optional: true } } }]
                   : []),
               ],
               volumeMounts: [

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -240,9 +240,10 @@ export function deploymentManifest(
   const useOtelDirect = useOtel && !otelViaOperator;
 
   const optionalKeys = [
-    // Fix for #6: in proxy mode the gateway talks to LiteLLM, not directly
-    // to Anthropic/OpenAI, so don't leak API keys into the gateway env.
-    ...(!useProxy ? ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"] : []),
+    // Gateway always gets provider API keys so it can route to OpenAI/Anthropic
+    // natively. LiteLLM only handles Vertex models.
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
     "MODEL_ENDPOINT",
     "MODEL_ENDPOINT_API_KEY",
     "TELEGRAM_BOT_TOKEN",
@@ -436,9 +437,9 @@ echo "Config initialized"
                 capabilities: { drop: ["ALL"] },
               },
             },
-            // LiteLLM proxy sidecar: holds GCP creds, exposes OpenAI-compatible API
-            // Fix for #78: also inject secondary provider API keys so LiteLLM
-            // can route to all configured providers (OpenAI, direct Anthropic).
+            // LiteLLM proxy sidecar: holds GCP creds, exposes OpenAI-compatible API.
+            // Only handles Vertex models — secondary providers (OpenAI, Anthropic)
+            // are routed directly by the gateway using their native API keys.
             ...(useProxy ? [{
               name: "litellm",
               image: config.litellmImage || LITELLM_IMAGE,
@@ -447,12 +448,6 @@ echo "Config initialized"
               env: [
                 ...(config.gcpServiceAccountJson
                   ? [{ name: "GOOGLE_APPLICATION_CREDENTIALS", value: "/home/node/gcp/sa.json" }]
-                  : []),
-                ...(config.openaiApiKey || config.openaiApiKeyRef
-                  ? [{ name: "OPENAI_API_KEY", valueFrom: { secretKeyRef: { name: "openclaw-secrets", key: "OPENAI_API_KEY", optional: true } } }]
-                  : []),
-                ...(config.anthropicApiKey || config.anthropicApiKeyRef
-                  ? [{ name: "ANTHROPIC_API_KEY", valueFrom: { secretKeyRef: { name: "openclaw-secrets", key: "ANTHROPIC_API_KEY", optional: true } } }]
                   : []),
               ],
               volumeMounts: [

--- a/src/server/deployers/litellm.ts
+++ b/src/server/deployers/litellm.ts
@@ -40,13 +40,17 @@ export function litellmModelString(config: DeployConfig): string {
 
 /**
  * Build model entries for the LiteLLM config based on the Vertex provider.
+ * Fix for #78: also includes secondary provider models when their API keys
+ * are configured, so LiteLLM can route to all configured providers.
  */
 function buildModelList(config: DeployConfig): Array<Record<string, unknown>> {
   const project = config.googleCloudProject || "";
   const location = config.googleCloudLocation || "";
 
+  const models: Array<Record<string, unknown>> = [];
+
   if (config.vertexProvider === "google") {
-    return [
+    models.push(
       {
         model_name: "gemini-2.5-pro",
         litellm_params: {
@@ -63,28 +67,51 @@ function buildModelList(config: DeployConfig): Array<Record<string, unknown>> {
           vertex_location: location,
         },
       },
-    ];
+    );
+  } else {
+    // Anthropic (Claude via Vertex)
+    models.push(
+      {
+        model_name: "claude-sonnet-4-6",
+        litellm_params: {
+          model: "vertex_ai/claude-sonnet-4-6",
+          vertex_project: project,
+          vertex_location: location,
+        },
+      },
+      {
+        model_name: "claude-haiku-4-5",
+        litellm_params: {
+          model: "vertex_ai/claude-haiku-4-5",
+          vertex_project: project,
+          vertex_location: location,
+        },
+      },
+    );
   }
 
-  // Anthropic (Claude via Vertex)
-  return [
-    {
-      model_name: "claude-sonnet-4-6",
-      litellm_params: {
-        model: "vertex_ai/claude-sonnet-4-6",
-        vertex_project: project,
-        vertex_location: location,
-      },
-    },
-    {
-      model_name: "claude-haiku-4-5",
-      litellm_params: {
-        model: "vertex_ai/claude-haiku-4-5",
-        vertex_project: project,
-        vertex_location: location,
-      },
-    },
-  ];
+  // Fix for #78: add secondary provider models when their API keys are configured.
+  // LiteLLM picks up OPENAI_API_KEY / ANTHROPIC_API_KEY from the environment.
+  if (config.openaiApiKey || config.openaiApiKeyRef) {
+    const openaiModel = config.openaiModel?.trim() || "gpt-5.4";
+    if (!models.some((m) => m.model_name === openaiModel)) {
+      models.push({
+        model_name: openaiModel,
+        litellm_params: { model: `openai/${openaiModel}` },
+      });
+    }
+  }
+  if (config.anthropicApiKey || config.anthropicApiKeyRef) {
+    const anthropicModel = config.anthropicModel?.trim() || "claude-sonnet-4-6";
+    if (!models.some((m) => m.model_name === anthropicModel)) {
+      models.push({
+        model_name: anthropicModel,
+        litellm_params: { model: `anthropic/${anthropicModel}` },
+      });
+    }
+  }
+
+  return models;
 }
 
 /**
@@ -117,8 +144,10 @@ export function generateLitellmConfig(config: DeployConfig, masterKey: string): 
     lines.push(`  - model_name: ${m.model_name}`);
     lines.push("    litellm_params:");
     lines.push(`      model: ${params.model}`);
-    lines.push(`      vertex_project: "${params.vertex_project}"`);
-    lines.push(`      vertex_location: "${params.vertex_location}"`);
+    if (params.vertex_project !== undefined) {
+      lines.push(`      vertex_project: "${params.vertex_project}"`);
+      lines.push(`      vertex_location: "${params.vertex_location}"`);
+    }
   }
 
   lines.push("");
@@ -126,4 +155,28 @@ export function generateLitellmConfig(config: DeployConfig, masterKey: string): 
   lines.push(`  master_key: "${masterKey}"`);
 
   return lines.join("\n") + "\n";
+}
+
+/**
+ * Fix for #78: returns env vars that the LiteLLM sidecar needs for
+ * secondary providers (OpenAI, direct Anthropic).  The sidecar picks
+ * these up automatically when routing requests to non-Vertex providers.
+ */
+export function litellmSidecarEnvVars(config: DeployConfig): Record<string, string> {
+  const env: Record<string, string> = {};
+  if (config.openaiApiKey) {
+    env.OPENAI_API_KEY = config.openaiApiKey;
+  }
+  if (config.anthropicApiKey) {
+    env.ANTHROPIC_API_KEY = config.anthropicApiKey;
+  }
+  return env;
+}
+
+/**
+ * Fix for #78: returns all model names registered in LiteLLM, so the
+ * OpenClaw config can list them in the provider's models array.
+ */
+export function litellmRegisteredModelNames(config: DeployConfig): string[] {
+  return buildModelList(config).map((m) => String(m.model_name));
 }

--- a/src/server/deployers/litellm.ts
+++ b/src/server/deployers/litellm.ts
@@ -40,8 +40,8 @@ export function litellmModelString(config: DeployConfig): string {
 
 /**
  * Build model entries for the LiteLLM config based on the Vertex provider.
- * Fix for #78: also includes secondary provider models when their API keys
- * are configured, so LiteLLM can route to all configured providers.
+ * LiteLLM only handles Vertex models — secondary providers (OpenAI, Anthropic)
+ * are routed directly by the gateway using their native API keys.
  */
 function buildModelList(config: DeployConfig): Array<Record<string, unknown>> {
   const project = config.googleCloudProject || "";
@@ -88,27 +88,6 @@ function buildModelList(config: DeployConfig): Array<Record<string, unknown>> {
         },
       },
     );
-  }
-
-  // Fix for #78: add secondary provider models when their API keys are configured.
-  // LiteLLM picks up OPENAI_API_KEY / ANTHROPIC_API_KEY from the environment.
-  if (config.openaiApiKey || config.openaiApiKeyRef) {
-    const openaiModel = config.openaiModel?.trim() || "gpt-5.4";
-    if (!models.some((m) => m.model_name === openaiModel)) {
-      models.push({
-        model_name: openaiModel,
-        litellm_params: { model: `openai/${openaiModel}` },
-      });
-    }
-  }
-  if (config.anthropicApiKey || config.anthropicApiKeyRef) {
-    const anthropicModel = config.anthropicModel?.trim() || "claude-sonnet-4-6";
-    if (!models.some((m) => m.model_name === anthropicModel)) {
-      models.push({
-        model_name: anthropicModel,
-        litellm_params: { model: `anthropic/${anthropicModel}` },
-      });
-    }
   }
 
   return models;
@@ -158,24 +137,8 @@ export function generateLitellmConfig(config: DeployConfig, masterKey: string): 
 }
 
 /**
- * Fix for #78: returns env vars that the LiteLLM sidecar needs for
- * secondary providers (OpenAI, direct Anthropic).  The sidecar picks
- * these up automatically when routing requests to non-Vertex providers.
- */
-export function litellmSidecarEnvVars(config: DeployConfig): Record<string, string> {
-  const env: Record<string, string> = {};
-  if (config.openaiApiKey) {
-    env.OPENAI_API_KEY = config.openaiApiKey;
-  }
-  if (config.anthropicApiKey) {
-    env.ANTHROPIC_API_KEY = config.anthropicApiKey;
-  }
-  return env;
-}
-
-/**
- * Fix for #78: returns all model names registered in LiteLLM, so the
- * OpenClaw config can list them in the provider's models array.
+ * Returns all model names registered in LiteLLM (Vertex models only), so the
+ * OpenClaw config can list them in the litellm provider's models array.
  */
 export function litellmRegisteredModelNames(config: DeployConfig): string[] {
   return buildModelList(config).map((m) => String(m.model_name));

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -27,6 +27,8 @@ import {
   litellmModelName,
   generateLitellmMasterKey,
   generateLitellmConfig,
+  litellmSidecarEnvVars,
+  litellmRegisteredModelNames,
   LITELLM_IMAGE,
   LITELLM_PORT,
 } from "./litellm.js";
@@ -495,15 +497,19 @@ function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string
         }))),
       ],
     },
+    // Fix for #78: register all LiteLLM models (primary + secondary providers)
+    // in the provider listing.  Exclude the primary model since it is already
+    // in agents.defaults.models via buildDefaultAgentModelCatalog, avoiding a
+    // duplicate entry in the UI dropdown.
     ...(shouldUseLitellmProxy(config) ? {
       models: {
         providers: {
           litellm: {
             baseUrl: `http://localhost:${LITELLM_PORT}/v1`,
             api: "openai-completions",
-            models: [
-              { id: litellmModelName(config), name: litellmModelName(config) },
-            ],
+            models: litellmRegisteredModelNames(config)
+              .filter((name) => name !== litellmModelName(config))
+              .map((name) => ({ id: name, name })),
           },
         },
       },
@@ -1140,13 +1146,22 @@ Use this table to track verified peer OpenClaw instances.
           throw new Error("Failed to create pod for sidecars");
         }
 
+        // Fix for #78: build env args for the LiteLLM sidecar, including
+        // secondary provider API keys so it can route to all configured providers.
+        const sidecarEnvArgs: string[] = [
+          "-e", `GOOGLE_APPLICATION_CREDENTIALS=${GCP_SA_CONTAINER_PATH}`,
+        ];
+        for (const [key, val] of Object.entries(litellmSidecarEnvVars(config))) {
+          sidecarEnvArgs.push("-e", `${key}=${val}`);
+        }
+
         // Start LiteLLM in the pod
         const litellmRunResult = await runCommand(runtime, [
           "run", "-d",
           "--name", litellmName,
           "--pod", pod,
           ...localStateMountArgs(config),
-          "-e", `GOOGLE_APPLICATION_CREDENTIALS=${GCP_SA_CONTAINER_PATH}`,
+          ...sidecarEnvArgs,
           litellmImage,
           "--config", LITELLM_CONFIG_PATH, "--port", String(LITELLM_PORT),
         ], log);
@@ -1154,6 +1169,15 @@ Use this table to track verified peer OpenClaw instances.
           throw new Error("Failed to start LiteLLM sidecar");
         }
       } else {
+        // Fix for #78: build env args for the LiteLLM sidecar, including
+        // secondary provider API keys so it can route to all configured providers.
+        const sidecarEnvArgs: string[] = [
+          "-e", `GOOGLE_APPLICATION_CREDENTIALS=${GCP_SA_CONTAINER_PATH}`,
+        ];
+        for (const [key, val] of Object.entries(litellmSidecarEnvVars(config))) {
+          sidecarEnvArgs.push("-e", `${key}=${val}`);
+        }
+
         // Docker: start LiteLLM container, gateway will use --network=container:
         await removeContainer(runtime as ContainerRuntime, litellmName);
         const litellmRunResult = await runCommand(runtime, [
@@ -1162,7 +1186,7 @@ Use this table to track verified peer OpenClaw instances.
           "-p", `${port}:18789`,
           "-p", `${port + 1}:${LITELLM_PORT}`,
           ...localStateMountArgs(config),
-          "-e", `GOOGLE_APPLICATION_CREDENTIALS=${GCP_SA_CONTAINER_PATH}`,
+          ...sidecarEnvArgs,
           litellmImage,
           "--config", LITELLM_CONFIG_PATH, "--port", String(LITELLM_PORT),
         ], log);

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -27,7 +27,6 @@ import {
   litellmModelName,
   generateLitellmMasterKey,
   generateLitellmConfig,
-  litellmSidecarEnvVars,
   litellmRegisteredModelNames,
   LITELLM_IMAGE,
   LITELLM_PORT,
@@ -759,18 +758,16 @@ function buildRunArgs(
     NODE_ENV: "production",
   };
 
-  // Fix for #6: in proxy mode the gateway talks to LiteLLM, not directly
-  // to Anthropic/OpenAI, so don't expose API keys to the gateway.
+  // Pass API keys to the gateway so it can route to OpenAI/Anthropic natively.
+  // LiteLLM only handles Vertex models — secondary providers go direct.
   if (
-    !useProxy
-    && effectiveConfig.anthropicApiKey
+    effectiveConfig.anthropicApiKey
     && (!effectiveConfig.anthropicApiKeyRef || usesDefaultEnvSecretRef(effectiveConfig.anthropicApiKeyRef))
   ) {
     env.ANTHROPIC_API_KEY = effectiveConfig.anthropicApiKey;
   }
   if (
-    !useProxy
-    && effectiveConfig.openaiApiKey
+    effectiveConfig.openaiApiKey
     && (!effectiveConfig.openaiApiKeyRef || usesDefaultEnvSecretRef(effectiveConfig.openaiApiKeyRef))
   ) {
     env.OPENAI_API_KEY = effectiveConfig.openaiApiKey;
@@ -1146,22 +1143,13 @@ Use this table to track verified peer OpenClaw instances.
           throw new Error("Failed to create pod for sidecars");
         }
 
-        // Fix for #78: build env args for the LiteLLM sidecar, including
-        // secondary provider API keys so it can route to all configured providers.
-        const sidecarEnvArgs: string[] = [
-          "-e", `GOOGLE_APPLICATION_CREDENTIALS=${GCP_SA_CONTAINER_PATH}`,
-        ];
-        for (const [key, val] of Object.entries(litellmSidecarEnvVars(config))) {
-          sidecarEnvArgs.push("-e", `${key}=${val}`);
-        }
-
         // Start LiteLLM in the pod
         const litellmRunResult = await runCommand(runtime, [
           "run", "-d",
           "--name", litellmName,
           "--pod", pod,
           ...localStateMountArgs(config),
-          ...sidecarEnvArgs,
+          "-e", `GOOGLE_APPLICATION_CREDENTIALS=${GCP_SA_CONTAINER_PATH}`,
           litellmImage,
           "--config", LITELLM_CONFIG_PATH, "--port", String(LITELLM_PORT),
         ], log);
@@ -1169,15 +1157,6 @@ Use this table to track verified peer OpenClaw instances.
           throw new Error("Failed to start LiteLLM sidecar");
         }
       } else {
-        // Fix for #78: build env args for the LiteLLM sidecar, including
-        // secondary provider API keys so it can route to all configured providers.
-        const sidecarEnvArgs: string[] = [
-          "-e", `GOOGLE_APPLICATION_CREDENTIALS=${GCP_SA_CONTAINER_PATH}`,
-        ];
-        for (const [key, val] of Object.entries(litellmSidecarEnvVars(config))) {
-          sidecarEnvArgs.push("-e", `${key}=${val}`);
-        }
-
         // Docker: start LiteLLM container, gateway will use --network=container:
         await removeContainer(runtime as ContainerRuntime, litellmName);
         const litellmRunResult = await runCommand(runtime, [
@@ -1186,7 +1165,7 @@ Use this table to track verified peer OpenClaw instances.
           "-p", `${port}:18789`,
           "-p", `${port + 1}:${LITELLM_PORT}`,
           ...localStateMountArgs(config),
-          ...sidecarEnvArgs,
+          "-e", `GOOGLE_APPLICATION_CREDENTIALS=${GCP_SA_CONTAINER_PATH}`,
           litellmImage,
           "--config", LITELLM_CONFIG_PATH, "--port", String(LITELLM_PORT),
         ], log);


### PR DESCRIPTION
When deploying with Vertex AI as primary and OpenAI/Anthropic as secondary providers, the LiteLLM proxy sidecar only received GOOGLE_APPLICATION_CREDENTIALS. Secondary provider API keys were never injected, causing requests to those models to hang indefinitely. The models appeared in the UI dropdown but LiteLLM couldn't authenticate with the secondary providers.

Changes:
- litellm.ts: Extended buildModelList() to register secondary provider models (OpenAI, direct Anthropic) in the LiteLLM config when their API keys are configured. Added litellmSidecarEnvVars() and litellmRegisteredModelNames() helpers.
- local.ts: LiteLLM sidecar start (Podman + Docker) now passes OPENAI_API_KEY and ANTHROPIC_API_KEY when configured. Model catalog excludes primary model to fix duplicate dropdown entries.
- k8s-manifests.ts: LiteLLM sidecar container env now includes secondary provider keys via secretKeyRef.
- k8s-helpers.ts: Same model catalog dedup fix as local.ts.
- 20 new regression tests across 3 test files (241 total, all pass).

Fixes #78