### PR TITLE
feat: support multiple models per provider with model discovery (#79)

### DIFF
--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -57,6 +57,12 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
   const [modelEndpointOptions, setModelEndpointOptions] = useState<ModelEndpointOption[]>([]);
   const [loadingModelEndpointOptions, setLoadingModelEndpointOptions] = useState(false);
   const [modelEndpointOptionsError, setModelEndpointOptionsError] = useState<string | null>(null);
+  const [anthropicModelOptions, setAnthropicModelOptions] = useState<ModelEndpointOption[]>([]);
+  const [loadingAnthropicModels, setLoadingAnthropicModels] = useState(false);
+  const [anthropicModelsError, setAnthropicModelsError] = useState<string | null>(null);
+  const [openaiModelOptions, setOpenaiModelOptions] = useState<ModelEndpointOption[]>([]);
+  const [loadingOpenaiModels, setLoadingOpenaiModels] = useState(false);
+  const [openaiModelsError, setOpenaiModelsError] = useState<string | null>(null);
   const previousModelEndpointRef = useRef("");
 
   const isClusterMode = mode === "kubernetes" || mode === "openshift";
@@ -413,6 +419,58 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
       setModelEndpointOptionsError(err instanceof Error ? err.message : "Failed to fetch endpoint models");
     } finally {
       setLoadingModelEndpointOptions(false);
+    }
+  };
+
+  const fetchAnthropicModelOptions = async () => {
+    const apiKey = config.anthropicApiKey.trim();
+    if (!apiKey && !defaults?.hasAnthropicKey) {
+      setAnthropicModelsError("Enter an Anthropic API key first.");
+      return;
+    }
+    setLoadingAnthropicModels(true);
+    setAnthropicModelsError(null);
+    try {
+      const res = await fetch("/api/configs/anthropic-models", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey: apiKey || undefined }),
+      });
+      const data = await res.json() as { models?: ModelEndpointOption[]; error?: string };
+      if (!res.ok) {
+        throw new Error(data.error || `Failed to fetch models (${res.status})`);
+      }
+      setAnthropicModelOptions(Array.isArray(data.models) ? data.models : []);
+    } catch (err) {
+      setAnthropicModelsError(err instanceof Error ? err.message : "Failed to fetch Anthropic models");
+    } finally {
+      setLoadingAnthropicModels(false);
+    }
+  };
+
+  const fetchOpenaiModelOptions = async () => {
+    const apiKey = config.openaiApiKey.trim();
+    if (!apiKey && !defaults?.hasOpenaiKey) {
+      setOpenaiModelsError("Enter an OpenAI API key first.");
+      return;
+    }
+    setLoadingOpenaiModels(true);
+    setOpenaiModelsError(null);
+    try {
+      const res = await fetch("/api/configs/openai-models", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey: apiKey || undefined }),
+      });
+      const data = await res.json() as { models?: ModelEndpointOption[]; error?: string };
+      if (!res.ok) {
+        throw new Error(data.error || `Failed to fetch models (${res.status})`);
+      }
+      setOpenaiModelOptions(Array.isArray(data.models) ? data.models : []);
+    } catch (err) {
+      setOpenaiModelsError(err instanceof Error ? err.message : "Failed to fetch OpenAI models");
+    } finally {
+      setLoadingOpenaiModels(false);
     }
   };
 
@@ -992,6 +1050,14 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
           setConfig={setConfig}
           setInferenceProvider={setInferenceProvider}
           update={update}
+          fetchAnthropicModels={fetchAnthropicModelOptions}
+          fetchOpenaiModels={fetchOpenaiModelOptions}
+          loadingAnthropicModels={loadingAnthropicModels}
+          loadingOpenaiModels={loadingOpenaiModels}
+          anthropicModelOptions={anthropicModelOptions}
+          openaiModelOptions={openaiModelOptions}
+          anthropicModelsError={anthropicModelsError}
+          openaiModelsError={openaiModelsError}
         />
 
         <h3 style={{ marginTop: "1.5rem" }}>Observability</h3>

--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -547,7 +547,7 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
       prevAnthropicKeyRef.current = anthropicKeyForFetch;
       fetchAnthropicModelOptions();
     }
-  }, [anthropicKeyForFetch]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [anthropicKeyForFetch]);
 
   const openaiKeyForFetch = config.openaiApiKey.trim() || (defaults?.hasOpenaiKey ? "__env__" : "");
   const prevOpenaiKeyRef = useRef("");
@@ -556,7 +556,7 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
       prevOpenaiKeyRef.current = openaiKeyForFetch;
       fetchOpenaiModelOptions();
     }
-  }, [openaiKeyForFetch]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [openaiKeyForFetch]);
 
   const vertexCredsForFetch = (config.gcpServiceAccountJson || gcpDefaults?.hasServiceAccountJson ? "has-creds" : "")
     + "|" + (config.googleCloudProject || gcpDefaults?.projectId || "")
@@ -570,7 +570,7 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
       fetchVertexAnthropicModelOptions();
       fetchVertexGoogleModelOptions();
     }
-  }, [vertexCredsForFetch]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [vertexCredsForFetch]);
 
   const handleDeploy = async () => {
     if (!isValid) {
@@ -1140,7 +1140,6 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
           fetchModelEndpointOptions={fetchModelEndpointOptions}
           gcpDefaults={gcpDefaults}
           inferenceProvider={inferenceProvider}
-          isVertex={isVertex}
           loadingModelEndpointOptions={loadingModelEndpointOptions}
           mode={mode}
           modelEndpointOptions={modelEndpointOptions}

--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -63,6 +63,14 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
   const [openaiModelOptions, setOpenaiModelOptions] = useState<ModelEndpointOption[]>([]);
   const [loadingOpenaiModels, setLoadingOpenaiModels] = useState(false);
   const [openaiModelsError, setOpenaiModelsError] = useState<string | null>(null);
+  const [vertexAnthropicModelOptions, setVertexAnthropicModelOptions] = useState<ModelEndpointOption[]>([]);
+  const [loadingVertexAnthropicModels, setLoadingVertexAnthropicModels] = useState(false);
+  const [vertexAnthropicModelsError, setVertexAnthropicModelsError] = useState<string | null>(null);
+  const [vertexAnthropicModelsWarning, setVertexAnthropicModelsWarning] = useState<string | null>(null);
+  const [vertexGoogleModelOptions, setVertexGoogleModelOptions] = useState<ModelEndpointOption[]>([]);
+  const [loadingVertexGoogleModels, setLoadingVertexGoogleModels] = useState(false);
+  const [vertexGoogleModelsError, setVertexGoogleModelsError] = useState<string | null>(null);
+  const [vertexGoogleModelsWarning, setVertexGoogleModelsWarning] = useState<string | null>(null);
   const previousModelEndpointRef = useRef("");
 
   const isClusterMode = mode === "kubernetes" || mode === "openshift";
@@ -471,6 +479,63 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
       setOpenaiModelsError(err instanceof Error ? err.message : "Failed to fetch OpenAI models");
     } finally {
       setLoadingOpenaiModels(false);
+    }
+  };
+
+  const fetchVertexAnthropicModelOptions = async () => {
+    setLoadingVertexAnthropicModels(true);
+    setVertexAnthropicModelsError(null);
+    setVertexAnthropicModelsWarning(null);
+    try {
+      const res = await fetch("/api/configs/vertex-models", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          saJson: config.gcpServiceAccountJson || undefined,
+          project: config.googleCloudProject || undefined,
+          location: config.googleCloudLocation || undefined,
+          vertexProvider: "anthropic",
+          anthropicApiKey: config.anthropicApiKey || undefined,
+        }),
+      });
+      const data = await res.json() as { models?: ModelEndpointOption[]; error?: string; warning?: string };
+      if (!res.ok) {
+        throw new Error(data.error || `Failed to fetch models (${res.status})`);
+      }
+      setVertexAnthropicModelOptions(Array.isArray(data.models) ? data.models : []);
+      if (data.warning) setVertexAnthropicModelsWarning(data.warning);
+    } catch (err) {
+      setVertexAnthropicModelsError(err instanceof Error ? err.message : "Failed to fetch Vertex models");
+    } finally {
+      setLoadingVertexAnthropicModels(false);
+    }
+  };
+
+  const fetchVertexGoogleModelOptions = async () => {
+    setLoadingVertexGoogleModels(true);
+    setVertexGoogleModelsError(null);
+    setVertexGoogleModelsWarning(null);
+    try {
+      const res = await fetch("/api/configs/vertex-models", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          saJson: config.gcpServiceAccountJson || undefined,
+          project: config.googleCloudProject || undefined,
+          location: config.googleCloudLocation || undefined,
+          vertexProvider: "google",
+        }),
+      });
+      const data = await res.json() as { models?: ModelEndpointOption[]; error?: string; warning?: string };
+      if (!res.ok) {
+        throw new Error(data.error || `Failed to fetch models (${res.status})`);
+      }
+      setVertexGoogleModelOptions(Array.isArray(data.models) ? data.models : []);
+      if (data.warning) setVertexGoogleModelsWarning(data.warning);
+    } catch (err) {
+      setVertexGoogleModelsError(err instanceof Error ? err.message : "Failed to fetch Vertex models");
+    } finally {
+      setLoadingVertexGoogleModels(false);
     }
   };
 
@@ -1058,6 +1123,16 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
           openaiModelOptions={openaiModelOptions}
           anthropicModelsError={anthropicModelsError}
           openaiModelsError={openaiModelsError}
+          fetchVertexAnthropicModels={fetchVertexAnthropicModelOptions}
+          loadingVertexAnthropicModels={loadingVertexAnthropicModels}
+          vertexAnthropicModelOptions={vertexAnthropicModelOptions}
+          vertexAnthropicModelsError={vertexAnthropicModelsError}
+          vertexAnthropicModelsWarning={vertexAnthropicModelsWarning}
+          fetchVertexGoogleModels={fetchVertexGoogleModelOptions}
+          loadingVertexGoogleModels={loadingVertexGoogleModels}
+          vertexGoogleModelOptions={vertexGoogleModelOptions}
+          vertexGoogleModelsError={vertexGoogleModelsError}
+          vertexGoogleModelsWarning={vertexGoogleModelsWarning}
         />
 
         <h3 style={{ marginTop: "1.5rem" }}>Observability</h3>

--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -539,6 +539,39 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
     }
   };
 
+  // Auto-fetch model lists when credentials become available
+  const anthropicKeyForFetch = config.anthropicApiKey.trim() || (defaults?.hasAnthropicKey ? "__env__" : "");
+  const prevAnthropicKeyRef = useRef("");
+  useEffect(() => {
+    if (anthropicKeyForFetch && anthropicKeyForFetch !== prevAnthropicKeyRef.current) {
+      prevAnthropicKeyRef.current = anthropicKeyForFetch;
+      fetchAnthropicModelOptions();
+    }
+  }, [anthropicKeyForFetch]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const openaiKeyForFetch = config.openaiApiKey.trim() || (defaults?.hasOpenaiKey ? "__env__" : "");
+  const prevOpenaiKeyRef = useRef("");
+  useEffect(() => {
+    if (openaiKeyForFetch && openaiKeyForFetch !== prevOpenaiKeyRef.current) {
+      prevOpenaiKeyRef.current = openaiKeyForFetch;
+      fetchOpenaiModelOptions();
+    }
+  }, [openaiKeyForFetch]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const vertexCredsForFetch = (config.gcpServiceAccountJson || gcpDefaults?.hasServiceAccountJson ? "has-creds" : "")
+    + "|" + (config.googleCloudProject || gcpDefaults?.projectId || "")
+    + "|" + (config.googleCloudLocation || gcpDefaults?.location || "");
+  const prevVertexCredsRef = useRef("");
+  useEffect(() => {
+    const hasCreds = config.gcpServiceAccountJson || gcpDefaults?.hasServiceAccountJson;
+    const hasProject = config.googleCloudProject || gcpDefaults?.projectId;
+    if (hasCreds && hasProject && vertexCredsForFetch !== prevVertexCredsRef.current) {
+      prevVertexCredsRef.current = vertexCredsForFetch;
+      fetchVertexAnthropicModelOptions();
+      fetchVertexGoogleModelOptions();
+    }
+  }, [vertexCredsForFetch]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleDeploy = async () => {
     if (!isValid) {
       return;
@@ -1115,20 +1148,16 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
           setConfig={setConfig}
           setInferenceProvider={setInferenceProvider}
           update={update}
-          fetchAnthropicModels={fetchAnthropicModelOptions}
-          fetchOpenaiModels={fetchOpenaiModelOptions}
           loadingAnthropicModels={loadingAnthropicModels}
           loadingOpenaiModels={loadingOpenaiModels}
           anthropicModelOptions={anthropicModelOptions}
           openaiModelOptions={openaiModelOptions}
           anthropicModelsError={anthropicModelsError}
           openaiModelsError={openaiModelsError}
-          fetchVertexAnthropicModels={fetchVertexAnthropicModelOptions}
           loadingVertexAnthropicModels={loadingVertexAnthropicModels}
           vertexAnthropicModelOptions={vertexAnthropicModelOptions}
           vertexAnthropicModelsError={vertexAnthropicModelsError}
           vertexAnthropicModelsWarning={vertexAnthropicModelsWarning}
-          fetchVertexGoogleModels={fetchVertexGoogleModelOptions}
           loadingVertexGoogleModels={loadingVertexGoogleModels}
           vertexGoogleModelOptions={vertexGoogleModelOptions}
           vertexGoogleModelsError={vertexGoogleModelsError}

--- a/src/client/components/__tests__/multi-model.test.tsx
+++ b/src/client/components/__tests__/multi-model.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import {
+  createInitialDeployFormConfig,
+  applySavedVarsToConfig,
+  buildDeployRequestBody,
+  buildEnvFileContent,
+} from "../deploy-form/serialization.js";
+
+describe("Multi-model per provider", () => {
+  describe("createInitialDeployFormConfig", () => {
+    it("initializes anthropicModels and openaiModels as empty arrays", () => {
+      const config = createInitialDeployFormConfig();
+      expect(config.anthropicModels).toEqual([]);
+      expect(config.openaiModels).toEqual([]);
+    });
+  });
+
+  describe("buildDeployRequestBody", () => {
+    it("includes anthropicModels when non-empty", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      config.anthropicModels = ["claude-opus-4-6", "claude-haiku-4-5"];
+      const body = buildDeployRequestBody({
+        mode: "local",
+        inferenceProvider: "anthropic",
+        config,
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+      });
+      expect(body.anthropicModels).toEqual(["claude-opus-4-6", "claude-haiku-4-5"]);
+    });
+
+    it("excludes anthropicModels when empty", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      const body = buildDeployRequestBody({
+        mode: "local",
+        inferenceProvider: "anthropic",
+        config,
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+      });
+      expect(body.anthropicModels).toBeUndefined();
+    });
+
+    it("includes openaiModels when non-empty", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      config.openaiModels = ["gpt-5", "gpt-5.3"];
+      const body = buildDeployRequestBody({
+        mode: "local",
+        inferenceProvider: "openai",
+        config,
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+      });
+      expect(body.openaiModels).toEqual(["gpt-5", "gpt-5.3"]);
+    });
+
+    it("excludes openaiModels when empty", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      const body = buildDeployRequestBody({
+        mode: "local",
+        inferenceProvider: "openai",
+        config,
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+      });
+      expect(body.openaiModels).toBeUndefined();
+    });
+  });
+
+  describe("buildEnvFileContent", () => {
+    it("encodes anthropicModels and openaiModels as base64", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      config.anthropicModels = ["claude-opus-4-6"];
+      config.openaiModels = ["gpt-5"];
+      const env = buildEnvFileContent({
+        config,
+        inferenceProvider: "anthropic",
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+      });
+      expect(env).toContain("ANTHROPIC_MODELS_B64=");
+      expect(env).toContain("OPENAI_MODELS_B64=");
+      // Verify the B64 decodes to the expected JSON
+      const anthropicMatch = env.match(/ANTHROPIC_MODELS_B64=(.+)/);
+      expect(anthropicMatch).toBeTruthy();
+      const decoded = JSON.parse(window.atob(anthropicMatch![1]));
+      expect(decoded).toEqual(["claude-opus-4-6"]);
+    });
+  });
+
+  describe("applySavedVarsToConfig (backward compat)", () => {
+    it("loads single-model config without anthropicModels/openaiModels", () => {
+      const prev = createInitialDeployFormConfig();
+      const vars: Record<string, unknown> = {
+        ANTHROPIC_MODEL: "claude-sonnet-4-6",
+        OPENAI_MODEL: "gpt-5",
+      };
+      const { config } = applySavedVarsToConfig(vars, prev);
+      expect(config.anthropicModel).toBe("claude-sonnet-4-6");
+      expect(config.openaiModel).toBe("gpt-5");
+      expect(config.anthropicModels).toEqual([]);
+      expect(config.openaiModels).toEqual([]);
+    });
+
+    it("loads anthropicModels from B64-encoded var", () => {
+      const prev = createInitialDeployFormConfig();
+      const models = ["claude-opus-4-6", "claude-haiku-4-5"];
+      const vars: Record<string, unknown> = {
+        ANTHROPIC_MODELS_B64: window.btoa(JSON.stringify(models)),
+      };
+      const { config } = applySavedVarsToConfig(vars, prev);
+      expect(config.anthropicModels).toEqual(models);
+    });
+
+    it("loads openaiModels from JSON key", () => {
+      const prev = createInitialDeployFormConfig();
+      const models = ["gpt-5", "gpt-5.3"];
+      const vars: Record<string, unknown> = {
+        openaiModels: models,
+      };
+      const { config } = applySavedVarsToConfig(vars, prev);
+      expect(config.openaiModels).toEqual(models);
+    });
+  });
+});

--- a/src/client/components/__tests__/reproduce-issue-23.test.tsx
+++ b/src/client/components/__tests__/reproduce-issue-23.test.tsx
@@ -2,7 +2,10 @@
  * Regression tests for issue #23:
  * "Custom model override carries over across providers"
  *
- * Verifies that switching inference providers clears the custom model field.
+ * Verifies that switching inference providers clears the agentModel field
+ * (used by Vertex/custom-endpoint). Provider-specific fields (anthropicModel,
+ * openaiModel) persist across switches since they may be used as secondary
+ * providers.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
@@ -54,8 +57,8 @@ function getProviderSelect() {
   return screen.getByText("Primary Provider").closest(".form-group")!.querySelector("select")! as HTMLSelectElement;
 }
 
-function getModelInput() {
-  return screen.getByText("Primary Model").closest(".form-group")!.querySelector("input")! as HTMLInputElement;
+function getModelInput(label: string) {
+  return screen.getByText(label).closest(".form-group")!.querySelector("input[type='text']")! as HTMLInputElement;
 }
 
 describe("Issue #23: Custom model override carries over across providers", () => {
@@ -64,65 +67,61 @@ describe("Issue #23: Custom model override carries over across providers", () =>
     vi.restoreAllMocks();
   });
 
-  it("clears agentModel when switching from Anthropic to OpenAI", async () => {
+  it("clears agentModel when switching from Vertex to another provider", async () => {
     global.fetch = mockFetch();
     render(<DeployForm onDeployStarted={() => {}} />);
     await screen.findByText("This Machine");
 
     const providerSelect = getProviderSelect();
-    const modelInput = getModelInput();
 
-    // Set a custom model for Anthropic
-    fireEvent.change(modelInput, { target: { value: "claude-opus-4-6" } });
-    expect(modelInput.value).toBe("claude-opus-4-6");
+    // Switch to Vertex and set a custom model via the Vertex Model field
+    fireEvent.change(providerSelect, { target: { value: "vertex-anthropic" } });
+    const vertexInput = screen.getByPlaceholderText("claude-sonnet-4-6") as HTMLInputElement;
+    fireEvent.change(vertexInput, { target: { value: "claude-opus-4-6" } });
+    expect(vertexInput.value).toBe("claude-opus-4-6");
 
-    // Switch to OpenAI — model should be cleared
+    // Switch to OpenAI — agentModel should be cleared, OpenAI model field starts empty
     fireEvent.change(providerSelect, { target: { value: "openai" } });
     await waitFor(() => {
-      expect(modelInput.value).toBe("");
+      const openaiInput = getModelInput("OpenAI Model");
+      expect(openaiInput.value).toBe("");
     });
   });
 
-  it("clears agentModel when switching from OpenAI to Vertex", async () => {
+  it("clears agentModel when switching between Vertex providers", async () => {
     global.fetch = mockFetch();
     render(<DeployForm onDeployStarted={() => {}} />);
     await screen.findByText("This Machine");
 
     const providerSelect = getProviderSelect();
-    const modelInput = getModelInput();
 
-    // Switch to OpenAI and set a custom model
-    fireEvent.change(providerSelect, { target: { value: "openai" } });
-    fireEvent.change(modelInput, { target: { value: "openai/gpt-5" } });
-    expect(modelInput.value).toBe("openai/gpt-5");
+    // Switch to Vertex Google and set a model
+    fireEvent.change(providerSelect, { target: { value: "vertex-google" } });
+    const vertexInput = screen.getByPlaceholderText("gemini-2.5-pro") as HTMLInputElement;
+    fireEvent.change(vertexInput, { target: { value: "gemini-2.5-flash" } });
+    expect(vertexInput.value).toBe("gemini-2.5-flash");
 
-    // Switch to Vertex Anthropic — model should be cleared
+    // Switch to Vertex Anthropic — agentModel should be cleared
     fireEvent.change(providerSelect, { target: { value: "vertex-anthropic" } });
     await waitFor(() => {
-      expect(modelInput.value).toBe("");
+      const newVertexInput = screen.getByPlaceholderText("claude-sonnet-4-6") as HTMLInputElement;
+      expect(newVertexInput.value).toBe("");
     });
   });
 
-  it("clears agentModel on every consecutive provider switch", async () => {
+  it("OpenAI model field starts empty on first visit", async () => {
     global.fetch = mockFetch();
     render(<DeployForm onDeployStarted={() => {}} />);
     await screen.findByText("This Machine");
 
     const providerSelect = getProviderSelect();
-    const modelInput = getModelInput();
 
-    // Set model, switch, verify cleared — repeat for multiple providers
-    fireEvent.change(modelInput, { target: { value: "model-a" } });
+    // Switch to OpenAI — model field should be empty
     fireEvent.change(providerSelect, { target: { value: "openai" } });
-    await waitFor(() => expect(modelInput.value).toBe(""));
-
-    fireEvent.change(modelInput, { target: { value: "model-b" } });
-    fireEvent.change(providerSelect, { target: { value: "vertex-google" } });
-    await waitFor(() => expect(modelInput.value).toBe(""));
-
-    fireEvent.change(modelInput, { target: { value: "model-c" } });
-    fireEvent.change(providerSelect, { target: { value: "anthropic" } });
-    await waitFor(() => expect(modelInput.value).toBe(""));
+    await waitFor(() => {
+      const openaiInput = getModelInput("OpenAI Model");
+      expect(openaiInput.value).toBe("");
+    });
   });
 
   it("does not interfere when model field is already empty", async () => {
@@ -131,13 +130,14 @@ describe("Issue #23: Custom model override carries over across providers", () =>
     await screen.findByText("This Machine");
 
     const providerSelect = getProviderSelect();
-    const modelInput = getModelInput();
+    const modelInput = getModelInput("Anthropic Model");
 
     // Switch without setting a model — should remain empty
     expect(modelInput.value).toBe("");
     fireEvent.change(providerSelect, { target: { value: "openai" } });
     await waitFor(() => {
-      expect(modelInput.value).toBe("");
+      const openaiInput = getModelInput("OpenAI Model");
+      expect(openaiInput.value).toBe("");
     });
   });
 });

--- a/src/client/components/deploy-form/ProviderSection.tsx
+++ b/src/client/components/deploy-form/ProviderSection.tsx
@@ -25,6 +25,14 @@ interface ProviderSectionProps {
   mode: string;
   modelEndpointOptions: ModelEndpointOption[];
   modelEndpointOptionsError: string | null;
+  fetchAnthropicModels: () => Promise<void>;
+  fetchOpenaiModels: () => Promise<void>;
+  loadingAnthropicModels: boolean;
+  loadingOpenaiModels: boolean;
+  anthropicModelOptions: Array<{ id: string; name: string }>;
+  openaiModelOptions: Array<{ id: string; name: string }>;
+  anthropicModelsError: string | null;
+  openaiModelsError: string | null;
   setConfig: Dispatch<SetStateAction<DeployFormConfig>>;
   setInferenceProvider: Dispatch<SetStateAction<InferenceProvider>>;
   update: (field: string, value: string) => void;
@@ -54,6 +62,14 @@ export function ProviderSection({
   mode,
   modelEndpointOptions,
   modelEndpointOptionsError,
+  fetchAnthropicModels,
+  fetchOpenaiModels,
+  loadingAnthropicModels,
+  loadingOpenaiModels,
+  anthropicModelOptions,
+  openaiModelOptions,
+  anthropicModelsError,
+  openaiModelsError,
   setConfig,
   setInferenceProvider,
   update,
@@ -120,6 +136,94 @@ export function ProviderSection({
                 Adds this Anthropic model to the OpenClaw model picker as <code>anthropic/&lt;model&gt;</code>.
               </div>
             </div>
+            <div className="form-group">
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <label>Additional Models</label>
+                <button
+                  type="button"
+                  className="btn btn-ghost"
+                  style={{ fontSize: "0.8rem", padding: "0.25rem 0.5rem" }}
+                  onClick={fetchAnthropicModels}
+                  disabled={loadingAnthropicModels}
+                >
+                  {loadingAnthropicModels ? "Fetching..." : "Browse Models"}
+                </button>
+              </div>
+              {anthropicModelsError && (
+                <div className="hint" style={{ color: "#e74c3c" }}>{anthropicModelsError}</div>
+              )}
+              {anthropicModelOptions.length > 0 && (
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "200px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
+                  {anthropicModelOptions.map((option) => {
+                    const checked = config.anthropicModels.includes(option.id);
+                    return (
+                      <label key={option.id} style={{ display: "flex", alignItems: "center", gap: "0.5rem", fontSize: "0.85rem", cursor: "pointer" }}>
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => {
+                            setConfig((prev) => ({
+                              ...prev,
+                              anthropicModels: checked
+                                ? prev.anthropicModels.filter((m) => m !== option.id)
+                                : [...prev.anthropicModels, option.id],
+                            }));
+                          }}
+                          style={{ width: "auto" }}
+                        />
+                        <code>{option.id}</code>
+                        {option.name !== option.id && <span style={{ color: "var(--text-secondary)" }}>({option.name})</span>}
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+              {config.anthropicModels.map((modelId, index) => (
+                <div key={index} style={{ display: "flex", gap: "0.5rem", alignItems: "center", marginBottom: "0.25rem" }}>
+                  <input
+                    type="text"
+                    placeholder="e.g., claude-opus-4-6"
+                    value={modelId}
+                    onChange={(e) => {
+                      setConfig((prev) => ({
+                        ...prev,
+                        anthropicModels: prev.anthropicModels.map((m, i) => i === index ? e.target.value : m),
+                      }));
+                    }}
+                    style={{ flex: 1 }}
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-ghost"
+                    style={{ padding: "0.25rem 0.5rem" }}
+                    onClick={() => {
+                      setConfig((prev) => ({
+                        ...prev,
+                        anthropicModels: prev.anthropicModels.filter((_, i) => i !== index),
+                      }));
+                    }}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                className="btn btn-ghost"
+                style={{ fontSize: "0.85rem", padding: "0.25rem 0.5rem", marginTop: "0.25rem" }}
+                onClick={() => {
+                  setConfig((prev) => ({
+                    ...prev,
+                    anthropicModels: [...prev.anthropicModels, ""],
+                  }));
+                }}
+              >
+                + Add Model
+              </button>
+              <div className="hint">
+                Additional models appear in the OpenClaw model picker as <code>anthropic/&lt;model&gt;</code>.
+              </div>
+            </div>
           </>
         );
 
@@ -151,6 +255,93 @@ export function ProviderSection({
               />
               <div className="hint">
                 Adds this OpenAI model to the OpenClaw model picker as <code>openai/&lt;model&gt;</code>.
+              </div>
+            </div>
+            <div className="form-group">
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <label>Additional Models</label>
+                <button
+                  type="button"
+                  className="btn btn-ghost"
+                  style={{ fontSize: "0.8rem", padding: "0.25rem 0.5rem" }}
+                  onClick={fetchOpenaiModels}
+                  disabled={loadingOpenaiModels}
+                >
+                  {loadingOpenaiModels ? "Fetching..." : "Browse Models"}
+                </button>
+              </div>
+              {openaiModelsError && (
+                <div className="hint" style={{ color: "#e74c3c" }}>{openaiModelsError}</div>
+              )}
+              {openaiModelOptions.length > 0 && (
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "200px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
+                  {openaiModelOptions.map((option) => {
+                    const checked = config.openaiModels.includes(option.id);
+                    return (
+                      <label key={option.id} style={{ display: "flex", alignItems: "center", gap: "0.5rem", fontSize: "0.85rem", cursor: "pointer" }}>
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => {
+                            setConfig((prev) => ({
+                              ...prev,
+                              openaiModels: checked
+                                ? prev.openaiModels.filter((m) => m !== option.id)
+                                : [...prev.openaiModels, option.id],
+                            }));
+                          }}
+                          style={{ width: "auto" }}
+                        />
+                        <code>{option.id}</code>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+              {config.openaiModels.map((modelId, index) => (
+                <div key={index} style={{ display: "flex", gap: "0.5rem", alignItems: "center", marginBottom: "0.25rem" }}>
+                  <input
+                    type="text"
+                    placeholder="e.g., gpt-5.3"
+                    value={modelId}
+                    onChange={(e) => {
+                      setConfig((prev) => ({
+                        ...prev,
+                        openaiModels: prev.openaiModels.map((m, i) => i === index ? e.target.value : m),
+                      }));
+                    }}
+                    style={{ flex: 1 }}
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-ghost"
+                    style={{ padding: "0.25rem 0.5rem" }}
+                    onClick={() => {
+                      setConfig((prev) => ({
+                        ...prev,
+                        openaiModels: prev.openaiModels.filter((_, i) => i !== index),
+                      }));
+                    }}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                className="btn btn-ghost"
+                style={{ fontSize: "0.85rem", padding: "0.25rem 0.5rem", marginTop: "0.25rem" }}
+                onClick={() => {
+                  setConfig((prev) => ({
+                    ...prev,
+                    openaiModels: [...prev.openaiModels, ""],
+                  }));
+                }}
+              >
+                + Add Model
+              </button>
+              <div className="hint">
+                Additional models appear in the OpenClaw model picker as <code>openai/&lt;model&gt;</code>.
               </div>
             </div>
           </>

--- a/src/client/components/deploy-form/ProviderSection.tsx
+++ b/src/client/components/deploy-form/ProviderSection.tsx
@@ -4,7 +4,6 @@ import {
   MODEL_DEFAULTS,
   MODEL_HINTS,
   PROVIDER_OPTIONS,
-  PROXY_MODEL_HINTS,
 } from "./constants.js";
 import type {
   DeployFormConfig,
@@ -20,7 +19,6 @@ interface ProviderSectionProps {
   fetchModelEndpointOptions: () => Promise<void>;
   gcpDefaults: GcpDefaults | null;
   inferenceProvider: InferenceProvider;
-  isVertex: boolean;
   loadingModelEndpointOptions: boolean;
   mode: string;
   modelEndpointOptions: ModelEndpointOption[];
@@ -63,7 +61,6 @@ export function ProviderSection({
   fetchModelEndpointOptions,
   gcpDefaults,
   inferenceProvider,
-  isVertex,
   loadingModelEndpointOptions,
   mode,
   modelEndpointOptions,

--- a/src/client/components/deploy-form/ProviderSection.tsx
+++ b/src/client/components/deploy-form/ProviderSection.tsx
@@ -25,20 +25,16 @@ interface ProviderSectionProps {
   mode: string;
   modelEndpointOptions: ModelEndpointOption[];
   modelEndpointOptionsError: string | null;
-  fetchAnthropicModels: () => Promise<void>;
-  fetchOpenaiModels: () => Promise<void>;
   loadingAnthropicModels: boolean;
   loadingOpenaiModels: boolean;
   anthropicModelOptions: Array<{ id: string; name: string }>;
   openaiModelOptions: Array<{ id: string; name: string }>;
   anthropicModelsError: string | null;
   openaiModelsError: string | null;
-  fetchVertexAnthropicModels: () => Promise<void>;
   loadingVertexAnthropicModels: boolean;
   vertexAnthropicModelOptions: Array<{ id: string; name: string }>;
   vertexAnthropicModelsError: string | null;
   vertexAnthropicModelsWarning: string | null;
-  fetchVertexGoogleModels: () => Promise<void>;
   loadingVertexGoogleModels: boolean;
   vertexGoogleModelOptions: Array<{ id: string; name: string }>;
   vertexGoogleModelsError: string | null;
@@ -72,20 +68,16 @@ export function ProviderSection({
   mode,
   modelEndpointOptions,
   modelEndpointOptionsError,
-  fetchAnthropicModels,
-  fetchOpenaiModels,
   loadingAnthropicModels,
   loadingOpenaiModels,
   anthropicModelOptions,
   openaiModelOptions,
   anthropicModelsError,
   openaiModelsError,
-  fetchVertexAnthropicModels,
   loadingVertexAnthropicModels,
   vertexAnthropicModelOptions,
   vertexAnthropicModelsError,
   vertexAnthropicModelsWarning,
-  fetchVertexGoogleModels,
   loadingVertexGoogleModels,
   vertexGoogleModelOptions,
   vertexGoogleModelsError,
@@ -145,23 +137,15 @@ export function ProviderSection({
               </div>
             </div>
             <div className="form-group">
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                <label>Anthropic Model</label>
-                <button
-                  type="button"
-                  className="btn btn-ghost"
-                  style={{ fontSize: "0.8rem", padding: "0.25rem 0.5rem" }}
-                  onClick={fetchAnthropicModels}
-                  disabled={loadingAnthropicModels}
-                >
-                  {loadingAnthropicModels ? "Fetching..." : "Browse Models"}
-                </button>
-              </div>
+              <label>Anthropic Model</label>
+              {loadingAnthropicModels && (
+                <div className="hint">Loading models...</div>
+              )}
               {anthropicModelsError && (
                 <div className="hint" style={{ color: "#e74c3c" }}>{anthropicModelsError}</div>
               )}
               {anthropicModelOptions.length > 0 && (
-                <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "200px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "150px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
                   {anthropicModelOptions.map((option) => {
                     const isSelected = config.anthropicModel === option.id || config.anthropicModels.includes(option.id);
                     return (
@@ -276,23 +260,15 @@ export function ProviderSection({
               </div>
             </div>
             <div className="form-group">
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                <label>OpenAI Model</label>
-                <button
-                  type="button"
-                  className="btn btn-ghost"
-                  style={{ fontSize: "0.8rem", padding: "0.25rem 0.5rem" }}
-                  onClick={fetchOpenaiModels}
-                  disabled={loadingOpenaiModels}
-                >
-                  {loadingOpenaiModels ? "Fetching..." : "Browse Models"}
-                </button>
-              </div>
+              <label>OpenAI Model</label>
+              {loadingOpenaiModels && (
+                <div className="hint">Loading models...</div>
+              )}
               {openaiModelsError && (
                 <div className="hint" style={{ color: "#e74c3c" }}>{openaiModelsError}</div>
               )}
               {openaiModelOptions.length > 0 && (
-                <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "200px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "150px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
                   {openaiModelOptions.map((option) => {
                     const isSelected = config.openaiModel === option.id || config.openaiModels.includes(option.id);
                     return (
@@ -534,7 +510,6 @@ export function ProviderSection({
               const modelsValue = isVertexAnthropic ? config.vertexAnthropicModels : config.vertexGoogleModels;
               const placeholder = isVertexAnthropic ? "claude-sonnet-4-6" : "gemini-2.5-pro";
               const addPlaceholder = isVertexAnthropic ? "e.g., claude-opus-4-6" : "e.g., gemini-2.5-flash";
-              const fetchFn = isVertexAnthropic ? fetchVertexAnthropicModels : fetchVertexGoogleModels;
               const loading = isVertexAnthropic ? loadingVertexAnthropicModels : loadingVertexGoogleModels;
               const options = isVertexAnthropic ? vertexAnthropicModelOptions : vertexGoogleModelOptions;
               const error = isVertexAnthropic ? vertexAnthropicModelsError : vertexGoogleModelsError;
@@ -542,18 +517,10 @@ export function ProviderSection({
               return (
                 <>
                   <div className="form-group">
-                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                      <label>Model</label>
-                      <button
-                        type="button"
-                        className="btn btn-ghost"
-                        style={{ fontSize: "0.8rem", padding: "0.25rem 0.5rem" }}
-                        onClick={fetchFn}
-                        disabled={loading}
-                      >
-                        {loading ? "Fetching..." : "Browse Models"}
-                      </button>
-                    </div>
+                    <label>Model</label>
+                    {loading && (
+                      <div className="hint">Loading models...</div>
+                    )}
                     {error && (
                       <div className="hint" style={{ color: "#e74c3c" }}>{error}</div>
                     )}
@@ -561,7 +528,7 @@ export function ProviderSection({
                       <div className="hint">{warning}</div>
                     )}
                     {options.length > 0 && (
-                      <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "200px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
+                      <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "150px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
                         {options.map((option) => {
                           const isSelected = modelValue === option.id || modelsValue.includes(option.id);
                           return (

--- a/src/client/components/deploy-form/ProviderSection.tsx
+++ b/src/client/components/deploy-form/ProviderSection.tsx
@@ -33,6 +33,16 @@ interface ProviderSectionProps {
   openaiModelOptions: Array<{ id: string; name: string }>;
   anthropicModelsError: string | null;
   openaiModelsError: string | null;
+  fetchVertexAnthropicModels: () => Promise<void>;
+  loadingVertexAnthropicModels: boolean;
+  vertexAnthropicModelOptions: Array<{ id: string; name: string }>;
+  vertexAnthropicModelsError: string | null;
+  vertexAnthropicModelsWarning: string | null;
+  fetchVertexGoogleModels: () => Promise<void>;
+  loadingVertexGoogleModels: boolean;
+  vertexGoogleModelOptions: Array<{ id: string; name: string }>;
+  vertexGoogleModelsError: string | null;
+  vertexGoogleModelsWarning: string | null;
   setConfig: Dispatch<SetStateAction<DeployFormConfig>>;
   setInferenceProvider: Dispatch<SetStateAction<InferenceProvider>>;
   update: (field: string, value: string) => void;
@@ -70,6 +80,16 @@ export function ProviderSection({
   openaiModelOptions,
   anthropicModelsError,
   openaiModelsError,
+  fetchVertexAnthropicModels,
+  loadingVertexAnthropicModels,
+  vertexAnthropicModelOptions,
+  vertexAnthropicModelsError,
+  vertexAnthropicModelsWarning,
+  fetchVertexGoogleModels,
+  loadingVertexGoogleModels,
+  vertexGoogleModelOptions,
+  vertexGoogleModelsError,
+  vertexGoogleModelsWarning,
   setConfig,
   setInferenceProvider,
   update,
@@ -125,20 +145,8 @@ export function ProviderSection({
               </div>
             </div>
             <div className="form-group">
-              <label>Anthropic Model</label>
-              <input
-                type="text"
-                placeholder="e.g., claude-sonnet-4-6"
-                value={config.anthropicModel}
-                onChange={(e) => update("anthropicModel", e.target.value)}
-              />
-              <div className="hint">
-                Adds this Anthropic model to the OpenClaw model picker as <code>anthropic/&lt;model&gt;</code>.
-              </div>
-            </div>
-            <div className="form-group">
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                <label>Additional Models</label>
+                <label>Anthropic Model</label>
                 <button
                   type="button"
                   className="btn btn-ghost"
@@ -155,29 +163,50 @@ export function ProviderSection({
               {anthropicModelOptions.length > 0 && (
                 <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "200px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
                   {anthropicModelOptions.map((option) => {
-                    const checked = config.anthropicModels.includes(option.id);
+                    const isSelected = config.anthropicModel === option.id || config.anthropicModels.includes(option.id);
                     return (
                       <label key={option.id} style={{ display: "flex", alignItems: "center", gap: "0.5rem", fontSize: "0.85rem", cursor: "pointer" }}>
                         <input
                           type="checkbox"
-                          checked={checked}
+                          checked={isSelected}
                           onChange={() => {
-                            setConfig((prev) => ({
-                              ...prev,
-                              anthropicModels: checked
-                                ? prev.anthropicModels.filter((m) => m !== option.id)
-                                : [...prev.anthropicModels, option.id],
-                            }));
+                            setConfig((prev) => {
+                              if (isSelected) {
+                                // Unchecking: remove from primary or additional
+                                if (prev.anthropicModel === option.id) {
+                                  return { ...prev, anthropicModel: "" };
+                                }
+                                return { ...prev, anthropicModels: prev.anthropicModels.filter((m) => m !== option.id) };
+                              }
+                              // Checking: if no primary set, use as primary; otherwise add to additional
+                              if (!prev.anthropicModel.trim()) {
+                                return { ...prev, anthropicModel: option.id };
+                              }
+                              return { ...prev, anthropicModels: [...prev.anthropicModels, option.id] };
+                            });
                           }}
                           style={{ width: "auto" }}
                         />
                         <code>{option.id}</code>
                         {option.name !== option.id && <span style={{ color: "var(--text-secondary)" }}>({option.name})</span>}
+                        {config.anthropicModel === option.id && <span style={{ color: "var(--text-secondary)", fontStyle: "italic" }}>(primary)</span>}
                       </label>
                     );
                   })}
                 </div>
               )}
+              <input
+                type="text"
+                placeholder="e.g., claude-sonnet-4-6"
+                value={config.anthropicModel}
+                onChange={(e) => update("anthropicModel", e.target.value)}
+              />
+              <div className="hint">
+                Primary model used as the default in the OpenClaw model picker as <code>anthropic/&lt;model&gt;</code>.
+              </div>
+            </div>
+            <div className="form-group">
+              <label>Additional Models</label>
               {config.anthropicModels.map((modelId, index) => (
                 <div key={index} style={{ display: "flex", gap: "0.5rem", alignItems: "center", marginBottom: "0.25rem" }}>
                   <input
@@ -211,6 +240,7 @@ export function ProviderSection({
                 type="button"
                 className="btn btn-ghost"
                 style={{ fontSize: "0.85rem", padding: "0.25rem 0.5rem", marginTop: "0.25rem" }}
+                disabled={!config.anthropicModel.trim()}
                 onClick={() => {
                   setConfig((prev) => ({
                     ...prev,
@@ -246,20 +276,8 @@ export function ProviderSection({
               </div>
             </div>
             <div className="form-group">
-              <label>OpenAI Model</label>
-              <input
-                type="text"
-                placeholder="e.g., gpt-5"
-                value={config.openaiModel}
-                onChange={(e) => update("openaiModel", e.target.value)}
-              />
-              <div className="hint">
-                Adds this OpenAI model to the OpenClaw model picker as <code>openai/&lt;model&gt;</code>.
-              </div>
-            </div>
-            <div className="form-group">
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                <label>Additional Models</label>
+                <label>OpenAI Model</label>
                 <button
                   type="button"
                   className="btn btn-ghost"
@@ -276,28 +294,47 @@ export function ProviderSection({
               {openaiModelOptions.length > 0 && (
                 <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "200px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
                   {openaiModelOptions.map((option) => {
-                    const checked = config.openaiModels.includes(option.id);
+                    const isSelected = config.openaiModel === option.id || config.openaiModels.includes(option.id);
                     return (
                       <label key={option.id} style={{ display: "flex", alignItems: "center", gap: "0.5rem", fontSize: "0.85rem", cursor: "pointer" }}>
                         <input
                           type="checkbox"
-                          checked={checked}
+                          checked={isSelected}
                           onChange={() => {
-                            setConfig((prev) => ({
-                              ...prev,
-                              openaiModels: checked
-                                ? prev.openaiModels.filter((m) => m !== option.id)
-                                : [...prev.openaiModels, option.id],
-                            }));
+                            setConfig((prev) => {
+                              if (isSelected) {
+                                if (prev.openaiModel === option.id) {
+                                  return { ...prev, openaiModel: "" };
+                                }
+                                return { ...prev, openaiModels: prev.openaiModels.filter((m) => m !== option.id) };
+                              }
+                              if (!prev.openaiModel.trim()) {
+                                return { ...prev, openaiModel: option.id };
+                              }
+                              return { ...prev, openaiModels: [...prev.openaiModels, option.id] };
+                            });
                           }}
                           style={{ width: "auto" }}
                         />
                         <code>{option.id}</code>
+                        {config.openaiModel === option.id && <span style={{ color: "var(--text-secondary)", fontStyle: "italic" }}>(primary)</span>}
                       </label>
                     );
                   })}
                 </div>
               )}
+              <input
+                type="text"
+                placeholder="e.g., gpt-5"
+                value={config.openaiModel}
+                onChange={(e) => update("openaiModel", e.target.value)}
+              />
+              <div className="hint">
+                Primary model used as the default in the OpenClaw model picker as <code>openai/&lt;model&gt;</code>.
+              </div>
+            </div>
+            <div className="form-group">
+              <label>Additional Models</label>
               {config.openaiModels.map((modelId, index) => (
                 <div key={index} style={{ display: "flex", gap: "0.5rem", alignItems: "center", marginBottom: "0.25rem" }}>
                   <input
@@ -331,6 +368,7 @@ export function ProviderSection({
                 type="button"
                 className="btn btn-ghost"
                 style={{ fontSize: "0.85rem", padding: "0.25rem 0.5rem", marginTop: "0.25rem" }}
+                disabled={!config.openaiModel.trim()}
                 onClick={() => {
                   setConfig((prev) => ({
                     ...prev,
@@ -487,6 +525,138 @@ export function ProviderSection({
                   && " Leave blank to use credentials detected from environment."}
               </div>
             </div>
+
+            {(() => {
+              const isVertexAnthropic = provider === "vertex-anthropic";
+              const modelField = isVertexAnthropic ? "vertexAnthropicModel" : "vertexGoogleModel";
+              const modelsField = isVertexAnthropic ? "vertexAnthropicModels" : "vertexGoogleModels";
+              const modelValue = isVertexAnthropic ? config.vertexAnthropicModel : config.vertexGoogleModel;
+              const modelsValue = isVertexAnthropic ? config.vertexAnthropicModels : config.vertexGoogleModels;
+              const placeholder = isVertexAnthropic ? "claude-sonnet-4-6" : "gemini-2.5-pro";
+              const addPlaceholder = isVertexAnthropic ? "e.g., claude-opus-4-6" : "e.g., gemini-2.5-flash";
+              const fetchFn = isVertexAnthropic ? fetchVertexAnthropicModels : fetchVertexGoogleModels;
+              const loading = isVertexAnthropic ? loadingVertexAnthropicModels : loadingVertexGoogleModels;
+              const options = isVertexAnthropic ? vertexAnthropicModelOptions : vertexGoogleModelOptions;
+              const error = isVertexAnthropic ? vertexAnthropicModelsError : vertexGoogleModelsError;
+              const warning = isVertexAnthropic ? vertexAnthropicModelsWarning : vertexGoogleModelsWarning;
+              return (
+                <>
+                  <div className="form-group">
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                      <label>Model</label>
+                      <button
+                        type="button"
+                        className="btn btn-ghost"
+                        style={{ fontSize: "0.8rem", padding: "0.25rem 0.5rem" }}
+                        onClick={fetchFn}
+                        disabled={loading}
+                      >
+                        {loading ? "Fetching..." : "Browse Models"}
+                      </button>
+                    </div>
+                    {error && (
+                      <div className="hint" style={{ color: "#e74c3c" }}>{error}</div>
+                    )}
+                    {warning && !error && (
+                      <div className="hint">{warning}</div>
+                    )}
+                    {options.length > 0 && (
+                      <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "200px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
+                        {options.map((option) => {
+                          const isSelected = modelValue === option.id || modelsValue.includes(option.id);
+                          return (
+                            <label key={option.id} style={{ display: "flex", alignItems: "center", gap: "0.5rem", fontSize: "0.85rem", cursor: "pointer" }}>
+                              <input
+                                type="checkbox"
+                                checked={isSelected}
+                                onChange={() => {
+                                  setConfig((prev) => {
+                                    const prevModel = prev[modelField] as string;
+                                    const prevModels = prev[modelsField] as string[];
+                                    if (isSelected) {
+                                      if (prevModel === option.id) {
+                                        return { ...prev, [modelField]: "" };
+                                      }
+                                      return { ...prev, [modelsField]: prevModels.filter((m) => m !== option.id) };
+                                    }
+                                    if (!prevModel.trim()) {
+                                      return { ...prev, [modelField]: option.id };
+                                    }
+                                    return { ...prev, [modelsField]: [...prevModels, option.id] };
+                                  });
+                                }}
+                                style={{ width: "auto" }}
+                              />
+                              <code>{option.id}</code>
+                              {option.name !== option.id && <span style={{ color: "var(--text-secondary)" }}>({option.name})</span>}
+                              {modelValue === option.id && <span style={{ color: "var(--text-secondary)", fontStyle: "italic" }}>(primary)</span>}
+                            </label>
+                          );
+                        })}
+                      </div>
+                    )}
+                    <input
+                      type="text"
+                      placeholder={placeholder}
+                      value={modelValue}
+                      onChange={(e) => update(modelField, e.target.value)}
+                    />
+                    <div className="hint">
+                      Primary model used as the default in the OpenClaw model picker.
+                    </div>
+                  </div>
+                  <div className="form-group">
+                    <label>Additional Models</label>
+                    {modelsValue.map((modelId, index) => (
+                      <div key={index} style={{ display: "flex", gap: "0.5rem", alignItems: "center", marginBottom: "0.25rem" }}>
+                        <input
+                          type="text"
+                          placeholder={addPlaceholder}
+                          value={modelId}
+                          onChange={(e) => {
+                            setConfig((prev) => ({
+                              ...prev,
+                              [modelsField]: (prev[modelsField] as string[]).map((m, i) => i === index ? e.target.value : m),
+                            }));
+                          }}
+                          style={{ flex: 1 }}
+                        />
+                        <button
+                          type="button"
+                          className="btn btn-ghost"
+                          style={{ padding: "0.25rem 0.5rem" }}
+                          onClick={() => {
+                            setConfig((prev) => ({
+                              ...prev,
+                              [modelsField]: (prev[modelsField] as string[]).filter((_, i) => i !== index),
+                            }));
+                          }}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      className="btn btn-ghost"
+                      style={{ fontSize: "0.85rem", padding: "0.25rem 0.5rem", marginTop: "0.25rem" }}
+                      disabled={!modelValue.trim()}
+                      onClick={() => {
+                        setConfig((prev) => ({
+                          ...prev,
+                          [modelsField]: [...(prev[modelsField] as string[]), ""],
+                        }));
+                      }}
+                    >
+                      + Add Model
+                    </button>
+                    <div className="hint">
+                      Additional models appear in the OpenClaw model picker.
+                    </div>
+                  </div>
+                </>
+              );
+            })()}
 
             <div className="form-group">
               <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
@@ -650,26 +820,23 @@ export function ProviderSection({
           </div>
         </div>
 
-        <div className="form-group" style={{ marginTop: "0.75rem" }}>
-          <label>Primary Model</label>
-          <input
-            type="text"
-            placeholder={
-              isVertex && config.litellmProxy
-                ? (inferenceProvider === "vertex-anthropic" ? "claude-sonnet-4-6" : "gemini-2.5-pro")
-                : (MODEL_DEFAULTS[inferenceProvider] || "model-id")
-            }
-            value={config.agentModel}
-            onChange={(e) => update("agentModel", e.target.value)}
-          />
-          <div className="hint">
-            {config.agentModel
-              ? "Custom primary model override"
-              : isVertex && config.litellmProxy
-                ? `Leave blank for default (routed through LiteLLM proxy). ${PROXY_MODEL_HINTS[inferenceProvider] || MODEL_HINTS[inferenceProvider]}`
+        {/* Show Primary Model field for custom endpoint only — Anthropic/OpenAI/Vertex have their own model fields */}
+        {inferenceProvider === "custom-endpoint" && (
+          <div className="form-group" style={{ marginTop: "0.75rem" }}>
+            <label>Primary Model</label>
+            <input
+              type="text"
+              placeholder={MODEL_DEFAULTS[inferenceProvider] || "model-id"}
+              value={config.agentModel}
+              onChange={(e) => update("agentModel", e.target.value)}
+            />
+            <div className="hint">
+              {config.agentModel
+                ? "Custom primary model override"
                 : `Leave blank for default${MODEL_DEFAULTS[inferenceProvider] ? ` (${MODEL_DEFAULTS[inferenceProvider]})` : ""}. ${MODEL_HINTS[inferenceProvider]}`}
+            </div>
           </div>
-        </div>
+        )}
 
         <div className="form-group" style={{ marginTop: "0.75rem" }}>
           <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>

--- a/src/client/components/deploy-form/serialization.ts
+++ b/src/client/components/deploy-form/serialization.ts
@@ -53,6 +53,8 @@ export function createInitialDeployFormConfig(): DeployFormConfig {
     openaiApiKey: "",
     anthropicModel: "",
     openaiModel: "",
+    anthropicModels: [],
+    openaiModels: [],
     agentModel: "",
     openaiCompatibleEndpointsEnabled: true,
     modelEndpoint: "",
@@ -107,6 +109,12 @@ function decodeEndpointModelsVar(vars: Record<string, unknown>): ModelEndpointOp
   return Array.isArray(vars.modelEndpointModels)
     ? (vars.modelEndpointModels as ModelEndpointOption[])
     : undefined;
+}
+
+function decodeStringArrayVar(vars: Record<string, unknown>, b64Key: string, jsonKey: string): string[] | undefined {
+  const decoded = decodeJsonBase64<string[]>(vars[b64Key] as string | undefined);
+  if (decoded && Array.isArray(decoded)) return decoded;
+  return Array.isArray(vars[jsonKey]) ? (vars[jsonKey] as string[]) : undefined;
 }
 
 function decodeSecretsProvidersJson(vars: Record<string, unknown>): string {
@@ -253,6 +261,10 @@ export function applySavedVarsToConfig(
       port: getStringVar(vars, "OPENCLAW_PORT", "port") || prev.port,
       anthropicModel: getStringVar(vars, "ANTHROPIC_MODEL", "anthropicModel") || prev.anthropicModel,
       openaiModel: getStringVar(vars, "OPENAI_MODEL", "openaiModel") || prev.openaiModel,
+      anthropicModels:
+        decodeStringArrayVar(vars, "ANTHROPIC_MODELS_B64", "anthropicModels") || prev.anthropicModels,
+      openaiModels:
+        decodeStringArrayVar(vars, "OPENAI_MODELS_B64", "openaiModels") || prev.openaiModels,
       agentModel: getStringVar(vars, "AGENT_MODEL", "agentModel") || prev.agentModel,
       openaiCompatibleEndpointsEnabled:
         vars.OPENAI_COMPATIBLE_ENDPOINTS_ENABLED === "false"
@@ -364,7 +376,9 @@ export function buildDeployRequestBody(params: {
     anthropicApiKey: !anthropicApiKeyRef ? trimToUndefined(config.anthropicApiKey) : undefined,
     openaiApiKey: !openaiApiKeyRef ? trimToUndefined(config.openaiApiKey) : undefined,
     anthropicModel: trimToUndefined(config.anthropicModel),
+    anthropicModels: config.anthropicModels.length > 0 ? config.anthropicModels : undefined,
     openaiModel: trimToUndefined(config.openaiModel),
+    openaiModels: config.openaiModels.length > 0 ? config.openaiModels : undefined,
     agentModel: config.agentModel || undefined,
     openaiCompatibleEndpointsEnabled: config.openaiCompatibleEndpointsEnabled,
     modelEndpoint: trimToUndefined(config.modelEndpoint),
@@ -433,7 +447,9 @@ export function buildEnvFileContent(params: {
     `ANTHROPIC_API_KEY=${anthropicApiKeyRef ? "" : config.anthropicApiKey}`,
     `OPENAI_API_KEY=${openaiApiKeyRef ? "" : config.openaiApiKey}`,
     `ANTHROPIC_MODEL=${config.anthropicModel}`,
+    `ANTHROPIC_MODELS_B64=${encodeBase64(JSON.stringify(config.anthropicModels))}`,
     `OPENAI_MODEL=${config.openaiModel}`,
+    `OPENAI_MODELS_B64=${encodeBase64(JSON.stringify(config.openaiModels))}`,
     `OPENAI_COMPATIBLE_ENDPOINTS_ENABLED=${config.openaiCompatibleEndpointsEnabled}`,
     `MODEL_ENDPOINT=${config.modelEndpoint}`,
     `MODEL_ENDPOINT_API_KEY=${config.modelEndpointApiKey}`,

--- a/src/client/components/deploy-form/serialization.ts
+++ b/src/client/components/deploy-form/serialization.ts
@@ -56,6 +56,10 @@ export function createInitialDeployFormConfig(): DeployFormConfig {
     anthropicModels: [],
     openaiModels: [],
     agentModel: "",
+    vertexAnthropicModel: "",
+    vertexAnthropicModels: [],
+    vertexGoogleModel: "",
+    vertexGoogleModels: [],
     openaiCompatibleEndpointsEnabled: true,
     modelEndpoint: "",
     modelEndpointApiKey: "",
@@ -266,6 +270,12 @@ export function applySavedVarsToConfig(
       openaiModels:
         decodeStringArrayVar(vars, "OPENAI_MODELS_B64", "openaiModels") || prev.openaiModels,
       agentModel: getStringVar(vars, "AGENT_MODEL", "agentModel") || prev.agentModel,
+      vertexAnthropicModel: getStringVar(vars, "VERTEX_ANTHROPIC_MODEL", "vertexAnthropicModel") || prev.vertexAnthropicModel,
+      vertexAnthropicModels:
+        decodeStringArrayVar(vars, "VERTEX_ANTHROPIC_MODELS_B64", "vertexAnthropicModels") || prev.vertexAnthropicModels,
+      vertexGoogleModel: getStringVar(vars, "VERTEX_GOOGLE_MODEL", "vertexGoogleModel") || prev.vertexGoogleModel,
+      vertexGoogleModels:
+        decodeStringArrayVar(vars, "VERTEX_GOOGLE_MODELS_B64", "vertexGoogleModels") || prev.vertexGoogleModels,
       openaiCompatibleEndpointsEnabled:
         vars.OPENAI_COMPATIBLE_ENDPOINTS_ENABLED === "false"
           ? false
@@ -380,6 +390,10 @@ export function buildDeployRequestBody(params: {
     openaiModel: trimToUndefined(config.openaiModel),
     openaiModels: config.openaiModels.length > 0 ? config.openaiModels : undefined,
     agentModel: config.agentModel || undefined,
+    vertexAnthropicModel: trimToUndefined(config.vertexAnthropicModel),
+    vertexAnthropicModels: config.vertexAnthropicModels.length > 0 ? config.vertexAnthropicModels : undefined,
+    vertexGoogleModel: trimToUndefined(config.vertexGoogleModel),
+    vertexGoogleModels: config.vertexGoogleModels.length > 0 ? config.vertexGoogleModels : undefined,
     openaiCompatibleEndpointsEnabled: config.openaiCompatibleEndpointsEnabled,
     modelEndpoint: trimToUndefined(config.modelEndpoint),
     modelEndpointApiKey: trimToUndefined(config.modelEndpointApiKey),
@@ -457,6 +471,10 @@ export function buildEnvFileContent(params: {
     `MODEL_ENDPOINT_MODEL_LABEL=${config.modelEndpointModelLabel}`,
     `MODEL_ENDPOINT_MODELS_B64=${encodeBase64(JSON.stringify(config.modelEndpointModels))}`,
     `AGENT_MODEL=${config.agentModel}`,
+    `VERTEX_ANTHROPIC_MODEL=${config.vertexAnthropicModel}`,
+    `VERTEX_ANTHROPIC_MODELS_B64=${encodeBase64(JSON.stringify(config.vertexAnthropicModels))}`,
+    `VERTEX_GOOGLE_MODEL=${config.vertexGoogleModel}`,
+    `VERTEX_GOOGLE_MODELS_B64=${encodeBase64(JSON.stringify(config.vertexGoogleModels))}`,
     "",
     `VERTEX_ENABLED=${isVertex}`,
     `VERTEX_PROVIDER=${inferenceProvider === "vertex-google" ? "google" : "anthropic"}`,

--- a/src/client/components/deploy-form/types.ts
+++ b/src/client/components/deploy-form/types.ts
@@ -109,6 +109,8 @@ export interface DeployFormConfig {
   openaiApiKey: string;
   anthropicModel: string;
   openaiModel: string;
+  anthropicModels: string[];
+  openaiModels: string[];
   agentModel: string;
   openaiCompatibleEndpointsEnabled: boolean;
   modelEndpoint: string;

--- a/src/client/components/deploy-form/types.ts
+++ b/src/client/components/deploy-form/types.ts
@@ -112,6 +112,10 @@ export interface DeployFormConfig {
   anthropicModels: string[];
   openaiModels: string[];
   agentModel: string;
+  vertexAnthropicModel: string;
+  vertexAnthropicModels: string[];
+  vertexGoogleModel: string;
+  vertexGoogleModels: string[];
   openaiCompatibleEndpointsEnabled: boolean;
   modelEndpoint: string;
   modelEndpointApiKey: string;

--- a/src/server/deployers/__tests__/multi-model-catalog.test.ts
+++ b/src/server/deployers/__tests__/multi-model-catalog.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { buildConfiguredAgentModelCatalog } from "../k8s-helpers.js";
+import type { DeployConfig } from "../types.js";
+
+function minimalConfig(overrides: Partial<DeployConfig> = {}): DeployConfig {
+  return {
+    mode: "local",
+    agentName: "test",
+    agentDisplayName: "Test",
+    ...overrides,
+  };
+}
+
+describe("buildConfiguredAgentModelCatalog with multi-model arrays", () => {
+  it("includes models from anthropicModels array", () => {
+    const config = minimalConfig({
+      inferenceProvider: "anthropic",
+      anthropicApiKey: "sk-test",
+      anthropicModels: ["claude-opus-4-6", "claude-haiku-4-5"],
+    });
+    const catalog = buildConfiguredAgentModelCatalog(config, "anthropic/claude-sonnet-4-6");
+    expect(catalog["anthropic/claude-opus-4-6"]).toEqual({ alias: "claude-opus-4-6" });
+    expect(catalog["anthropic/claude-haiku-4-5"]).toEqual({ alias: "claude-haiku-4-5" });
+  });
+
+  it("includes models from openaiModels array", () => {
+    const config = minimalConfig({
+      inferenceProvider: "openai",
+      openaiApiKey: "sk-test",
+      openaiModels: ["gpt-5", "gpt-5.3"],
+    });
+    const catalog = buildConfiguredAgentModelCatalog(config, "openai/gpt-5");
+    expect(catalog["openai/gpt-5.3"]).toEqual({ alias: "gpt-5.3" });
+  });
+
+  it("handles models with provider prefix already included", () => {
+    const config = minimalConfig({
+      inferenceProvider: "anthropic",
+      anthropicApiKey: "sk-test",
+      anthropicModels: ["anthropic/claude-opus-4-6"],
+    });
+    const catalog = buildConfiguredAgentModelCatalog(config, "anthropic/claude-sonnet-4-6");
+    expect(catalog["anthropic/claude-opus-4-6"]).toEqual({ alias: "anthropic/claude-opus-4-6" });
+  });
+
+  it("skips empty model IDs in arrays", () => {
+    const config = minimalConfig({
+      inferenceProvider: "anthropic",
+      anthropicApiKey: "sk-test",
+      anthropicModels: ["claude-opus-4-6", "", "  "],
+    });
+    const catalog = buildConfiguredAgentModelCatalog(config, "anthropic/claude-sonnet-4-6");
+    expect(catalog["anthropic/claude-opus-4-6"]).toBeDefined();
+    // Verify no malformed keys like "anthropic/" or "anthropic/  "
+    const keys = Object.keys(catalog).filter((k) => k.endsWith("/") || k.includes("/ "));
+    expect(keys).toHaveLength(0);
+  });
+
+  it("works with empty arrays (backward compat)", () => {
+    const config = minimalConfig({
+      inferenceProvider: "anthropic",
+      anthropicApiKey: "sk-test",
+      anthropicModels: [],
+      openaiModels: [],
+    });
+    const catalog = buildConfiguredAgentModelCatalog(config, "anthropic/claude-sonnet-4-6");
+    expect(catalog["anthropic/claude-sonnet-4-6"]).toBeDefined();
+  });
+
+  it("works with undefined arrays (backward compat)", () => {
+    const config = minimalConfig({
+      inferenceProvider: "anthropic",
+      anthropicApiKey: "sk-test",
+    });
+    const catalog = buildConfiguredAgentModelCatalog(config, "anthropic/claude-sonnet-4-6");
+    expect(catalog["anthropic/claude-sonnet-4-6"]).toBeDefined();
+  });
+});

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -129,6 +129,18 @@ export function buildConfiguredAgentModelCatalog(
     }
     catalog[modelRef] = { alias: alias || modelRef.split("/").pop() || modelRef };
   }
+  for (const modelId of config.anthropicModels || []) {
+    const trimmed = modelId.trim();
+    if (!trimmed) continue;
+    const ref = trimmed.includes("/") ? trimmed : `anthropic/${trimmed}`;
+    catalog[ref] = { alias: trimmed };
+  }
+  for (const modelId of config.openaiModels || []) {
+    const trimmed = modelId.trim();
+    if (!trimmed) continue;
+    const ref = trimmed.includes("/") ? trimmed : `openai/${trimmed}`;
+    catalog[ref] = { alias: trimmed };
+  }
   for (const option of config.modelEndpointModels || []) {
     const id = String(option.id || "").trim();
     if (!id) {

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -150,6 +150,18 @@ export function buildConfiguredAgentModelCatalog(
     const alias = String(option.name || "").trim() || id;
     catalog[ref] = { alias };
   }
+  for (const modelId of config.vertexAnthropicModels || []) {
+    const trimmed = modelId.trim();
+    if (!trimmed) continue;
+    const ref = shouldUseLitellmProxy(config) ? `litellm/${trimmed}` : `anthropic-vertex/${trimmed}`;
+    catalog[ref] = { alias: trimmed };
+  }
+  for (const modelId of config.vertexGoogleModels || []) {
+    const trimmed = modelId.trim();
+    if (!trimmed) continue;
+    const ref = shouldUseLitellmProxy(config) ? `litellm/${trimmed}` : `google-vertex/${trimmed}`;
+    catalog[ref] = { alias: trimmed };
+  }
   return catalog;
 }
 
@@ -164,18 +176,24 @@ function buildAgentModelConfig(config: DeployConfig, primaryModelRef: string): {
 
 export function deriveModel(config: DeployConfig): string {
   if (config.agentModel) return normalizeModelRef(config, config.agentModel);
-  if (config.inferenceProvider === "anthropic") return "anthropic/claude-sonnet-4-6";
-  if (config.inferenceProvider === "openai") return "openai/gpt-5.4";
+  if (config.inferenceProvider === "anthropic") {
+    return `anthropic/${config.anthropicModel?.trim() || "claude-sonnet-4-6"}`;
+  }
+  if (config.inferenceProvider === "openai") {
+    return `openai/${config.openaiModel?.trim() || "gpt-5.4"}`;
+  }
   if (config.inferenceProvider === "custom-endpoint") {
     return config.modelEndpointModel?.trim()
       ? normalizeModelRef(config, config.modelEndpointModel)
       : `${CUSTOM_ENDPOINT_PROVIDER}/default`;
   }
   if (config.inferenceProvider === "vertex-anthropic") {
-    return config.litellmProxy ? `litellm/${litellmModelName(config)}` : "anthropic-vertex/claude-sonnet-4-6";
+    const model = config.vertexAnthropicModel?.trim() || config.agentModel?.trim() || "claude-sonnet-4-6";
+    return config.litellmProxy ? `litellm/${model}` : `anthropic-vertex/${model}`;
   }
   if (config.inferenceProvider === "vertex-google") {
-    return config.litellmProxy ? `litellm/${litellmModelName(config)}` : "google-vertex/gemini-2.5-pro";
+    const model = config.vertexGoogleModel?.trim() || config.agentModel?.trim() || "gemini-2.5-pro";
+    return config.litellmProxy ? `litellm/${model}` : `google-vertex/${model}`;
   }
   if (config.vertexEnabled && shouldUseLitellmProxy(config)) {
     return `litellm/${litellmModelName(config)}`;

--- a/src/server/deployers/litellm.ts
+++ b/src/server/deployers/litellm.ts
@@ -46,48 +46,40 @@ export function litellmModelString(config: DeployConfig): string {
 function buildModelList(config: DeployConfig): Array<Record<string, unknown>> {
   const project = config.googleCloudProject || "";
   const location = config.googleCloudLocation || "";
+  const seen = new Set<string>();
 
   const models: Array<Record<string, unknown>> = [];
 
+  function addModel(name: string) {
+    if (seen.has(name)) return;
+    seen.add(name);
+    models.push({
+      model_name: name,
+      litellm_params: {
+        model: `vertex_ai/${name}`,
+        vertex_project: project,
+        vertex_location: location,
+      },
+    });
+  }
+
+  // Add the primary model (from provider-specific field, agentModel, or default)
   if (config.vertexProvider === "google") {
-    models.push(
-      {
-        model_name: "gemini-2.5-pro",
-        litellm_params: {
-          model: "vertex_ai/gemini-2.5-pro",
-          vertex_project: project,
-          vertex_location: location,
-        },
-      },
-      {
-        model_name: "gemini-2.5-flash",
-        litellm_params: {
-          model: "vertex_ai/gemini-2.5-flash",
-          vertex_project: project,
-          vertex_location: location,
-        },
-      },
-    );
+    addModel(config.vertexGoogleModel?.trim() || config.agentModel?.trim() || "gemini-2.5-pro");
+    addModel("gemini-2.5-pro");
+    addModel("gemini-2.5-flash");
+    for (const modelId of config.vertexGoogleModels || []) {
+      const trimmed = modelId.trim();
+      if (trimmed) addModel(trimmed);
+    }
   } else {
-    // Anthropic (Claude via Vertex)
-    models.push(
-      {
-        model_name: "claude-sonnet-4-6",
-        litellm_params: {
-          model: "vertex_ai/claude-sonnet-4-6",
-          vertex_project: project,
-          vertex_location: location,
-        },
-      },
-      {
-        model_name: "claude-haiku-4-5",
-        litellm_params: {
-          model: "vertex_ai/claude-haiku-4-5",
-          vertex_project: project,
-          vertex_location: location,
-        },
-      },
-    );
+    addModel(config.vertexAnthropicModel?.trim() || config.agentModel?.trim() || "claude-sonnet-4-6");
+    addModel("claude-sonnet-4-6");
+    addModel("claude-haiku-4-5");
+    for (const modelId of config.vertexAnthropicModels || []) {
+      const trimmed = modelId.trim();
+      if (trimmed) addModel(trimmed);
+    }
   }
 
   return models;

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -227,10 +227,10 @@ function deriveModel(config: DeployConfig): string {
     return normalizeModelRef(config, config.agentModel);
   }
   if (config.inferenceProvider === "anthropic") {
-    return "anthropic/claude-sonnet-4-6";
+    return `anthropic/${config.anthropicModel?.trim() || "claude-sonnet-4-6"}`;
   }
   if (config.inferenceProvider === "openai") {
-    return "openai/gpt-5.4";
+    return `openai/${config.openaiModel?.trim() || "gpt-5.4"}`;
   }
   if (config.inferenceProvider === "custom-endpoint") {
     return config.modelEndpointModel?.trim()
@@ -238,14 +238,12 @@ function deriveModel(config: DeployConfig): string {
       : `${CUSTOM_ENDPOINT_PROVIDER}/default`;
   }
   if (config.inferenceProvider === "vertex-anthropic") {
-    return shouldUseLitellmProxy(config)
-      ? `litellm/${litellmModelName(config)}`
-      : "anthropic-vertex/claude-sonnet-4-6";
+    const model = config.vertexAnthropicModel?.trim() || config.agentModel?.trim() || "claude-sonnet-4-6";
+    return shouldUseLitellmProxy(config) ? `litellm/${model}` : `anthropic-vertex/${model}`;
   }
   if (config.inferenceProvider === "vertex-google") {
-    return shouldUseLitellmProxy(config)
-      ? `litellm/${litellmModelName(config)}`
-      : "google-vertex/gemini-2.5-pro";
+    const model = config.vertexGoogleModel?.trim() || config.agentModel?.trim() || "gemini-2.5-pro";
+    return shouldUseLitellmProxy(config) ? `litellm/${model}` : `google-vertex/${model}`;
   }
   if (config.vertexEnabled && shouldUseLitellmProxy(config)) {
     return `litellm/${litellmModelName(config)}`;

--- a/src/server/deployers/types.ts
+++ b/src/server/deployers/types.ts
@@ -60,6 +60,8 @@ export interface DeployConfig {
   openaiApiKey?: string;
   anthropicModel?: string;
   openaiModel?: string;
+  anthropicModels?: string[];
+  openaiModels?: string[];
   inferenceProvider?: InferenceProvider;
   agentModel?: string;
   modelFallbacks?: string[];

--- a/src/server/deployers/types.ts
+++ b/src/server/deployers/types.ts
@@ -64,6 +64,10 @@ export interface DeployConfig {
   openaiModels?: string[];
   inferenceProvider?: InferenceProvider;
   agentModel?: string;
+  vertexAnthropicModel?: string;
+  vertexAnthropicModels?: string[];
+  vertexGoogleModel?: string;
+  vertexGoogleModels?: string[];
   modelFallbacks?: string[];
   openaiCompatibleEndpointsEnabled?: boolean;
   modelEndpoint?: string;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import { isClusterReachable, currentContext, currentNamespace, resetKubeConfig }
 import { stopAllK8sPortForwards } from "./services/k8s-port-forward.js";
 import { detectGcpDefaults } from "./services/gcp.js";
 import { fetchModelEndpointCatalog } from "./services/model-endpoint.js";
+import { fetchAnthropicModels, fetchOpenaiModels } from "./services/model-discovery.js";
 import { readdir, readFile } from "node:fs/promises";
 import { userInfo } from "node:os";
 import { installerDataDir } from "./paths.js";
@@ -202,6 +203,34 @@ app.post("/api/configs/model-endpoint-models", async (req, res) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     res.status(502).json({ error: message });
+  }
+});
+
+app.post("/api/configs/anthropic-models", async (req, res) => {
+  const apiKey = (req.body as { apiKey?: string }).apiKey?.trim() || process.env.ANTHROPIC_API_KEY || "";
+  if (!apiKey) {
+    res.status(400).json({ error: "API key is required" });
+    return;
+  }
+  try {
+    const models = await fetchAnthropicModels(apiKey);
+    res.json({ models });
+  } catch (err) {
+    res.status(502).json({ error: err instanceof Error ? err.message : "Failed to fetch Anthropic models" });
+  }
+});
+
+app.post("/api/configs/openai-models", async (req, res) => {
+  const apiKey = (req.body as { apiKey?: string }).apiKey?.trim() || process.env.OPENAI_API_KEY || "";
+  if (!apiKey) {
+    res.status(400).json({ error: "API key is required" });
+    return;
+  }
+  try {
+    const models = await fetchOpenaiModels(apiKey);
+    res.json({ models });
+  } catch (err) {
+    res.status(502).json({ error: err instanceof Error ? err.message : "Failed to fetch OpenAI models" });
   }
 });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,7 +12,7 @@ import { isClusterReachable, currentContext, currentNamespace, resetKubeConfig }
 import { stopAllK8sPortForwards } from "./services/k8s-port-forward.js";
 import { detectGcpDefaults } from "./services/gcp.js";
 import { fetchModelEndpointCatalog } from "./services/model-endpoint.js";
-import { fetchAnthropicModels, fetchOpenaiModels } from "./services/model-discovery.js";
+import { fetchAnthropicModels, fetchOpenaiModels, fetchVertexModels } from "./services/model-discovery.js";
 import { readdir, readFile } from "node:fs/promises";
 import { userInfo } from "node:os";
 import { installerDataDir } from "./paths.js";
@@ -231,6 +231,36 @@ app.post("/api/configs/openai-models", async (req, res) => {
     res.json({ models });
   } catch (err) {
     res.status(502).json({ error: err instanceof Error ? err.message : "Failed to fetch OpenAI models" });
+  }
+});
+
+app.post("/api/configs/vertex-models", async (req, res) => {
+  const body = req.body as {
+    saJson?: string;
+    project?: string;
+    location?: string;
+    vertexProvider?: string;
+    anthropicApiKey?: string;
+  };
+  const gcpDefs = await detectGcpDefaults();
+  const saJson = body.saJson?.trim() || gcpDefs.serviceAccountJson || "";
+  const project = body.project?.trim() || gcpDefs.projectId || "";
+  const location = body.location?.trim() || gcpDefs.location || "us-east5";
+  const vertexProvider = body.vertexProvider?.trim() || "anthropic";
+  const anthropicApiKey = body.anthropicApiKey?.trim() || process.env.ANTHROPIC_API_KEY || "";
+  if (!saJson) {
+    res.status(400).json({ error: "GCP credentials are required" });
+    return;
+  }
+  if (!project) {
+    res.status(400).json({ error: "GCP project ID is required" });
+    return;
+  }
+  try {
+    const result = await fetchVertexModels(saJson, project, location, vertexProvider, anthropicApiKey || undefined);
+    res.json({ models: result.models, warning: result.warning });
+  } catch (err) {
+    res.status(502).json({ error: err instanceof Error ? err.message : "Failed to fetch Vertex models" });
   }
 });
 

--- a/src/server/routes/deploy.ts
+++ b/src/server/routes/deploy.ts
@@ -57,6 +57,15 @@ function normalizeModelFallbacks(modelFallbacks: string[] | undefined): string[]
   return normalized.length > 0 ? normalized : undefined;
 }
 
+function normalizeStringArray(arr: string[] | undefined): string[] | undefined {
+  if (!Array.isArray(arr)) return undefined;
+  const normalized = arr
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 export function applyServerEnvFallbacks(config: DeployConfig, env: NodeJS.ProcessEnv = process.env): void {
   if (!config.image && env.OPENCLAW_IMAGE) {
     config.image = env.OPENCLAW_IMAGE;
@@ -105,6 +114,8 @@ router.post("/", async (req, res) => {
   config.telegramAllowFrom = trimOptional(config.telegramAllowFrom);
   config.anthropicModel = trimOptional(config.anthropicModel);
   config.openaiModel = trimOptional(config.openaiModel);
+  config.anthropicModels = normalizeStringArray(config.anthropicModels);
+  config.openaiModels = normalizeStringArray(config.openaiModels);
   config.namespace = trimOptional(config.namespace);
   config.a2aRealm = trimOptional(config.a2aRealm);
   config.a2aKeycloakNamespace = trimOptional(config.a2aKeycloakNamespace);

--- a/src/server/services/__tests__/model-discovery.test.ts
+++ b/src/server/services/__tests__/model-discovery.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fetchAnthropicModels, fetchOpenaiModels } from "../model-discovery.js";
+
+describe("model-discovery", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("fetchAnthropicModels", () => {
+    it("parses Anthropic model list response", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
+            { id: "claude-opus-4-6", display_name: "Claude Opus 4.6" },
+          ],
+        }),
+      });
+      const models = await fetchAnthropicModels("sk-ant-test");
+      expect(models).toHaveLength(2);
+      expect(models[0]).toEqual({ id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" });
+      expect(models[1]).toEqual({ id: "claude-opus-4-6", name: "Claude Opus 4.6" });
+    });
+
+    it("deduplicates model IDs", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
+            { id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6 duplicate" },
+          ],
+        }),
+      });
+      const models = await fetchAnthropicModels("sk-ant-test");
+      expect(models).toHaveLength(1);
+    });
+
+    it("throws on non-OK response", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+      });
+      await expect(fetchAnthropicModels("bad-key")).rejects.toThrow("Anthropic API returned HTTP 401");
+    });
+
+    it("sends correct headers", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      });
+      await fetchAnthropicModels("sk-ant-test");
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "https://api.anthropic.com/v1/models",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "x-api-key": "sk-ant-test",
+            "anthropic-version": "2023-06-01",
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("fetchOpenaiModels", () => {
+    it("parses OpenAI model list response and sorts", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: "gpt-5.3", owned_by: "openai" },
+            { id: "gpt-5", owned_by: "openai" },
+          ],
+        }),
+      });
+      const models = await fetchOpenaiModels("sk-test");
+      expect(models).toHaveLength(2);
+      expect(models[0].id).toBe("gpt-5");
+      expect(models[1].id).toBe("gpt-5.3");
+    });
+
+    it("sends Bearer auth header", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      });
+      await fetchOpenaiModels("sk-test");
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "https://api.openai.com/v1/models",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer sk-test",
+          }),
+        }),
+      );
+    });
+
+    it("throws on non-OK response", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+      });
+      await expect(fetchOpenaiModels("bad-key")).rejects.toThrow("OpenAI API returned HTTP 403");
+    });
+
+    it("deduplicates model IDs", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: "gpt-5", owned_by: "openai" },
+            { id: "gpt-5", owned_by: "openai" },
+          ],
+        }),
+      });
+      const models = await fetchOpenaiModels("sk-test");
+      expect(models).toHaveLength(1);
+    });
+  });
+});

--- a/src/server/services/__tests__/model-discovery.test.ts
+++ b/src/server/services/__tests__/model-discovery.test.ts
@@ -78,8 +78,8 @@ describe("model-discovery", () => {
       });
       const models = await fetchOpenaiModels("sk-test");
       expect(models).toHaveLength(2);
-      expect(models[0].id).toBe("gpt-5");
-      expect(models[1].id).toBe("gpt-5.3");
+      expect(models[0].id).toBe("gpt-5.3");
+      expect(models[1].id).toBe("gpt-5");
     });
 
     it("sends Bearer auth header", async () => {

--- a/src/server/services/model-discovery.ts
+++ b/src/server/services/model-discovery.ts
@@ -1,0 +1,50 @@
+import type { ModelEndpointCatalogEntry } from "./model-endpoint.js";
+
+export async function fetchAnthropicModels(apiKey: string): Promise<ModelEndpointCatalogEntry[]> {
+  const response = await fetch("https://api.anthropic.com/v1/models", {
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Anthropic API returned HTTP ${response.status}`);
+  }
+  const payload = await response.json() as { data?: Array<{ id: string; display_name?: string }> };
+  const entries = Array.isArray(payload.data) ? payload.data : [];
+  const models: ModelEndpointCatalogEntry[] = [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const id = typeof entry.id === "string" ? entry.id.trim() : "";
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const name = typeof entry.display_name === "string" && entry.display_name.trim()
+      ? entry.display_name.trim()
+      : id;
+    models.push({ id, name });
+  }
+  return models;
+}
+
+export async function fetchOpenaiModels(apiKey: string): Promise<ModelEndpointCatalogEntry[]> {
+  const response = await fetch("https://api.openai.com/v1/models", {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`OpenAI API returned HTTP ${response.status}`);
+  }
+  const payload = await response.json() as { data?: Array<{ id: string; owned_by?: string }> };
+  const entries = Array.isArray(payload.data) ? payload.data : [];
+  const models: ModelEndpointCatalogEntry[] = [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const id = typeof entry.id === "string" ? entry.id.trim() : "";
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    models.push({ id, name: id });
+  }
+  models.sort((a, b) => a.id.localeCompare(b.id));
+  return models;
+}

--- a/src/server/services/model-discovery.ts
+++ b/src/server/services/model-discovery.ts
@@ -1,3 +1,4 @@
+import { createSign } from "node:crypto";
 import type { ModelEndpointCatalogEntry } from "./model-endpoint.js";
 
 export async function fetchAnthropicModels(apiKey: string): Promise<ModelEndpointCatalogEntry[]> {
@@ -26,6 +27,13 @@ export async function fetchAnthropicModels(apiKey: string): Promise<ModelEndpoin
   return models;
 }
 
+// Keywords indicating non-chat models that aren't useful for agent inference
+// Keywords indicating non-chat models that aren't useful for agent inference
+const OPENAI_EXCLUDE_PATTERNS = /\b(embedding|tts|whisper|dall-e|moderation|realtime|audio|search|babbage|davinci|canary|transcribe|instruct|image|sora)\b|^ft:/i;
+
+// Date suffix pattern (e.g., -2024-08-06, -20250514)
+const DATE_SUFFIX = /-\d{4}(-\d{2}(-\d{2})?)?$|-\d{8}$/;
+
 export async function fetchOpenaiModels(apiKey: string): Promise<ModelEndpointCatalogEntry[]> {
   const response = await fetch("https://api.openai.com/v1/models", {
     headers: {
@@ -42,9 +50,235 @@ export async function fetchOpenaiModels(apiKey: string): Promise<ModelEndpointCa
   for (const entry of entries) {
     const id = typeof entry.id === "string" ? entry.id.trim() : "";
     if (!id || seen.has(id)) continue;
+    if (OPENAI_EXCLUDE_PATTERNS.test(id)) continue;
     seen.add(id);
     models.push({ id, name: id });
   }
-  models.sort((a, b) => a.id.localeCompare(b.id));
+  // Sort: stable GPT first, stable non-GPT, dated GPT, dated non-GPT
+  // Within each group, reverse alphabetical so newest models come first
+  models.sort((a, b) => {
+    const aHasDate = DATE_SUFFIX.test(a.id) ? 1 : 0;
+    const bHasDate = DATE_SUFFIX.test(b.id) ? 1 : 0;
+    const aIsGpt = a.id.startsWith("gpt-") ? 0 : 1;
+    const bIsGpt = b.id.startsWith("gpt-") ? 0 : 1;
+    const aBucket = aHasDate * 2 + aIsGpt;
+    const bBucket = bHasDate * 2 + bIsGpt;
+    if (aBucket !== bBucket) return aBucket - bBucket;
+    return b.id.localeCompare(a.id); // reverse alpha within bucket
+  });
   return models;
+}
+
+/**
+ * Get an access token from a GCP Service Account JSON using the JWT grant flow.
+ */
+async function getAccessTokenFromSaJson(saJson: string): Promise<string> {
+  const sa = JSON.parse(saJson) as {
+    client_email?: string;
+    private_key?: string;
+    token_uri?: string;
+    type?: string;
+  };
+
+  // For authorized_user credentials, use the refresh token flow
+  if (sa.type === "authorized_user") {
+    const au = sa as unknown as {
+      client_id?: string;
+      client_secret?: string;
+      refresh_token?: string;
+    };
+    const response = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: au.client_id || "",
+        client_secret: au.client_secret || "",
+        refresh_token: au.refresh_token || "",
+        grant_type: "refresh_token",
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`Token refresh failed: HTTP ${response.status}`);
+    }
+    const token = await response.json() as { access_token?: string };
+    if (!token.access_token) throw new Error("No access_token in refresh response");
+    return token.access_token;
+  }
+
+  // Service account: sign a JWT and exchange for an access token
+  if (!sa.client_email || !sa.private_key) {
+    throw new Error("Invalid service account JSON: missing client_email or private_key");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({
+    iss: sa.client_email,
+    scope: "https://www.googleapis.com/auth/cloud-platform",
+    aud: sa.token_uri || "https://oauth2.googleapis.com/token",
+    iat: now,
+    exp: now + 3600,
+  })).toString("base64url");
+
+  const sign = createSign("RSA-SHA256");
+  sign.update(`${header}.${payload}`);
+  const signature = sign.sign(sa.private_key, "base64url");
+
+  const jwt = `${header}.${payload}.${signature}`;
+
+  const response = await fetch(sa.token_uri || "https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: jwt,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Token exchange failed: HTTP ${response.status}`);
+  }
+  const token = await response.json() as { access_token?: string };
+  if (!token.access_token) throw new Error("No access_token in token response");
+  return token.access_token;
+}
+
+/**
+ * Fetch available models from Vertex AI for a given provider type.
+ */
+// Well-known Vertex AI models as a fallback when API discovery fails
+const KNOWN_VERTEX_MODELS: Record<string, ModelEndpointCatalogEntry[]> = {
+  anthropic: [
+    { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+    { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    { id: "claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" },
+    { id: "claude-sonnet-4-5-20250514", name: "Claude Sonnet 4.5" },
+  ],
+  google: [
+    { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
+    { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
+    { id: "gemini-2.0-flash", name: "Gemini 2.0 Flash" },
+  ],
+};
+
+export interface VertexModelsResult {
+  models: ModelEndpointCatalogEntry[];
+  warning?: string;
+}
+
+/**
+ * Probe whether a model ID works on Vertex AI by sending a minimal request.
+ */
+async function probeVertexModel(
+  accessToken: string,
+  project: string,
+  location: string,
+  modelId: string,
+): Promise<boolean> {
+  try {
+    const url = `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models/${modelId}:rawPredict`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        anthropic_version: "vertex-2023-10-16",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 1,
+      }),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function fetchVertexModels(
+  saJson: string,
+  project: string,
+  location: string,
+  vertexProvider: string,
+  anthropicApiKey?: string,
+): Promise<VertexModelsResult> {
+  const publisher = vertexProvider === "google" ? "google" : "anthropic";
+
+  try {
+    const accessToken = await getAccessTokenFromSaJson(saJson);
+
+    // Query the Vertex AI Model Garden (v1beta1 publishers endpoint)
+    const url = `https://${location}-aiplatform.googleapis.com/v1beta1/publishers/${publisher}/models`;
+
+    const headers: Record<string, string> = { Authorization: `Bearer ${accessToken}` };
+    // authorized_user credentials require a quota project header
+    if (project) headers["x-goog-user-project"] = project;
+
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const payload = await response.json() as {
+      publisherModels?: Array<{
+        name?: string;
+        versionId?: string;
+        openSourceCategory?: string;
+      }>;
+    };
+
+    const entries = Array.isArray(payload.publisherModels) ? payload.publisherModels : [];
+    const models: ModelEndpointCatalogEntry[] = [];
+    const seen = new Set<string>();
+
+    for (const entry of entries) {
+      // name is like "publishers/anthropic/models/claude-sonnet-4-6"
+      const fullName = typeof entry.name === "string" ? entry.name : "";
+      const id = fullName.split("/").pop() || "";
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      models.push({ id, name: id });
+    }
+
+    if (models.length > 0) {
+      models.sort((a, b) => a.id.localeCompare(b.id));
+      return { models };
+    }
+  } catch {
+    // Fall through to probe-based or curated list
+  }
+
+  // For Vertex Anthropic: if we have an Anthropic API key and GCP credentials,
+  // fetch the Anthropic model list and probe each against Vertex in parallel
+  if (publisher === "anthropic" && anthropicApiKey && saJson) {
+    try {
+      const [anthropicModels, accessToken] = await Promise.all([
+        fetchAnthropicModels(anthropicApiKey),
+        getAccessTokenFromSaJson(saJson),
+      ]);
+
+      // Probe ALL models in parallel to find which ones work on this user's Vertex
+      const probeResults = await Promise.all(
+        anthropicModels.map(async (m) => ({
+          model: m,
+          works: await probeVertexModel(accessToken, project, location, m.id),
+        })),
+      );
+
+      const verified = probeResults.filter((r) => r.works).map((r) => r.model);
+      const failed = probeResults.filter((r) => !r.works).map((r) => r.model.id);
+      console.log(`Vertex model probing: ${anthropicModels.length} from Anthropic API, ${verified.length} verified, ${failed.length} failed${failed.length > 0 ? ` (${failed.join(", ")})` : ""}`);
+
+      if (verified.length > 0) {
+        return { models: verified };
+      }
+    } catch {
+      // Fall through to curated list
+    }
+  }
+
+  // Return curated list when all discovery methods fail
+  return {
+    models: KNOWN_VERTEX_MODELS[publisher] || [],
+    warning: "Unable to list available models. Showing common models. You can also type any model ID.",
+  };
 }

--- a/src/server/services/model-discovery.ts
+++ b/src/server/services/model-discovery.ts
@@ -28,8 +28,20 @@ export async function fetchAnthropicModels(apiKey: string): Promise<ModelEndpoin
 }
 
 // Keywords indicating non-chat models that aren't useful for agent inference
-// Keywords indicating non-chat models that aren't useful for agent inference
 const OPENAI_EXCLUDE_PATTERNS = /\b(embedding|tts|whisper|dall-e|moderation|realtime|audio|search|babbage|davinci|canary|transcribe|instruct|image|sora)\b|^ft:/i;
+
+// Models known not to work with OpenClaw (not in its model registry)
+const OPENAI_EXCLUDE_MODELS = new Set([
+  "gpt-3.5-turbo",
+  "gpt-3.5-turbo-0125",
+  "gpt-3.5-turbo-1106",
+  "gpt-3.5-turbo-16k",
+  "gpt-4-0613",
+  "computer-use-preview",
+  "computer-use-preview-2025-03-11",
+  "o1-2024-12-17",
+  "o3-2025-04-16",
+]);
 
 // Date suffix pattern (e.g., -2024-08-06, -20250514)
 const DATE_SUFFIX = /-\d{4}(-\d{2}(-\d{2})?)?$|-\d{8}$/;
@@ -51,6 +63,7 @@ export async function fetchOpenaiModels(apiKey: string): Promise<ModelEndpointCa
     const id = typeof entry.id === "string" ? entry.id.trim() : "";
     if (!id || seen.has(id)) continue;
     if (OPENAI_EXCLUDE_PATTERNS.test(id)) continue;
+    if (OPENAI_EXCLUDE_MODELS.has(id)) continue;
     seen.add(id);
     models.push({ id, name: id });
   }


### PR DESCRIPTION
## Summary

Allow users to configure multiple models per inference provider with automatic model discovery across Anthropic, OpenAI, and Vertex AI.

- Add per-provider model arrays (anthropicModels, openaiModels, vertexAnthropicModel/Models, vertexGoogleModel/Models) to client and server types
- Auto-fetch available models when credentials become available (no manual button click needed)
- Vertex AI model discovery with 3-tier fallback: Model Garden API, Anthropic API + per-model probing, curated list with warning
- Separate vertex model state per provider so secondary providers don't share state
- Filter non-chat and incompatible models from OpenAI list (embeddings, TTS, gpt-3.5-turbo, o1-2024-12-17, etc.) and sort with stable GPT aliases first
- Multi-select checklist UI for model selection across all providers
- Update serialization (env file, deploy request, saved config restore)
- Extend model catalog builder and LiteLLM config to register models from the new arrays
- Add 23 tests covering serialization, catalog building, and discovery
- Maintain backward compatibility with existing single-model configs

Closes #79

## Test plan

- [x] npm run build and npm test (259 tests pass)
- [x] npm run lint (no errors)
- [x] Deployed local agent with Anthropic provider, model list auto-populates from API
- [x] Deployed local agent with OpenAI provider, model list auto-populates, filtered and sorted correctly
- [x] Deployed local agent with Vertex Anthropic provider, model probing verifies available models against GCP project
- [x] Verified per-provider model state isolation: adding vertex-google as secondary does not inherit vertex-anthropic model selections
- [x] Verified excluded models (gpt-3.5-turbo, o1-2024-12-17) no longer appear in model picker
- [x] Tested model switching in deployed agent, confirmed working models respond and excluded models no longer cause infinite retry loops
- [x] Vertex fallback warning displays correctly when Model Garden API is inaccessible