### PR TITLE
docs: add Podman secrets best practices and macOS volume backup scripts

### DIFF
--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -62,6 +62,9 @@ For local deploys, the installer now follows the upstream OpenClaw secret model 
 
 This means the container still receives the credentials it needs, but `openclaw.json` does not embed the plaintext API keys or Telegram bot token.
 
+For credentials like GitHub PATs, API keys, and bot tokens, see [podman-secrets.md](podman-secrets.md)
+for current options including Podman secrets, 1Password, and HashiCorp Vault.
+
 ## Using The OpenClaw CLI
 
 Installer-managed local instances save `OPENCLAW_CONTAINER` in their instance `.env`, so the upstream OpenClaw CLI can target the running local container directly.

--- a/docs/podman-secrets.md
+++ b/docs/podman-secrets.md
@@ -1,0 +1,152 @@
+# Managing Credentials with Podman Secrets
+
+> **Note:** This space is evolving fast. Here are some current solutions that
+> work well for local setup — expect more options and tighter integrations over time.
+
+The goal: no secrets at rest inside the container or data volume.
+
+## Why Not Just Use `.env`?
+
+Placing secrets directly in the data volume works but has a significant downside:
+the volume backup (`podman volume export`) captures those secrets too. The options
+below keep secrets out of the volume entirely.
+
+---
+
+## Option 1: Podman Secrets
+
+Podman has a built-in secrets manager. Secrets are stored outside the container
+and injected at runtime as environment variables — they never touch the volume.
+
+### Create a secret
+
+```bash
+echo "ghp_yourtoken" | podman secret create gh_token -
+```
+
+### Inject at container start
+
+Add `--secret` to the `podman run` command:
+
+```bash
+podman run \
+  --secret gh_token,type=env,target=GH_TOKEN \
+  ... # rest of your openclaw run flags
+```
+
+The secret is available inside the container as `$GH_TOKEN`. It is not written to disk.
+
+In the openclaw-installer UI, add `--secret` flags in the **Extra Podman Args** field.
+They are preserved across Stop/Start cycles.
+
+### Manage secrets
+
+```bash
+podman secret ls                                       # list registered secrets
+podman secret rm gh_token                              # delete a secret
+echo "new_token" | podman secret create gh_token -     # rotate
+```
+
+### Portability note
+
+Podman secrets are local to the machine — they do not travel with volume exports
+or backups. When moving to a new host, recreate secrets before starting the container.
+
+---
+
+## Option 2: 1Password CLI exec Provider
+
+For setups already using 1Password, the OpenClaw exec secrets provider can fetch
+credentials live from the 1Password vault. Nothing is stored on disk.
+
+### Prerequisites
+
+- 1Password desktop app installed and unlocked on the host
+- 1Password CLI installed: `brew install 1password-cli`
+- Desktop app integration enabled: Settings → Developer → Enable CLI integration
+
+### Store the credential in 1Password
+
+Create an item in your vault (e.g. "OpenClaw GitHub PAT") with a field named
+`credential` containing the token.
+
+### Mount the 1Password socket into the container
+
+```bash
+-v /run/user/$(id -u)/1password/agent.sock:/run/1password/agent.sock \
+-e OP_AGENT_SOCK=/run/1password/agent.sock
+```
+
+### Configure the OpenClaw exec provider
+
+```bash
+openclaw config set secrets.providers.onepassword \
+  --provider-source exec \
+  --provider-command op \
+  --provider-arg "op://Personal/OpenClaw GitHub PAT/credential" \
+  --provider-timeout-ms 5000
+```
+
+OpenClaw calls `op read` at session start. The resolved value is injected into the
+process environment and never written to disk. To rotate: update the item in 1Password.
+
+---
+
+## Option 3: HashiCorp Vault exec Provider
+
+For setups using HashiCorp Vault, the same OpenClaw exec provider pattern applies.
+
+### Prerequisites
+
+- Vault CLI installed and authenticated (`vault login`)
+- Vault server accessible from the container
+
+### Mount Vault token into the container
+
+```bash
+-e VAULT_ADDR=https://vault.example.com \
+-e VAULT_TOKEN=<your-token>
+```
+
+Or mount a token file:
+
+```bash
+-v ~/.vault-token:/home/node/.vault-token:ro
+```
+
+### Configure the OpenClaw exec provider
+
+```bash
+openclaw config set secrets.providers.vault \
+  --provider-source exec \
+  --provider-command vault \
+  --provider-arg kv \
+  --provider-arg get \
+  --provider-arg -field=value \
+  --provider-arg secret/openclaw/gh-token \
+  --provider-timeout-ms 5000
+```
+
+---
+
+## Naming Conventions
+
+Use consistent secret names so scripts and docs are predictable:
+
+| Purpose | Podman secret name | Env var in container |
+|---|---|---|
+| GitHub PAT | `gh_token` | `GH_TOKEN` |
+| Anthropic API key | `anthropic_api_key` | `ANTHROPIC_API_KEY` |
+| OpenAI API key | `openai_api_key` | `OPENAI_API_KEY` |
+| Telegram bot token | `telegram_bot_token` | `TELEGRAM_BOT_TOKEN` |
+| OpenClaw gateway token | `openclaw_gateway_token` | `OPENCLAW_GATEWAY_TOKEN` |
+
+---
+
+## Summary
+
+| Approach | Secret at rest? | Travels with volume backup? |
+|---|---|---|
+| Podman secrets | No (Podman store) | No |
+| 1Password exec provider | No (fetched live) | No |
+| HashiCorp Vault exec provider | No (fetched live) | No |

--- a/scripts/macos/README.md
+++ b/scripts/macos/README.md
@@ -1,0 +1,55 @@
+# macOS Maintenance Scripts
+
+## Volume Backup (`backup-openclaw-volumes.sh`)
+
+Daily backup of all `openclaw-*` Podman volumes to `~/openclaw-backups/`.
+Keeps 7 days of backups and auto-prunes older ones.
+
+### Install (one-time)
+
+```bash
+# Install the backup script to a fixed path
+sudo cp scripts/macos/backup-openclaw-volumes.sh /usr/local/bin/openclaw-backup.sh
+sudo chmod +x /usr/local/bin/openclaw-backup.sh
+
+# Install and load the launchd agent
+cp scripts/macos/ai.openclaw.backup.plist ~/Library/LaunchAgents/
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.openclaw.backup.plist
+```
+
+Runs automatically every day at 2:00 AM. Logs go to `/tmp/openclaw-backup.log`.
+
+### Run manually
+
+```bash
+bash scripts/macos/backup-openclaw-volumes.sh
+```
+
+### Test the launchd job immediately
+
+```bash
+launchctl kickstart gui/$(id -u)/ai.openclaw.backup
+tail -f /tmp/openclaw-backup.log
+```
+
+### Check logs
+
+```bash
+tail -f /tmp/openclaw-backup.log
+tail -f /tmp/openclaw-backup.error.log
+```
+
+### Uninstall
+
+```bash
+launchctl bootout gui/$(id -u)/ai.openclaw.backup
+rm ~/Library/LaunchAgents/ai.openclaw.backup.plist
+sudo rm /usr/local/bin/openclaw-backup.sh
+```
+
+### Restore a volume
+
+```bash
+podman volume import openclaw-<prefix>-<name>-data \
+  ~/openclaw-backups/openclaw-<prefix>-<name>-data-<date>.tar
+```

--- a/scripts/macos/ai.openclaw.backup.plist
+++ b/scripts/macos/ai.openclaw.backup.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.openclaw.backup</string>
+
+    <key>Program</key>
+    <string>/usr/local/bin/openclaw-backup.sh</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/somalley</string>
+        <key>PATH</key>
+        <string>/opt/podman/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/openclaw-backup.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/openclaw-backup.error.log</string>
+
+    <!-- Run daily at 2:00 AM -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/macos/backup-openclaw-volumes.sh
+++ b/scripts/macos/backup-openclaw-volumes.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Backup all OpenClaw podman volumes to ~/openclaw-backups/
+# Keeps the last 7 daily backups per volume, deletes older ones.
+#
+# Install:
+#   sudo cp scripts/macos/backup-openclaw-volumes.sh /usr/local/bin/openclaw-backup.sh
+#   sudo chmod +x /usr/local/bin/openclaw-backup.sh
+#   cp scripts/macos/ai.openclaw.backup.plist ~/Library/LaunchAgents/
+#   launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.openclaw.backup.plist
+#
+# To run manually:
+#   bash scripts/macos/backup-openclaw-volumes.sh
+#
+# Logs: /tmp/openclaw-backup.log
+
+set -euo pipefail
+
+BACKUP_DIR="$HOME/openclaw-backups"
+KEEP_DAYS=7
+DATE=$(date +%Y%m%d)
+# Common podman install paths on macOS
+export PATH="/opt/podman/bin:/usr/local/bin:$PATH"
+PODMAN=$(command -v podman || echo "")
+
+if [[ -z "$PODMAN" ]]; then
+  echo "[openclaw-backup] ERROR: podman not found in PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+
+# Find all OpenClaw-managed volumes
+VOLUMES=$("$PODMAN" volume ls --format '{{.Name}}' | grep '^openclaw-' || true)
+
+if [[ -z "$VOLUMES" ]]; then
+  echo "[openclaw-backup] No openclaw-* volumes found, nothing to back up."
+  exit 0
+fi
+
+for VOL in $VOLUMES; do
+  OUTFILE="$BACKUP_DIR/${VOL}-${DATE}.tar"
+  echo "[openclaw-backup] Exporting $VOL -> $OUTFILE"
+  "$PODMAN" volume export "$VOL" -o "$OUTFILE"
+  echo "[openclaw-backup] Done: $OUTFILE ($(du -sh "$OUTFILE" | cut -f1))"
+done
+
+# Prune backups older than KEEP_DAYS days
+echo "[openclaw-backup] Pruning backups older than $KEEP_DAYS days..."
+find "$BACKUP_DIR" -name 'openclaw-*.tar' -mtime +"$KEEP_DAYS" -delete
+
+echo "[openclaw-backup] Backup complete at $(date)"


### PR DESCRIPTION
- docs/podman-secrets.md: credential management options for local deploys (Podman secrets, 1Password exec provider, HashiCorp Vault exec provider) with naming conventions and summary table
- docs/deploy-local.md: add reference to podman-secrets.md
- scripts/macos/backup-openclaw-volumes.sh: exports all openclaw-* volumes daily to ~/openclaw-backups/, 7-day retention with auto-prune