### PR TITLE
stop defaulting to dangerouslyDisableDeviceAuth

### DIFF
--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -51,7 +51,7 @@ The installer will:
 - fetch the gateway token
 - open the UI with the saved gateway token
 
-Control UI device pairing remains enabled by default for the base Kubernetes deployer, so first browser connect may still require the normal pairing/approval flow.
+Control UI device pairing remains enabled by default for the base Kubernetes deployer, so first browser connect may require approving the pending pairing request from the **Instances** tab with **Approve Pairing**.
 
 Manual access is still available if you prefer:
 

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -49,7 +49,9 @@ The installer will:
 - start or reuse a managed `kubectl port-forward`
 - choose a free local port automatically
 - fetch the gateway token
-- open the UI already authenticated
+- open the UI with the saved gateway token
+
+Control UI device pairing remains enabled by default for the base Kubernetes deployer, so first browser connect may still require the normal pairing/approval flow.
 
 Manual access is still available if you prefer:
 

--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -53,14 +53,16 @@ The installer pulls the image, provisions your agent with a default identity and
 For installer-managed local containerized installs, the Control UI opens with the saved gateway token.
 Browser device pairing remains enabled by default, so the first browser connect may still require the normal pairing/approval flow.
 
-If the browser prompts for pairing approval, approve the pending device request from the running container. With podman:
+If the browser prompts for pairing approval, go to the **Instances** tab and click **Approve Pairing** on the running instance.
+
+If you prefer to do it manually from the container instead, with podman:
 
 ```bash
 podman exec -it openclaw-<prefix>-<name> openclaw devices list
 podman exec -it openclaw-<prefix>-<name> openclaw devices approve <requestId>
 ```
 
-With docker:
+Or with docker:
 
 ```bash
 docker exec -it openclaw-<prefix>-<name> openclaw devices list

--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -50,7 +50,26 @@ The installer pulls the image, provisions your agent with a default identity and
 
 ## First Browser Connect
 
-For installer-managed local containerized installs, the Control UI opens directly with the saved gateway token.
+For installer-managed local containerized installs, the Control UI opens with the saved gateway token.
+Browser device pairing remains enabled by default, so the first browser connect may still require the normal pairing/approval flow.
+
+If the browser prompts for pairing approval, approve the pending device request from the running container. With podman:
+
+```bash
+podman exec -it openclaw-<prefix>-<name> openclaw devices list
+podman exec -it openclaw-<prefix>-<name> openclaw devices approve <requestId>
+```
+
+With docker:
+
+```bash
+docker exec -it openclaw-<prefix>-<name> openclaw devices list
+docker exec -it openclaw-<prefix>-<name> openclaw devices approve <requestId>
+```
+
+If you already have the upstream OpenClaw CLI installed on the host, you can use that instead by either exporting `OPENCLAW_CONTAINER=openclaw-<prefix>-<name>` directly or sourcing the saved per-instance `.env`.
+
+This is Control UI/browser device pairing, not channel DM pairing. You can find the local container name in the **Instances** tab.
 
 ## Secret Handling
 
@@ -66,7 +85,7 @@ This means the container still receives the credentials it needs, but `openclaw.
 
 Installer-managed local instances save `OPENCLAW_CONTAINER` in their instance `.env`, so the upstream OpenClaw CLI can target the running local container directly.
 
-See [openclaw-cli-local.md](openclaw-cli-local.md) for the exact workflow.
+If the host does not have the upstream OpenClaw CLI installed, use `podman exec` or `docker exec` against the running container instead. See [openclaw-cli-local.md](openclaw-cli-local.md) for both workflows.
 
 ## SSH Sandbox
 
@@ -87,6 +106,8 @@ The installer runs a podman (or docker) container with:
 - Labels: `openclaw.managed=true`, `openclaw.prefix=<prefix>`, `openclaw.agent=<name>`
 - Installer-managed local state volume `openclaw-<prefix>-data` at `/home/node/.openclaw`
 - Optional read-only agent source mount at `/tmp/agent-source` when `AGENT_SOURCE_DIR` or the form field is set
+
+The installer does not disable Control UI device auth by default. This keeps the upstream browser pairing check in place for local deploys.
 
 ### Init script
 

--- a/docs/openclaw-cli-local.md
+++ b/docs/openclaw-cli-local.md
@@ -1,6 +1,10 @@
 # Using OpenClaw Commands With Local Installer Instances
 
-For installer-managed local instances, the most reliable workflow is to run the upstream `openclaw` CLI inside the running container with `podman exec` or `docker exec`.
+For installer-managed local instances, the simplest way to approve first-connect browser pairing is now the **Approve Pairing** button in the **Instances** tab.
+
+This page documents the CLI workflows for cases where you want or need to run the upstream `openclaw` commands manually.
+
+For installer-managed local instances, the most reliable CLI workflow is to run the upstream `openclaw` command inside the running container with `podman exec` or `docker exec`.
 
 Use the host-installed CLI only if you already have it available locally.
 
@@ -22,7 +26,7 @@ docker exec -it openclaw-myuser-myagent openclaw status --deep
 docker exec -it openclaw-myuser-myagent openclaw sandbox explain
 ```
 
-This is also the workflow to approve first-connect browser device pairing for the Control UI:
+If you want to approve first-connect browser device pairing manually instead of using the **Instances** tab button:
 
 ```bash
 podman exec -it openclaw-myuser-myagent openclaw devices list
@@ -64,6 +68,14 @@ openclaw devices approve <requestId>
 ```
 
 Because `OPENCLAW_CONTAINER` is set either way, the host CLI will target the running local containerized instance directly.
+
+That same host CLI workflow can also be used for manual browser pairing approval:
+
+```bash
+source ~/.openclaw/installer/local/openclaw-myuser-myagent/.env
+openclaw devices list
+openclaw devices approve <requestId>
+```
 
 ## Switching Between Local Instances
 

--- a/docs/openclaw-cli-local.md
+++ b/docs/openclaw-cli-local.md
@@ -1,55 +1,90 @@
-# Using The OpenClaw CLI With Local Installer Instances
+# Using OpenClaw Commands With Local Installer Instances
 
-When you deploy locally with `openclaw-installer`, the upstream OpenClaw CLI can target the running container directly via `OPENCLAW_CONTAINER`.
+For installer-managed local instances, the most reliable workflow is to run the upstream `openclaw` CLI inside the running container with `podman exec` or `docker exec`.
 
-For example:
+Use the host-installed CLI only if you already have it available locally.
+
+## Recommended Workflow
+
+If you are using podman:
 
 ```bash
-export OPENCLAW_CONTAINER=openclaw-somalley-lobster
-openclaw health
-openclaw status --deep
-openclaw sandbox explain
+podman exec -it openclaw-myuser-myagent openclaw health
+podman exec -it openclaw-myuser-myagent openclaw status --deep
+podman exec -it openclaw-myuser-myagent openclaw sandbox explain
 ```
 
-The installer also saves per-instance metadata under:
+If you are using docker:
+
+```bash
+docker exec -it openclaw-myuser-myagent openclaw health
+docker exec -it openclaw-myuser-myagent openclaw status --deep
+docker exec -it openclaw-myuser-myagent openclaw sandbox explain
+```
+
+This is also the workflow to approve first-connect browser device pairing for the Control UI:
+
+```bash
+podman exec -it openclaw-myuser-myagent openclaw devices list
+podman exec -it openclaw-myuser-myagent openclaw devices approve <requestId>
+```
+
+Or with docker:
+
+```bash
+docker exec -it openclaw-myuser-myagent openclaw devices list
+docker exec -it openclaw-myuser-myagent openclaw devices approve <requestId>
+```
+
+## Optional Host CLI Workflow
+
+If you already have the upstream OpenClaw CLI installed on the host, the installer also saves per-instance metadata under:
 
 ```text
 ~/.openclaw/installer/local/openclaw-<prefix>-<name>/.env
 ```
 
-## Recommended Workflow
+You can target the running local instance either way:
 
-If you already know the container name, just export `OPENCLAW_CONTAINER` and run normal upstream OpenClaw CLI commands:
+1. export `OPENCLAW_CONTAINER` directly if you already know the container name
+2. source the saved per-instance `.env`, which sets `OPENCLAW_CONTAINER` for you
+
+Examples:
 
 ```bash
-export OPENCLAW_CONTAINER=openclaw-somalley-lobster
+export OPENCLAW_CONTAINER=openclaw-myuser-myagent
 openclaw health
 openclaw status --deep
-openclaw sandbox explain
 ```
-
-If you prefer, you can source the saved `.env` instead:
 
 ```bash
-source ~/.openclaw/installer/local/openclaw-somalley-lobster/.env
-openclaw health
+source ~/.openclaw/installer/local/openclaw-myuser-myagent/.env
+openclaw devices list
+openclaw devices approve <requestId>
 ```
 
-Because `OPENCLAW_CONTAINER` is set either way, the CLI will target the running local containerized instance directly.
+Because `OPENCLAW_CONTAINER` is set either way, the host CLI will target the running local containerized instance directly.
 
 ## Switching Between Local Instances
 
-Set `OPENCLAW_CONTAINER` to the instance you want:
+Use the container name shown in the **Instances** tab.
+
+For container-exec workflows:
 
 ```bash
-export OPENCLAW_CONTAINER=openclaw-somalley-lobster
-openclaw health
-
-export OPENCLAW_CONTAINER=openclaw-somalley-shubra
-openclaw status --deep
+podman exec -it openclaw-myuser-myagent openclaw health
+podman exec -it openclaw-myuser-otheragent openclaw status --deep
 ```
 
-Or source the matching saved `.env` if that is more convenient for your workflow.
+For host CLI workflows:
+
+```bash
+export OPENCLAW_CONTAINER=openclaw-myuser-myagent
+openclaw health
+
+export OPENCLAW_CONTAINER=openclaw-myuser-otheragent
+openclaw status --deep
+```
 
 ## Notes
 

--- a/provider-plugins/openshift/docs/deploy-openshift.md
+++ b/provider-plugins/openshift/docs/deploy-openshift.md
@@ -59,9 +59,7 @@ The Route URL is printed in the deploy log:
 https://openclaw-alice-myagent-openclaw.apps.your-cluster.example.com
 ```
 
-OpenShift OAuth handles the browser authentication in front of the gateway. The installer also configures the Control UI to skip browser device pairing on this OAuth-protected Route, so first connect should not require an extra pairing step.
-
-In the normal OpenShift setup here, that is not materially dangerous in practice because the Route is already protected by the OAuth proxy before traffic reaches the gateway.
+OpenShift OAuth handles browser authentication in front of the gateway, but Control UI device pairing still remains enabled. On first browser connect you may need to approve the pending pairing request from the **Instances** tab with **Approve Pairing**.
 
 Use the **Open** action from the **Instances** tab to open the Route with the saved **Gateway Token** automatically. The token is also saved to:
 

--- a/provider-plugins/openshift/src/openshift-deployer.ts
+++ b/provider-plugins/openshift/src/openshift-deployer.ts
@@ -187,10 +187,6 @@ export class OpenShiftDeployer implements Deployer {
           // Set allowedOrigins to include the Route URL
           if (parsed.gateway?.controlUi) {
             parsed.gateway.controlUi.allowedOrigins = [routeUrl];
-            // OAuth proxy already authenticates end users before they reach the
-            // gateway, so skipping device pairing on this Route is not
-            // meaningfully dangerous in practice.
-            parsed.gateway.controlUi.dangerouslyDisableDeviceAuth = true;
           }
           // NOTE: we intentionally do NOT set gateway.trustedProxies here.
           // Setting trustedProxies to ["127.0.0.1", "::1"] causes the gateway
@@ -198,9 +194,10 @@ export class OpenShiftDeployer implements Deployer {
           // for X-Forwarded-For headers that aren't there), which breaks
           // shouldAllowSilentLocalPairing and blocks subagent spawning (#69).
           // Without trustedProxies, the gateway logs a cosmetic warning about
-          // "proxy headers from untrusted address" but the Control UI still
-          // works because dangerouslyDisableDeviceAuth bypasses device auth.
-          // See ADR 0002 for full rationale.
+          // "proxy headers from untrusted address". Browser pairing stays
+          // enabled and can be approved from the Instances page. See
+          // adr/0002-remove-trustedproxies-for-subagent-pairing.md for the
+          // trustedProxies rationale.
 
           // Bind to loopback since OAuth proxy fronts the gateway
           if (parsed.gateway) {

--- a/src/client/components/InstanceList.tsx
+++ b/src/client/components/InstanceList.tsx
@@ -107,6 +107,7 @@ export default function InstanceList({ active }: { active: boolean }) {
   const [acting, setActing] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Record<string, ExpandedPanel>>({});
   const [panelData, setPanelData] = useState<Record<string, string>>({});
+  const [pairingMessages, setPairingMessages] = useState<Record<string, { tone: "success" | "warning" | "error"; text: string }>>({});
 
   const fetchInstances = async () => {
     try {
@@ -179,7 +180,48 @@ export default function InstanceList({ active }: { active: boolean }) {
 
   const handleApproveDevice = async (id: string) => {
     setActing(id);
-    await fetch(`/api/instances/${id}/approve-device`, { method: "POST" });
+    setPairingMessages((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    try {
+      const res = await fetch(`/api/instances/${id}/approve-device`, { method: "POST" });
+      const data = await res.json();
+      if (res.ok && data.status === "noop") {
+        setPairingMessages((prev) => ({
+          ...prev,
+          [id]: {
+            tone: "warning",
+            text: data.error || "No pending device pairing requests.",
+          },
+        }));
+      } else if (res.ok) {
+        setPairingMessages((prev) => ({
+          ...prev,
+          [id]: {
+            tone: "success",
+            text: "Approved the latest pending pairing request.",
+          },
+        }));
+      } else {
+        setPairingMessages((prev) => ({
+          ...prev,
+          [id]: {
+            tone: "error",
+            text: data.error || `Failed to approve pairing (${res.status})`,
+          },
+        }));
+      }
+    } catch (err) {
+      setPairingMessages((prev) => ({
+        ...prev,
+        [id]: {
+          tone: "error",
+          text: err instanceof Error ? err.message : "Failed to approve pairing",
+        },
+      }));
+    }
     await fetchInstances();
     setActing(null);
   };
@@ -282,10 +324,26 @@ export default function InstanceList({ active }: { active: boolean }) {
 
   return (
     <div className="card" style={{ padding: 0 }}>
+      <div
+        style={{
+          padding: "0.75rem 1rem",
+          borderBottom: "1px solid var(--border)",
+          background: "rgba(243, 156, 18, 0.08)",
+          color: "var(--text-secondary)",
+          fontSize: "0.9rem",
+        }}
+      >
+        Browser access may require a one-time device pairing. If the Control UI asks to pair, use
+        {" "}
+        <strong>Approve Pairing</strong>
+        {" "}
+        on the running instance.
+      </div>
       {instances.map((inst) => {
         const isActing = acting === inst.id;
         const activePanel = expanded[inst.id];
         const panelContent = panelData[`${inst.id}-${activePanel}`];
+        const pairingMessage = pairingMessages[inst.id];
         const isRunning = inst.status === "running";
         const isStopped = inst.status === "stopped";
         const isDeploying = inst.status === "deploying";
@@ -342,16 +400,14 @@ export default function InstanceList({ active }: { active: boolean }) {
               <div className="instance-actions">
                 {isRunning && (
                   <>
-                    {!isK8s && (
-                      <button
-                        className="btn btn-ghost"
-                        disabled={isActing}
-                        onClick={() => handleApproveDevice(inst.id)}
-                        title="Approve the latest pending browser device pairing request"
-                      >
-                        Approve Pairing
-                      </button>
-                    )}
+                    <button
+                      className="btn btn-ghost"
+                      disabled={isActing}
+                      onClick={() => handleApproveDevice(inst.id)}
+                      title="Approve the latest pending browser device pairing request"
+                    >
+                      Approve Pairing
+                    </button>
                     <button
                       className="btn btn-ghost"
                       onClick={() => togglePanel(inst.id, "connection")}
@@ -418,6 +474,23 @@ export default function InstanceList({ active }: { active: boolean }) {
                 </button>
               </div>
             </div>
+            {pairingMessage && (
+              <div
+                style={{
+                  padding: "0.5rem 1rem",
+                  borderTop: "1px solid var(--border)",
+                  color:
+                    pairingMessage.tone === "success"
+                      ? "#1f7a3d"
+                      : pairingMessage.tone === "warning"
+                        ? "#9a6700"
+                        : "#e74c3c",
+                  fontSize: "0.85rem",
+                }}
+              >
+                {pairingMessage.text}
+              </div>
+            )}
             <K8sProgress inst={inst} />
             {activePanel === "connection" && panelContent && inst.url && (
               <div

--- a/src/client/components/InstanceList.tsx
+++ b/src/client/components/InstanceList.tsx
@@ -177,6 +177,13 @@ export default function InstanceList({ active }: { active: boolean }) {
     setActing(null);
   };
 
+  const handleApproveDevice = async (id: string) => {
+    setActing(id);
+    await fetch(`/api/instances/${id}/approve-device`, { method: "POST" });
+    await fetchInstances();
+    setActing(null);
+  };
+
   const handleDeleteData = async (id: string, mode?: string) => {
     if (
       !confirm(
@@ -335,6 +342,16 @@ export default function InstanceList({ active }: { active: boolean }) {
               <div className="instance-actions">
                 {isRunning && (
                   <>
+                    {!isK8s && (
+                      <button
+                        className="btn btn-ghost"
+                        disabled={isActing}
+                        onClick={() => handleApproveDevice(inst.id)}
+                        title="Approve the latest pending browser device pairing request"
+                      >
+                        Approve Pairing
+                      </button>
+                    )}
                     <button
                       className="btn btn-ghost"
                       onClick={() => togglePanel(inst.id, "connection")}

--- a/src/client/components/__tests__/InstanceList.test.tsx
+++ b/src/client/components/__tests__/InstanceList.test.tsx
@@ -93,10 +93,11 @@ describe("InstanceList", () => {
     await waitFor(() => {
       expect(screen.getByText("abc123")).toBeInTheDocument();
     });
+    expect(screen.getByText(/browser access may require a one-time device pairing/i)).toBeInTheDocument();
     expect(screen.getByText("running")).toBeInTheDocument();
     expect(screen.getByText("http://localhost:18789")).toBeInTheDocument();
     // Running instances show panel and lifecycle buttons
-    expect(screen.getByText("Approve Pairing")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /approve pairing/i })).toBeInTheDocument();
     expect(screen.getByText("Connection Info")).toBeInTheDocument();
     expect(screen.getByText("Command")).toBeInTheDocument();
     expect(screen.getByText("Logs")).toBeInTheDocument();
@@ -144,7 +145,7 @@ describe("InstanceList", () => {
       expect(screen.getByRole("button", { name: /delete data/i })).toBeInTheDocument();
     });
     expect(screen.getByRole("button", { name: /delete data/i })).not.toBeDisabled();
-    expect(screen.queryByRole("button", { name: /approve pairing/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /approve pairing/i })).toBeInTheDocument();
   });
 
   it("toggles connection info panel on button click", async () => {
@@ -233,6 +234,62 @@ describe("InstanceList", () => {
 
     await user.click(screen.getByRole("button", { name: /approve pairing/i }));
     expect(fetchMock).toHaveBeenCalledWith("/api/instances/inst-1/approve-device", { method: "POST" });
+  });
+
+  it("shows a success message after pairing approval succeeds", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    globalThis.fetch = vi.fn((url: string, opts?: RequestInit) => {
+      if (url === "/api/health") {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ k8sAvailable: false }) });
+      }
+      if ((url === "/api/instances" || url === "/api/instances?includeK8s=1") && !opts?.method) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([runningInstance]) });
+      }
+      if (url === "/api/instances/inst-1/approve-device") {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: "approved" }) });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    }) as unknown as typeof globalThis.fetch;
+
+    render(<InstanceList active />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /approve pairing/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /approve pairing/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/approved the latest pending pairing request/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows a no-pending message when there is nothing to approve", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    globalThis.fetch = vi.fn((url: string, opts?: RequestInit) => {
+      if (url === "/api/health") {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ k8sAvailable: false }) });
+      }
+      if ((url === "/api/instances" || url === "/api/instances?includeK8s=1") && !opts?.method) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([runningInstance]) });
+      }
+      if (url === "/api/instances/inst-1/approve-device") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: "noop", error: "No pending device pairing requests" }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    }) as unknown as typeof globalThis.fetch;
+
+    render(<InstanceList active />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /approve pairing/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /approve pairing/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/no pending device pairing requests/i)).toBeInTheDocument();
+    });
   });
 
   it("opens URL with token via handleOpenWithToken", async () => {

--- a/src/client/components/__tests__/InstanceList.test.tsx
+++ b/src/client/components/__tests__/InstanceList.test.tsx
@@ -96,6 +96,7 @@ describe("InstanceList", () => {
     expect(screen.getByText("running")).toBeInTheDocument();
     expect(screen.getByText("http://localhost:18789")).toBeInTheDocument();
     // Running instances show panel and lifecycle buttons
+    expect(screen.getByText("Approve Pairing")).toBeInTheDocument();
     expect(screen.getByText("Connection Info")).toBeInTheDocument();
     expect(screen.getByText("Command")).toBeInTheDocument();
     expect(screen.getByText("Logs")).toBeInTheDocument();
@@ -143,6 +144,7 @@ describe("InstanceList", () => {
       expect(screen.getByRole("button", { name: /delete data/i })).toBeInTheDocument();
     });
     expect(screen.getByRole("button", { name: /delete data/i })).not.toBeDisabled();
+    expect(screen.queryByRole("button", { name: /approve pairing/i })).not.toBeInTheDocument();
   });
 
   it("toggles connection info panel on button click", async () => {
@@ -217,6 +219,20 @@ describe("InstanceList", () => {
 
     await user.click(screen.getByRole("button", { name: /re-deploy/i }));
     expect(fetchMock).toHaveBeenCalledWith("/api/instances/k8s-1/redeploy", { method: "POST" });
+  });
+
+  it("calls approve-device endpoint when Approve Pairing is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const fetchMock = mockFetchWith([runningInstance]);
+    globalThis.fetch = fetchMock;
+
+    render(<InstanceList active />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /approve pairing/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /approve pairing/i }));
+    expect(fetchMock).toHaveBeenCalledWith("/api/instances/inst-1/approve-device", { method: "POST" });
   });
 
   it("opens URL with token via handleOpenWithToken", async () => {

--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -119,9 +119,7 @@ describe("model config generation", () => {
     expect(rendered.models?.providers?.endpoint?.models).toEqual([]);
   });
 
-  // Regression test for #69: K8s config must disable device auth so the
-  // Control UI can connect without manual pairing.
-  it("disables device auth in the Control UI config", () => {
+  it("keeps device auth enabled in the Control UI config", () => {
     const config = makeConfig();
     const rendered = buildOpenClawConfig(config, "gateway-token") as {
       gateway?: {
@@ -133,7 +131,7 @@ describe("model config generation", () => {
     };
 
     expect(rendered.gateway?.controlUi?.enabled).toBe(true);
-    expect(rendered.gateway?.controlUi?.dangerouslyDisableDeviceAuth).toBe(true);
+    expect(rendered.gateway?.controlUi?.dangerouslyDisableDeviceAuth).toBeUndefined();
   });
 
   it("can disable OpenAI-compatible gateway endpoints in generated config", () => {

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -408,12 +408,12 @@ export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string):
   const model = deriveModel(config);
   const openaiCompatibleEndpointsEnabled = config.openaiCompatibleEndpointsEnabled !== false;
   const sourceBundle = loadAgentSourceBundle(config);
+  const pluginAllowlist = Array.from(new Set<string>([
+    ...(shouldUseOtel(config) ? ["diagnostics-otel"] : []),
+    ...((config.telegramBotToken || config.telegramBotTokenRef) ? ["telegram"] : []),
+  ]));
   const controlUi: Record<string, unknown> = {
     enabled: true,
-    // Bypass first-connect browser pairing — the gateway is behind K8s
-    // network policies and token auth, so device-level auth adds friction
-    // without meaningful security benefit (fixes #69).
-    dangerouslyDisableDeviceAuth: true,
   };
   controlUi.allowedOrigins = ["http://localhost:18789"];
   const useOtel = shouldUseOtel(config);
@@ -421,7 +421,7 @@ export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string):
     // Enable diagnostics-otel plugin so the gateway emits OTLP traces
     ...(useOtel ? {
       plugins: {
-        allow: ["diagnostics-otel"],
+        allow: pluginAllowlist,
         entries: { "diagnostics-otel": { enabled: true } },
       },
       diagnostics: {

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -416,18 +416,30 @@ function buildAgentModelConfig(config: DeployConfig, primaryModelRef: string): {
     : { primary: primaryModelRef };
 }
 
+function requiredBundledPluginAllowlist(config: DeployConfig): string[] {
+  const allow = new Set<string>();
+  if (shouldUseOtel(config)) {
+    allow.add("diagnostics-otel");
+  }
+  if (config.telegramBotToken || config.telegramBotTokenRef) {
+    allow.add("telegram");
+  }
+  return Array.from(allow);
+}
+
 function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string {
   const agentId = `${config.prefix || "openclaw"}_${config.agentName}`;
   const model = deriveModel(config);
   const port = config.port ?? 18789;
   const openaiCompatibleEndpointsEnabled = config.openaiCompatibleEndpointsEnabled !== false;
   const useOtel = shouldUseOtel(config);
+  const pluginAllowlist = requiredBundledPluginAllowlist(config);
   const sourceBundle = loadAgentSourceBundle(config);
   const ocConfig: Record<string, unknown> = {
     // Enable diagnostics-otel plugin so the gateway emits OTLP traces
     ...(useOtel ? {
       plugins: {
-        allow: ["diagnostics-otel"],
+        allow: pluginAllowlist,
         entries: { "diagnostics-otel": { enabled: true } },
       },
       diagnostics: {
@@ -459,10 +471,6 @@ function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string
           `http://localhost:${port}`,
           `http://127.0.0.1:${port}`,
         ],
-        // The installer exposes the gateway only on localhost via port mapping.
-        // With a proper auth proxy in front, this bypass is not meaningfully
-        // dangerous in practice; here it avoids first-connect browser pairing.
-        dangerouslyDisableDeviceAuth: true,
       },
     },
     agents: {

--- a/src/server/routes/status.ts
+++ b/src/server/routes/status.ts
@@ -356,44 +356,77 @@ router.post("/:id/approve-device", async (req, res) => {
     return;
   }
 
-  if (instance.mode !== "local") {
-    res.status(400).json({ error: "Device approval is currently only supported for local instances" });
-    return;
-  }
-
-  const runtime = await detectRuntime();
-  if (!runtime) {
-    res.status(500).json({ error: "No container runtime" });
-    return;
-  }
-
-  const containers = await discoverContainers(runtime);
-  const c = containers.find((container) => container.name === req.params.id);
-  if (!c || c.status !== "running") {
-    res.status(400).json({ error: "Instance must be running to approve pairing" });
-    return;
-  }
-
   try {
-    const { execFile } = await import("node:child_process");
-    const { promisify } = await import("node:util");
-    const execFileAsync = promisify(execFile);
-    const { stdout, stderr } = await execFileAsync(runtime, [
-      "exec",
-      req.params.id,
-      "openclaw",
-      "devices",
-      "approve",
-      "--latest",
-    ]);
+    let stdout = "";
+    let stderr = "";
+
+    if (instance.mode === "local") {
+      const runtime = await detectRuntime();
+      if (!runtime) {
+        res.status(500).json({ error: "No container runtime" });
+        return;
+      }
+
+      const containers = await discoverContainers(runtime);
+      const c = containers.find((container) => container.name === req.params.id);
+      if (!c || c.status !== "running") {
+        res.status(400).json({ error: "Instance must be running to approve pairing" });
+        return;
+      }
+
+      const { execFile } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execFileAsync = promisify(execFile);
+      const result = await execFileAsync(runtime, [
+        "exec",
+        req.params.id,
+        "openclaw",
+        "devices",
+        "approve",
+        "--latest",
+      ]);
+      stdout = result.stdout.trim();
+      stderr = result.stderr.trim();
+    } else {
+      const ns = instance.config.namespace || instance.containerId || "";
+      const { coreApi, execInPod } = await import("../services/k8s.js");
+      const core = coreApi();
+      const podList = await core.listNamespacedPod({
+        namespace: ns,
+        labelSelector: "app=openclaw",
+      });
+      const pod = podList.items[0];
+      const podName = pod?.metadata?.name;
+      if (!podName) {
+        res.status(400).json({ error: "No running pod found to approve pairing" });
+        return;
+      }
+
+      const result = await execInPod(
+        ns,
+        podName,
+        "gateway",
+        ["openclaw", "devices", "approve", "--latest"],
+      );
+      stdout = result.stdout;
+      stderr = result.stderr;
+    }
 
     res.json({
       status: "approved",
       output: [stdout, stderr].filter(Boolean).join("").trim(),
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    res.status(500).json({ error: message });
+    const execError = err as Error & { stdout?: string; stderr?: string };
+    const details = [execError.stdout, execError.stderr, execError.message].filter(Boolean).join("\n").trim();
+    if (/\b(no|none|not)\b.*\b(pending|request|approval)\b/i.test(details)) {
+      res.json({
+        status: "noop",
+        error: "No pending device pairing requests",
+      });
+      return;
+    }
+    res.status(500).json({ error: details || "Failed to approve device pairing" });
   }
 });
 

--- a/src/server/routes/status.ts
+++ b/src/server/routes/status.ts
@@ -348,6 +348,55 @@ router.post("/:id/redeploy", async (req, res) => {
   }
 });
 
+// Approve the latest pending device pairing request for a running local instance.
+router.post("/:id/approve-device", async (req, res) => {
+  const instance = await findInstance(req.params.id);
+  if (!instance) {
+    res.status(404).json({ error: "Instance not found" });
+    return;
+  }
+
+  if (instance.mode !== "local") {
+    res.status(400).json({ error: "Device approval is currently only supported for local instances" });
+    return;
+  }
+
+  const runtime = await detectRuntime();
+  if (!runtime) {
+    res.status(500).json({ error: "No container runtime" });
+    return;
+  }
+
+  const containers = await discoverContainers(runtime);
+  const c = containers.find((container) => container.name === req.params.id);
+  if (!c || c.status !== "running") {
+    res.status(400).json({ error: "Instance must be running to approve pairing" });
+    return;
+  }
+
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+    const { stdout, stderr } = await execFileAsync(runtime, [
+      "exec",
+      req.params.id,
+      "openclaw",
+      "devices",
+      "approve",
+      "--latest",
+    ]);
+
+    res.json({
+      status: "approved",
+      output: [stdout, stderr].filter(Boolean).join("").trim(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(500).json({ error: message });
+  }
+});
+
 // Get gateway token from running container or K8s secret
 router.get("/:id/token", async (req, res) => {
   // Check if this is a K8s instance

--- a/src/server/services/k8s.ts
+++ b/src/server/services/k8s.ts
@@ -1,4 +1,5 @@
 import * as k8s from "@kubernetes/client-node";
+import { Writable } from "node:stream";
 
 let _kc: k8s.KubeConfig | null = null;
 
@@ -25,6 +26,87 @@ export function coreApi(): k8s.CoreV1Api {
 
 export function appsApi(): k8s.AppsV1Api {
   return loadKubeConfig().makeApiClient(k8s.AppsV1Api);
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  status?: unknown;
+}
+
+export async function execInPod(
+  namespace: string,
+  podName: string,
+  containerName: string,
+  command: string[],
+): Promise<ExecResult> {
+  const kc = loadKubeConfig();
+  const exec = new k8s.Exec(kc);
+
+  let stdout = "";
+  let stderr = "";
+  let settled = false;
+
+  const stdoutStream = new Writable({
+    write(chunk, _encoding, callback) {
+      stdout += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+      callback();
+    },
+  });
+  const stderrStream = new Writable({
+    write(chunk, _encoding, callback) {
+      stderr += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+      callback();
+    },
+  });
+
+  return await new Promise<ExecResult>((resolve, reject) => {
+    void exec.exec(
+      namespace,
+      podName,
+      containerName,
+      command,
+      stdoutStream,
+      stderrStream,
+      null,
+      false,
+      (status) => {
+        if (settled) return;
+        settled = true;
+        const code = Number(
+          (status as { details?: { causes?: Array<{ reason?: string; message?: string }> } })
+            .details?.causes?.find((cause) => cause.reason === "ExitCode")?.message ?? "0",
+        );
+        if (code === 0) {
+          resolve({ stdout: stdout.trim(), stderr: stderr.trim(), status });
+          return;
+        }
+        const errorText = [stdout, stderr].filter(Boolean).join("\n").trim()
+          || `Pod exec failed with exit code ${code}`;
+        reject(Object.assign(new Error(errorText), {
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+          status,
+          exitCode: code,
+        }));
+      },
+    ).then((ws) => {
+      ws.onclose = () => {
+        if (settled) return;
+        settled = true;
+        resolve({ stdout: stdout.trim(), stderr: stderr.trim() });
+      };
+      ws.onerror = (event) => {
+        if (settled) return;
+        settled = true;
+        reject(new Error(`Pod exec websocket error: ${String(event)}`));
+      };
+    }).catch((err) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    });
+  });
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/sallyom/openclaw-installer/issues/82 

Removes the dangerouslyDisableDeviceAuth from all deployments and adds a "Pair device" button in Instances page.