### PR TITLE
feat: add MCP server config via Agent Source Directory (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ registered as additional agents through `openclaw-agents.json`.
 
 The `software-qa-mcp` demo includes:
 
-- `mcp.json` for DeepWiki and Context7 MCP servers
+- `mcp.json` for the Context7 MCP server
 - `exec-approvals.json` for baseline tool approval policy
 - `workspace-main/` with a software Q&A agent persona
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ For upstream sandbox concepts and backend behavior, see the [OpenClaw sandboxing
 Try:
 
 - `demos/openclaw-builder-research-ops`
+- `demos/software-qa-mcp`
 
 This demo includes:
 
@@ -141,10 +142,49 @@ This demo includes:
 Other `workspace-*` directories are copied through as named agent workspaces and can be
 registered as additional agents through `openclaw-agents.json`.
 
+The `software-qa-mcp` demo includes:
+
+- `mcp.json` for DeepWiki and Context7 MCP servers
+- `exec-approvals.json` for baseline tool approval policy
+- `workspace-main/` with a software Q&A agent persona
+
 Environment templates are included too:
 
 - `.env.example` for a generic installer setup
 - `demos/openclaw-builder-research-ops/.env.example` for the bundled sandbox demo
+
+## MCP Servers
+
+The installer supports provisioning MCP servers through the Agent Source Directory. Place a `mcp.json` file in your agent source directory:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "url": "https://mcp.example.com/mcp"
+    }
+  }
+}
+```
+
+The installer merges these into the generated `openclaw.json` at deploy time.
+
+For tool approval policies, add an `exec-approvals.json`:
+
+```json
+{
+  "version": 1,
+  "defaults": {
+    "security": "allowlist",
+    "ask": "on-miss",
+    "askFallback": "deny"
+  }
+}
+```
+
+This file is copied directly to `~/.openclaw/exec-approvals.json` in the deployed instance.
+
+See `demos/software-qa-mcp` for a complete example.
 
 ## Agent Workspaces
 

--- a/demos/software-qa-mcp/README.md
+++ b/demos/software-qa-mcp/README.md
@@ -2,16 +2,15 @@
 
 This demo is an `Agent Source Directory` bundle for the OpenClaw installer.
 
-It provisions a single agent that can answer questions about software using live documentation from two MCP servers:
+It provisions a single agent that can answer questions about software using live documentation from an MCP server:
 
-- **DeepWiki** — AI-powered docs for any GitHub repository
 - **Context7** — Current docs for popular libraries and frameworks
 
 ## What's included
 
 | File | Purpose |
 |------|---------|
-| `mcp.json` | Configures DeepWiki and Context7 as streamable HTTP MCP servers |
+| `mcp.json` | Configures Context7 as a streamable HTTP MCP server |
 | `exec-approvals.json` | Sets baseline tool approval policy |
 | `workspace-main/AGENTS.md` | Agent identity and instructions |
 | `workspace-main/SOUL.md` | Agent persona |
@@ -20,7 +19,7 @@ It provisions a single agent that can answer questions about software using live
 
 1. Open the OpenClaw installer
 2. Set **Agent Source Directory** to this folder (e.g., `demos/software-qa-mcp`)
-3. Deploy as usual — the MCP servers are configured automatically
+3. Deploy as usual — the MCP server is configured automatically
 
 After deployment, ask your agent questions like:
 
@@ -38,7 +37,8 @@ Edit `mcp.json` to add or remove MCP servers. The format follows the OpenClaw `m
 {
   "mcpServers": {
     "server-name": {
-      "url": "https://your-server.example.com/mcp"
+      "url": "https://your-server.example.com/mcp",
+      "transport": "streamable-http"
     }
   }
 }

--- a/demos/software-qa-mcp/README.md
+++ b/demos/software-qa-mcp/README.md
@@ -1,0 +1,58 @@
+# Software Q&A with MCP Servers Demo
+
+This demo is an `Agent Source Directory` bundle for the OpenClaw installer.
+
+It provisions a single agent that can answer questions about software using live documentation from two MCP servers:
+
+- **DeepWiki** — AI-powered docs for any GitHub repository
+- **Context7** — Current docs for popular libraries and frameworks
+
+## What's included
+
+| File | Purpose |
+|------|---------|
+| `mcp.json` | Configures DeepWiki and Context7 as streamable HTTP MCP servers |
+| `exec-approvals.json` | Sets baseline tool approval policy |
+| `workspace-main/AGENTS.md` | Agent identity and instructions |
+| `workspace-main/SOUL.md` | Agent persona |
+
+## How to use it
+
+1. Open the OpenClaw installer
+2. Set **Agent Source Directory** to this folder (e.g., `demos/software-qa-mcp`)
+3. Deploy as usual — the MCP servers are configured automatically
+
+After deployment, ask your agent questions like:
+
+- "How does the Next.js App Router handle layouts?"
+- "What's the API for the octokit/rest.js GitHub client?"
+- "How does Django's ORM handle migrations?"
+
+The agent will use its MCP tools to fetch current documentation before answering.
+
+## Customizing
+
+Edit `mcp.json` to add or remove MCP servers. The format follows the OpenClaw `mcpServers` convention:
+
+```json
+{
+  "mcpServers": {
+    "server-name": {
+      "url": "https://your-server.example.com/mcp"
+    }
+  }
+}
+```
+
+For stdio-based servers, use `command` and `args` instead of `url`:
+
+```json
+{
+  "mcpServers": {
+    "local-server": {
+      "command": "npx",
+      "args": ["-y", "@some/mcp-server"]
+    }
+  }
+}
+```

--- a/demos/software-qa-mcp/exec-approvals.json
+++ b/demos/software-qa-mcp/exec-approvals.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "defaults": {
+    "security": "allowlist",
+    "ask": "on-miss",
+    "askFallback": "deny"
+  }
+}

--- a/demos/software-qa-mcp/mcp.json
+++ b/demos/software-qa-mcp/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "DeepWiki MCP Server": {
+      "url": "https://mcp.deepwiki.com/mcp"
+    },
+    "Context7 MCP Server": {
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}

--- a/demos/software-qa-mcp/mcp.json
+++ b/demos/software-qa-mcp/mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
-    "DeepWiki MCP Server": {
-      "url": "https://mcp.deepwiki.com/mcp"
-    },
     "Context7 MCP Server": {
-      "url": "https://mcp.context7.com/mcp"
+      "url": "https://mcp.context7.com/mcp",
+      "transport": "streamable-http"
     }
   }
 }

--- a/demos/software-qa-mcp/workspace-main/AGENTS.md
+++ b/demos/software-qa-mcp/workspace-main/AGENTS.md
@@ -9,17 +9,16 @@ You answer questions about software libraries, frameworks, and tools using live 
 
 ## Capabilities
 
-You have access to two MCP servers that give you live, up-to-date documentation:
+You have access to an MCP server that gives you live, up-to-date documentation:
 
-- **DeepWiki**: AI-powered documentation for any GitHub repository. Use this to look up how specific open-source projects work, their APIs, architecture, and usage patterns.
 - **Context7**: Current documentation for popular libraries and frameworks. Use this when asked about React, Next.js, Django, Express, Tailwind, and other well-known tools.
 
 ## Operating Model
 
 1. When asked about a library or framework, use your MCP tools to fetch current documentation before answering.
 2. Prefer MCP-sourced docs over your training data — they reflect the latest versions.
-3. Cite which source you used (DeepWiki or Context7) so the user knows where the information came from.
-4. If neither MCP server covers the topic, say so and answer from your training data with a caveat.
+3. Cite that you used Context7 so the user knows where the information came from.
+4. If Context7 doesn't cover the topic, say so and answer from your training data with a caveat.
 
 ## Style
 

--- a/demos/software-qa-mcp/workspace-main/AGENTS.md
+++ b/demos/software-qa-mcp/workspace-main/AGENTS.md
@@ -1,0 +1,28 @@
+---
+name: Software Q&A
+description: An agent that answers questions about software using live documentation
+---
+
+# Software Q&A Agent
+
+You answer questions about software libraries, frameworks, and tools using live documentation sources.
+
+## Capabilities
+
+You have access to two MCP servers that give you live, up-to-date documentation:
+
+- **DeepWiki**: AI-powered documentation for any GitHub repository. Use this to look up how specific open-source projects work, their APIs, architecture, and usage patterns.
+- **Context7**: Current documentation for popular libraries and frameworks. Use this when asked about React, Next.js, Django, Express, Tailwind, and other well-known tools.
+
+## Operating Model
+
+1. When asked about a library or framework, use your MCP tools to fetch current documentation before answering.
+2. Prefer MCP-sourced docs over your training data — they reflect the latest versions.
+3. Cite which source you used (DeepWiki or Context7) so the user knows where the information came from.
+4. If neither MCP server covers the topic, say so and answer from your training data with a caveat.
+
+## Style
+
+- Be concise and direct.
+- Include code examples when they help.
+- Note version-specific behavior when relevant.

--- a/demos/software-qa-mcp/workspace-main/SOUL.md
+++ b/demos/software-qa-mcp/workspace-main/SOUL.md
@@ -1,0 +1,3 @@
+You are a helpful software documentation assistant. You specialize in answering technical questions about libraries, frameworks, APIs, and development tools with accurate, up-to-date information.
+
+You value precision over speed — always check the docs before answering.

--- a/src/server/deployers/__tests__/agent-source.test.ts
+++ b/src/server/deployers/__tests__/agent-source.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
-import { loadAgentSourceCronJobs, subagentIds, mainWorkspaceShellCondition } from "../agent-source.js";
+import { loadAgentSourceCronJobs, loadAgentSourceMcpServers, loadAgentSourceExecApprovals, subagentIds, mainWorkspaceShellCondition } from "../agent-source.js";
 import type { AgentSourceBundle } from "../agent-source.js";
 
 const tempDirs: string[] = [];
@@ -116,5 +116,104 @@ describe("mainWorkspaceShellCondition", () => {
     expect(result).not.toContain('"workspace-main"');
     // It will fall to the else branch → main dest
     expect(result).toContain(`else dest="${mainDest}"`);
+  });
+});
+
+describe("loadAgentSourceMcpServers", () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup failures in tests.
+      }
+    }
+  });
+
+  it("loads mcpServers from mcp.json with wrapper format", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-agent-source-"));
+    tempDirs.push(dir);
+    writeFileSync(
+      join(dir, "mcp.json"),
+      JSON.stringify({ mcpServers: { test: { url: "https://example.com" } } }),
+      "utf8",
+    );
+
+    expect(loadAgentSourceMcpServers(dir)).toEqual({
+      test: { url: "https://example.com" },
+    });
+  });
+
+  it("loads mcpServers from mcp.json with flat format", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-agent-source-"));
+    tempDirs.push(dir);
+    writeFileSync(
+      join(dir, "mcp.json"),
+      JSON.stringify({ test: { url: "https://example.com" } }),
+      "utf8",
+    );
+
+    expect(loadAgentSourceMcpServers(dir)).toEqual({
+      test: { url: "https://example.com" },
+    });
+  });
+
+  it("returns undefined when no mcp.json exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-agent-source-"));
+    tempDirs.push(dir);
+
+    expect(loadAgentSourceMcpServers(dir)).toBeUndefined();
+  });
+
+  it("returns undefined for invalid JSON", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-agent-source-"));
+    tempDirs.push(dir);
+    writeFileSync(join(dir, "mcp.json"), "not json", "utf8");
+
+    expect(loadAgentSourceMcpServers(dir)).toBeUndefined();
+  });
+
+  it("returns undefined for empty object", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-agent-source-"));
+    tempDirs.push(dir);
+    writeFileSync(join(dir, "mcp.json"), "{}", "utf8");
+
+    expect(loadAgentSourceMcpServers(dir)).toBeUndefined();
+  });
+
+  it("returns undefined when agentSourceDir is undefined", () => {
+    expect(loadAgentSourceMcpServers(undefined)).toBeUndefined();
+  });
+});
+
+describe("loadAgentSourceExecApprovals", () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup failures in tests.
+      }
+    }
+  });
+
+  it("loads exec-approvals.json content", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-agent-source-"));
+    tempDirs.push(dir);
+    const content = JSON.stringify({ approvals: [{ command: "npm test" }] });
+    writeFileSync(join(dir, "exec-approvals.json"), content, "utf8");
+
+    expect(loadAgentSourceExecApprovals(dir)).toBe(content);
+  });
+
+  it("returns undefined when no exec-approvals.json exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-agent-source-"));
+    tempDirs.push(dir);
+
+    expect(loadAgentSourceExecApprovals(dir)).toBeUndefined();
+  });
+
+  it("returns undefined when agentSourceDir is undefined", () => {
+    expect(loadAgentSourceExecApprovals(undefined)).toBeUndefined();
   });
 });

--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildOpenClawConfig,
   deriveModel,
@@ -623,5 +626,59 @@ describe("detectUnavailableProvider", () => {
     const config = makeConfig({});
     expect(detectUnavailableProvider("litellm/my-model", config)).toBe(false);
     expect(detectUnavailableProvider("custom/model", config)).toBe(false);
+  });
+});
+
+describe("MCP servers from agent source", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup failures in tests.
+      }
+    }
+  });
+
+  it("includes mcpServers when mcp.json exists in agent source dir", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-k8s-mcp-"));
+    tempDirs.push(dir);
+    writeFileSync(
+      join(dir, "mcp.json"),
+      JSON.stringify({ mcpServers: { myserver: { url: "https://mcp.example.com" } } }),
+      "utf8",
+    );
+
+    const config = makeConfig({ agentSourceDir: dir });
+    const rendered = buildOpenClawConfig(config, "gateway-token") as {
+      mcpServers?: Record<string, unknown>;
+    };
+
+    expect(rendered.mcpServers).toEqual({
+      myserver: { url: "https://mcp.example.com" },
+    });
+  });
+
+  it("omits mcpServers when no mcp.json in agent source dir", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-k8s-mcp-"));
+    tempDirs.push(dir);
+
+    const config = makeConfig({ agentSourceDir: dir });
+    const rendered = buildOpenClawConfig(config, "gateway-token") as {
+      mcpServers?: Record<string, unknown>;
+    };
+
+    expect(rendered.mcpServers).toBeUndefined();
+  });
+
+  it("omits mcpServers when agentSourceDir is not set", () => {
+    const config = makeConfig();
+    const rendered = buildOpenClawConfig(config, "gateway-token") as {
+      mcpServers?: Record<string, unknown>;
+    };
+
+    expect(rendered.mcpServers).toBeUndefined();
   });
 });

--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -642,7 +642,7 @@ describe("MCP servers from agent source", () => {
     }
   });
 
-  it("includes mcpServers when mcp.json exists in agent source dir", () => {
+  it("includes mcp.servers when mcp.json exists in agent source dir", () => {
     const dir = mkdtempSync(join(tmpdir(), "openclaw-k8s-mcp-"));
     tempDirs.push(dir);
     writeFileSync(
@@ -653,32 +653,32 @@ describe("MCP servers from agent source", () => {
 
     const config = makeConfig({ agentSourceDir: dir });
     const rendered = buildOpenClawConfig(config, "gateway-token") as {
-      mcpServers?: Record<string, unknown>;
+      mcp?: { servers?: Record<string, unknown> };
     };
 
-    expect(rendered.mcpServers).toEqual({
+    expect(rendered.mcp?.servers).toEqual({
       myserver: { url: "https://mcp.example.com" },
     });
   });
 
-  it("omits mcpServers when no mcp.json in agent source dir", () => {
+  it("omits mcp when no mcp.json in agent source dir", () => {
     const dir = mkdtempSync(join(tmpdir(), "openclaw-k8s-mcp-"));
     tempDirs.push(dir);
 
     const config = makeConfig({ agentSourceDir: dir });
     const rendered = buildOpenClawConfig(config, "gateway-token") as {
-      mcpServers?: Record<string, unknown>;
+      mcp?: { servers?: Record<string, unknown> };
     };
 
-    expect(rendered.mcpServers).toBeUndefined();
+    expect(rendered.mcp).toBeUndefined();
   });
 
-  it("omits mcpServers when agentSourceDir is not set", () => {
+  it("omits mcp when agentSourceDir is not set", () => {
     const config = makeConfig();
     const rendered = buildOpenClawConfig(config, "gateway-token") as {
-      mcpServers?: Record<string, unknown>;
+      mcp?: { servers?: Record<string, unknown> };
     };
 
-    expect(rendered.mcpServers).toBeUndefined();
+    expect(rendered.mcp).toBeUndefined();
   });
 });

--- a/src/server/deployers/agent-source.ts
+++ b/src/server/deployers/agent-source.ts
@@ -85,3 +85,30 @@ export function loadAgentSourceCronJobs(agentSourceDir?: string): string | undef
     return undefined;
   }
 }
+
+export function loadAgentSourceMcpServers(agentSourceDir?: string): Record<string, unknown> | undefined {
+  if (!agentSourceDir) return undefined;
+  const mcpPath = join(agentSourceDir, "mcp.json");
+  if (!existsSync(mcpPath)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(mcpPath, "utf8"));
+    const servers = parsed.mcpServers || parsed;
+    if (typeof servers === "object" && servers !== null && !Array.isArray(servers) && Object.keys(servers).length > 0) {
+      return servers as Record<string, unknown>;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadAgentSourceExecApprovals(agentSourceDir?: string): string | undefined {
+  if (!agentSourceDir) return undefined;
+  const approvalsPath = join(agentSourceDir, "exec-approvals.json");
+  if (!existsSync(approvalsPath)) return undefined;
+  try {
+    return readFileSync(approvalsPath, "utf8");
+  } catch {
+    return undefined;
+  }
+}

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -513,7 +513,7 @@ export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string):
 
   const mcpServers = loadAgentSourceMcpServers(config.agentSourceDir);
   if (mcpServers) {
-    ocConfig.mcpServers = mcpServers;
+    ocConfig.mcp = { servers: mcpServers };
   }
 
   attachSecretHandlingConfig(ocConfig, config);

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -5,7 +5,7 @@ import { shouldUseLitellmProxy, litellmModelName, litellmRegisteredModelNames, L
 import { shouldUseOtel, OTEL_HTTP_PORT } from "./otel.js";
 import { buildSandboxConfig } from "./sandbox.js";
 import { buildSandboxToolPolicy } from "./tool-policy.js";
-import { loadAgentSourceBundle } from "./agent-source.js";
+import { loadAgentSourceBundle, loadAgentSourceMcpServers } from "./agent-source.js";
 
 export const DEFAULT_IMAGE = process.env.OPENCLAW_IMAGE || "ghcr.io/openclaw/openclaw:latest";
 export const DEFAULT_VERTEX_IMAGE = process.env.OPENCLAW_VERTEX_IMAGE || DEFAULT_IMAGE;
@@ -509,6 +509,11 @@ export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string):
       .map((s) => parseInt(s.trim(), 10))
       .filter((n) => !isNaN(n));
     ocConfig.channels = { telegram: { dmPolicy: "allowlist", allowFrom } };
+  }
+
+  const mcpServers = loadAgentSourceMcpServers(config.agentSourceDir);
+  if (mcpServers) {
+    ocConfig.mcpServers = mcpServers;
   }
 
   attachSecretHandlingConfig(ocConfig, config);

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -218,6 +218,7 @@ export function deploymentManifest(
   skillEntries: TreeEntry[] = [],
   agentTreeEntries: TreeEntry[] = [],
   cronJobsContent?: string,
+  execApprovalsContent?: string,
 ): k8s.V1Deployment {
   const image = defaultImage(config);
   const id = agentId(config);
@@ -304,6 +305,7 @@ ${copyLines}
 find -L /agents-tree -mindepth 1 -type d -name 'workspace-*' -exec sh -c 'base="$(basename "$1")"; ${workspaceRouting}; mkdir -p "$dest"; cp -r "$1"/* "$dest"/ 2>/dev/null || true' _ {} \\;
 cp -r /skills-src/. /home/node/.openclaw/skills/ 2>/dev/null || true
 cp /cron-src/jobs.json /home/node/.openclaw/cron/jobs.json 2>/dev/null || true
+cp /exec-approvals-src/exec-approvals.json /home/node/.openclaw/exec-approvals.json 2>/dev/null || true
 chown -R 1000:1000 /home/node/.openclaw 2>/dev/null || true
 echo "Config initialized"
 `.trim();
@@ -378,6 +380,7 @@ echo "Config initialized"
                 { name: "agent-tree-config", mountPath: "/agents-tree", readOnly: true },
                 { name: "skills-config", mountPath: "/skills-src", readOnly: true },
                 { name: "cron-config", mountPath: "/cron-src", readOnly: true },
+                { name: "exec-approvals-config", mountPath: "/exec-approvals-src", readOnly: true },
               ],
             },
           ],
@@ -543,6 +546,13 @@ echo "Config initialized"
                 ...(cronJobsContent !== undefined
                   ? { items: [{ key: "jobs.json", path: "jobs.json" }] }
                   : {}),
+              },
+            },
+            {
+              name: "exec-approvals-config",
+              configMap: {
+                name: "openclaw-exec-approvals",
+                optional: true,
               },
             },
             {

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -15,7 +15,7 @@ import type {
 } from "./types.js";
 import { namespaceName, agentId, deriveModel, detectUnavailableProvider, generateToken, usesDefaultEnvSecretRef } from "./k8s-helpers.js";
 import { loadWorkspaceFiles } from "./k8s-agent.js";
-import { loadAgentSourceBundle, loadAgentSourceCronJobs, loadAgentSourceWorkspaceTree, mainWorkspaceShellCondition } from "./agent-source.js";
+import { loadAgentSourceBundle, loadAgentSourceCronJobs, loadAgentSourceExecApprovals, loadAgentSourceWorkspaceTree, mainWorkspaceShellCondition } from "./agent-source.js";
 import {
   namespaceManifest,
   pvcManifest,
@@ -132,6 +132,7 @@ export class KubernetesDeployer implements Deployer {
     const agentTreeEntries = await loadAgentSourceWorkspaceTree(config.agentSourceDir).catch(() => []);
     const cronJobsContent = loadAgentSourceCronJobs(config.agentSourceDir)
       ?? await readFile(cronJobsFile(), "utf8").catch(() => undefined);
+    const execApprovalsContent = loadAgentSourceExecApprovals(config.agentSourceDir);
 
     // 1. Namespace
     await applyNamespace(core, ns, log);
@@ -278,6 +279,15 @@ export class KubernetesDeployer implements Deployer {
       log,
     );
 
+    const execApprovalsCm = fileConfigMapManifest(ns, "openclaw-exec-approvals", "exec-approvals.json", execApprovalsContent);
+    await applyResource(
+      () => core.readNamespacedConfigMap({ name: "openclaw-exec-approvals", namespace: ns }),
+      () => core.createNamespacedConfigMap({ namespace: ns, body: execApprovalsCm }),
+      () => core.replaceNamespacedConfigMap({ name: "openclaw-exec-approvals", namespace: ns, body: execApprovalsCm }),
+      "ConfigMap openclaw-exec-approvals",
+      log,
+    );
+
     // 4b. LiteLLM proxy config (when using Vertex via proxy)
     const useProxy = shouldUseLitellmProxy(config);
     const litellmMasterKey = useProxy ? generateLitellmMasterKey() : undefined;
@@ -388,7 +398,7 @@ export class KubernetesDeployer implements Deployer {
     );
 
     // 7. Deployment
-    const dep = deploymentManifest(ns, config, otelViaOperator, effectiveSkillEntries, agentTreeEntries, cronJobsContent);
+    const dep = deploymentManifest(ns, config, otelViaOperator, effectiveSkillEntries, agentTreeEntries, cronJobsContent, execApprovalsContent);
     await applyResource(
       () => apps.readNamespacedDeployment({ name: "openclaw", namespace: ns }),
       () => apps.createNamespacedDeployment({ namespace: ns, body: dep }),
@@ -545,6 +555,7 @@ export class KubernetesDeployer implements Deployer {
     const agentTreeEntries = await loadAgentSourceWorkspaceTree(result.config.agentSourceDir).catch(() => []);
     const cronJobsContent = loadAgentSourceCronJobs(result.config.agentSourceDir)
       ?? await readFile(cronJobsFile(), "utf8").catch(() => undefined);
+    const execApprovalsContent = loadAgentSourceExecApprovals(result.config.agentSourceDir);
     if (!fromHost) {
       log("No custom agent files found — using generated defaults");
     }
@@ -583,6 +594,15 @@ export class KubernetesDeployer implements Deployer {
       () => core.createNamespacedConfigMap({ namespace: ns, body: cronCm }),
       () => core.replaceNamespacedConfigMap({ name: "openclaw-cron", namespace: ns, body: cronCm }),
       "ConfigMap openclaw-cron",
+      log,
+    );
+
+    const execApprovalsCm = fileConfigMapManifest(ns, "openclaw-exec-approvals", "exec-approvals.json", execApprovalsContent);
+    await applyResource(
+      () => core.readNamespacedConfigMap({ name: "openclaw-exec-approvals", namespace: ns }),
+      () => core.createNamespacedConfigMap({ namespace: ns, body: execApprovalsCm }),
+      () => core.replaceNamespacedConfigMap({ name: "openclaw-exec-approvals", namespace: ns, body: execApprovalsCm }),
+      "ConfigMap openclaw-exec-approvals",
       log,
     );
 
@@ -643,7 +663,7 @@ echo "Config initialized"
       },
       {
         op: "replace",
-        path: "/spec/template/spec/volumes/5/configMap",
+        path: "/spec/template/spec/volumes/6/configMap",
         value: {
           name: "openclaw-agent-tree",
           ...(agentTreeEntries.length > 0
@@ -683,6 +703,7 @@ echo "Config initialized"
       { name: "ConfigMap openclaw-agent-tree", fn: () => core.deleteNamespacedConfigMap({ name: "openclaw-agent-tree", namespace: ns }) },
       { name: "ConfigMap openclaw-skills", fn: () => core.deleteNamespacedConfigMap({ name: "openclaw-skills", namespace: ns }) },
       { name: "ConfigMap openclaw-cron", fn: () => core.deleteNamespacedConfigMap({ name: "openclaw-cron", namespace: ns }) },
+      { name: "ConfigMap openclaw-exec-approvals", fn: () => core.deleteNamespacedConfigMap({ name: "openclaw-exec-approvals", namespace: ns }) },
       { name: "ConfigMap environments", fn: () => core.deleteNamespacedConfigMap({ name: "environments", namespace: ns }) },
       { name: "ConfigMap authbridge-config", fn: () => core.deleteNamespacedConfigMap({ name: "authbridge-config", namespace: ns }) },
       { name: "ConfigMap envoy-config", fn: () => core.deleteNamespacedConfigMap({ name: "envoy-config", namespace: ns }) },

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -1,7 +1,7 @@
 import { spawn, execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { v4 as uuid } from "uuid";
 import type {
@@ -181,7 +181,7 @@ function tryParseProjectId(saJson: string): string {
 
 function normalizeHostPath(value?: string): string | undefined {
   const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
+  return trimmed ? resolve(trimmed) : undefined;
 }
 
 function resolveOptionalTextFile(filePath?: string): string | undefined {
@@ -550,7 +550,7 @@ function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string
 
   const mcpServers = loadAgentSourceMcpServers(config.agentSourceDir);
   if (mcpServers) {
-    ocConfig.mcpServers = mcpServers;
+    ocConfig.mcp = { servers: mcpServers };
   }
 
   attachSecretHandlingConfig(ocConfig, config);

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -46,7 +46,7 @@ import {
 } from "./k8s-helpers.js";
 import { buildSandboxConfig } from "./sandbox.js";
 import { buildSandboxToolPolicy } from "./tool-policy.js";
-import { loadAgentSourceBundle, mainWorkspaceShellCondition } from "./agent-source.js";
+import { loadAgentSourceBundle, loadAgentSourceMcpServers, mainWorkspaceShellCondition } from "./agent-source.js";
 
 const DEFAULT_IMAGE = process.env.OPENCLAW_IMAGE || "ghcr.io/openclaw/openclaw:latest";
 const DEFAULT_VERTEX_IMAGE = process.env.OPENCLAW_VERTEX_IMAGE || DEFAULT_IMAGE;
@@ -548,6 +548,11 @@ function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string
     };
   }
 
+  const mcpServers = loadAgentSourceMcpServers(config.agentSourceDir);
+  if (mcpServers) {
+    ocConfig.mcpServers = mcpServers;
+  }
+
   attachSecretHandlingConfig(ocConfig, config);
 
   return JSON.stringify(ocConfig);
@@ -1041,6 +1046,7 @@ Use this table to track verified peer OpenClaw instances.
       `for d in /tmp/agent-source/workspace-*; do if [ -d "$d" ]; then base="$(basename "$d")"; ${mainWorkspaceShellCondition(workspaceDir, sourceBundle)}; mkdir -p "$dest"; cp -r "$d"/* "$dest"/ 2>/dev/null || true; fi; done`,
       `if [ -d /tmp/agent-source/skills ]; then cp -r /tmp/agent-source/skills/* /home/node/.openclaw/skills/ 2>/dev/null || true; fi`,
       `if [ -f /tmp/agent-source/cron/jobs.json ]; then mkdir -p /home/node/.openclaw/cron && cp /tmp/agent-source/cron/jobs.json /home/node/.openclaw/cron/jobs.json 2>/dev/null || true; fi`,
+      `if [ -f /tmp/agent-source/exec-approvals.json ]; then cp /tmp/agent-source/exec-approvals.json /home/node/.openclaw/exec-approvals.json 2>/dev/null || true; fi`,
       runtimeOwnershipFixupCommand(),
     ].join("\n");
 
@@ -1389,6 +1395,7 @@ Use this table to track verified peer OpenClaw instances.
         `done`,
         `if [ -d /tmp/agent-source/skills ]; then mkdir -p /home/node/.openclaw/skills && cp -r /tmp/agent-source/skills/* /home/node/.openclaw/skills/ 2>/dev/null || true; fi`,
         `if [ -f /tmp/agent-source/cron/jobs.json ]; then mkdir -p /home/node/.openclaw/cron && cp /tmp/agent-source/cron/jobs.json /home/node/.openclaw/cron/jobs.json 2>/dev/null || true; fi`,
+        `if [ -f /tmp/agent-source/exec-approvals.json ]; then cp /tmp/agent-source/exec-approvals.json /home/node/.openclaw/exec-approvals.json 2>/dev/null || true; fi`,
         runtimeOwnershipFixupCommand(),
       ].join("\n");
 
@@ -1861,6 +1868,9 @@ Use this table to track verified peer OpenClaw instances.
       `if [ -f /tmp/agent-source/cron/jobs.json ]; then`,
       `  mkdir -p /home/node/.openclaw/cron`,
       `  cp -v /tmp/agent-source/cron/jobs.json /home/node/.openclaw/cron/jobs.json 2>/dev/null || true`,
+      `fi`,
+      `if [ -f /tmp/agent-source/exec-approvals.json ]; then`,
+      `  cp -v /tmp/agent-source/exec-approvals.json /home/node/.openclaw/exec-approvals.json 2>/dev/null || true`,
       `fi`,
       runtimeOwnershipFixupCommand(),
     ].join("\n");

--- a/src/server/services/model-discovery.ts
+++ b/src/server/services/model-discovery.ts
@@ -278,8 +278,6 @@ export async function fetchVertexModels(
       );
 
       const verified = probeResults.filter((r) => r.works).map((r) => r.model);
-      const failed = probeResults.filter((r) => !r.works).map((r) => r.model.id);
-      console.log(`Vertex model probing: ${anthropicModels.length} from Anthropic API, ${verified.length} verified, ${failed.length} failed${failed.length > 0 ? ` (${failed.join(", ")})` : ""}`);
 
       if (verified.length > 0) {
         return { models: verified };


### PR DESCRIPTION
## Summary

Add support for provisioning MCP servers and tool approval policies through the existing Agent Source Directory mechanism.

- `mcp.json` is parsed and merged into the generated `openclaw.json` under `mcpServers`
- `exec-approvals.json` is copied as-is to `~/.openclaw/exec-approvals.json`
- New demo bundle `demos/software-qa-mcp` with DeepWiki and Context7 MCP servers
- README updated with MCP Servers documentation section

Fixes #85