### PR TITLE
fix: create .env file in workspace directory (closes #70)

### DIFF
--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -1022,6 +1022,8 @@ Use this table to track verified peer OpenClaw instances.
         : []),
       // Create workspace directory
       `mkdir -p '${workspaceDir}'`,
+      // Create .env file for heartbeat (same fix as bootstrap path)
+      `touch '${workspaceDir}/.env'`,
       // Create skills directory
       `mkdir -p /home/node/.openclaw/skills`,
       // Write AGENTS.md (always update — lets user change agent name/display on re-deploy)


### PR DESCRIPTION
Summary: Create .env file in workspace during provisioning. Fixes heartbeat failure when .env doesn't exist. Closes #70