### PR TITLE
fix: remove temporary Vertex model probing debug log

### DIFF
--- a/src/server/services/model-discovery.ts
+++ b/src/server/services/model-discovery.ts
@@ -278,8 +278,6 @@ export async function fetchVertexModels(
       );
 
       const verified = probeResults.filter((r) => r.works).map((r) => r.model);
-      const failed = probeResults.filter((r) => !r.works).map((r) => r.model.id);
-      console.log(`Vertex model probing: ${anthropicModels.length} from Anthropic API, ${verified.length} verified, ${failed.length} failed${failed.length > 0 ? ` (${failed.join(", ")})` : ""}`);
 
       if (verified.length > 0) {
         return { models: verified };


### PR DESCRIPTION
## Summary
- Remove `console.log` for Vertex model probing that was left in from development
- Remove the now-unused `failed` variable

## Test plan
- [x] `npm run build && npm test` passes (264 tests)
- [x] Verify no "Vertex model probing" messages appear in server console

*This comment was posted by Claude Code under the supervision of Bill Murdock.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)