### PR TITLE
fix issue where teammate claws show up in shared cluster but without local state

### DIFF
--- a/src/client/components/InstanceList.tsx
+++ b/src/client/components/InstanceList.tsx
@@ -17,6 +17,7 @@ interface Instance {
   id: string;
   mode: string;
   status: string;
+  hasLocalState?: boolean;
   config: {
     prefix: string;
     agentName: string;
@@ -103,6 +104,24 @@ function K8sProgress({ inst }: { inst: Instance }) {
           {pod.message}
         </div>
       )}
+    </div>
+  );
+}
+
+function RemoteClusterNotice({ namespace }: { namespace: string }) {
+  return (
+    <div
+      style={{
+        padding: "0.5rem 1rem",
+        borderTop: "1px solid var(--border)",
+        color: "var(--text-secondary)",
+        fontSize: "0.85rem",
+      }}
+    >
+      Cluster-discovered only. No matching local installer state was found for
+      {" "}
+      <code style={{ fontFamily: "var(--font-mono)" }}>{namespace}</code>
+      .
     </div>
   );
 }
@@ -436,6 +455,8 @@ export default function InstanceList({ active }: { active: boolean }) {
         const isDeploying = inst.status === "deploying";
         const isError = inst.status === "error";
         const isK8s = inst.mode !== "local";
+        const isRemoteClusterInstance = isK8s && inst.hasLocalState === false;
+        const canUseLocalManagedActions = !isRemoteClusterInstance;
         const canStop = isRunning || isDeploying || isError;
         // K8s: allow delete anytime (it deletes the whole namespace)
         // Local: must stop first
@@ -460,7 +481,7 @@ export default function InstanceList({ active }: { active: boolean }) {
                 <div className="instance-meta">
                   {inst.config.prefix && `${inst.config.prefix} · `}
                   {inst.config.agentName && `${inst.config.agentName} · `}
-                  {isRunning && inst.url ? (
+                  {isRunning && inst.url && canUseLocalManagedActions ? (
                     <a
                       href={inst.url}
                       target="_blank"
@@ -473,6 +494,8 @@ export default function InstanceList({ active }: { active: boolean }) {
                     >
                       {inst.url}
                     </a>
+                  ) : isRunning && isRemoteClusterInstance ? (
+                    "running on shared cluster"
                   ) : isDeploying ? (
                     "deploying..."
                   ) : isError ? (
@@ -487,20 +510,24 @@ export default function InstanceList({ active }: { active: boolean }) {
               <div className="instance-actions">
                 {isRunning && (
                   <>
-                    <button
-                      className="btn btn-ghost"
-                      disabled={isActing}
-                      onClick={() => handleApproveDevice(inst.id)}
-                      title="Approve the latest pending browser device pairing request"
-                    >
-                      Approve Pairing
-                    </button>
-                    <button
-                      className="btn btn-ghost"
-                      onClick={() => togglePanel(inst.id, "connection")}
-                    >
-                      {activePanel === "connection" ? "Hide" : "Connection Info"}
-                    </button>
+                    {canUseLocalManagedActions && (
+                      <>
+                        <button
+                          className="btn btn-ghost"
+                          disabled={isActing}
+                          onClick={() => handleApproveDevice(inst.id)}
+                          title="Approve the latest pending browser device pairing request"
+                        >
+                          Approve Pairing
+                        </button>
+                        <button
+                          className="btn btn-ghost"
+                          onClick={() => togglePanel(inst.id, "connection")}
+                        >
+                          {activePanel === "connection" ? "Hide" : "Connection Info"}
+                        </button>
+                      </>
+                    )}
                     <button
                       className="btn btn-ghost"
                       onClick={() => togglePanel(inst.id, "command")}
@@ -515,7 +542,7 @@ export default function InstanceList({ active }: { active: boolean }) {
                     </button>
                   </>
                 )}
-                {isK8s && (isRunning || isDeploying || isError) && (
+                {isK8s && canUseLocalManagedActions && (isRunning || isDeploying || isError) && (
                   <button
                     className="btn btn-ghost"
                     disabled={isActing}
@@ -579,6 +606,9 @@ export default function InstanceList({ active }: { active: boolean }) {
               >
                 {pairingMessage.text}
               </div>
+            )}
+            {isRemoteClusterInstance && (
+              <RemoteClusterNotice namespace={inst.id} />
             )}
             <K8sProgress inst={inst} />
             {activePanel === "connection" && panelContent && inst.url && (

--- a/src/client/components/__tests__/InstanceList.test.tsx
+++ b/src/client/components/__tests__/InstanceList.test.tsx
@@ -41,6 +41,15 @@ const errorK8sInstance = {
   pods: [{ name: "owl-pod", phase: "Running", ready: false, restarts: 5, containerStatus: "waiting", message: "Back-off restarting failed container" }],
 };
 
+const remoteK8sInstance = {
+  id: "shared-bob-openclaw",
+  mode: "kubernetes",
+  status: "running",
+  hasLocalState: false,
+  config: { prefix: "shared", agentName: "bob", agentDisplayName: "Bob" },
+  startedAt: "2025-01-01T00:00:00Z",
+};
+
 function mockFetchWith(instances: unknown[]) {
   return vi.fn((url: string, opts?: RequestInit) => {
     if (url === "/api/health") {
@@ -135,6 +144,21 @@ describe("InstanceList", () => {
     });
     expect(screen.getByText("Restarts: 5")).toBeInTheDocument();
     expect(screen.getByText("Back-off restarting failed container")).toBeInTheDocument();
+  });
+
+  it("renders cluster-discovered K8s instances without local-managed actions", async () => {
+    globalThis.fetch = mockFetchWith([remoteK8sInstance]);
+    render(<InstanceList active />);
+    await waitFor(() => {
+      expect(screen.getByText(/cluster-discovered only/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText((text) => text.includes("running on shared cluster"))).toBeInTheDocument();
+    expect(screen.getByText("Command")).toBeInTheDocument();
+    expect(screen.getByText("Logs")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /approve pairing/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /connection info/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /re-deploy/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("http://localhost:18789")).not.toBeInTheDocument();
   });
 
   it("enables Delete Data for running K8s instance", async () => {

--- a/src/server/deployers/types.ts
+++ b/src/server/deployers/types.ts
@@ -121,6 +121,7 @@ export interface DeployResult {
   status: "running" | "stopped" | "failed" | "deploying" | "error" | "unknown";
   config: DeployConfig;
   startedAt: string;
+  hasLocalState?: boolean;
   url?: string;
   containerId?: string;
   volumeName?: string;

--- a/src/server/routes/status.ts
+++ b/src/server/routes/status.ts
@@ -41,6 +41,7 @@ function containerToInstance(c: DiscoveredContainer): DeployResult {
     id: c.name,
     mode: "local",
     status: c.status,
+    hasLocalState: true,
     config: {
       mode: "local",
       prefix: prefix || c.name.replace(/^openclaw-/, "").replace(/-[^-]+$/, ""),
@@ -113,6 +114,7 @@ router.get("/", async (req, res) => {
             id: vol.containerName,
             mode: "local",
             status: "stopped",
+            hasLocalState: true,
             volumeName: vol.name,
             config: {
               mode: "local",
@@ -203,11 +205,13 @@ router.get("/", async (req, res) => {
       try {
         const k8sInstances = await discoverK8sInstances();
         for (const ki of k8sInstances) {
-          const mode = await savedDeployMode(ki.namespace);
+          const savedState = await readSavedK8sState(ki.namespace);
+          const mode = savedState.mode;
           let instance: DeployResult = {
             id: ki.namespace,
             mode,
             status: ki.status,
+            hasLocalState: savedState.hasLocalState,
             config: {
               mode,
               prefix: ki.prefix,
@@ -226,7 +230,7 @@ router.get("/", async (req, res) => {
           };
 
           // Let the deployer enrich with platform-specific info (e.g. Route URL)
-          const deployer = registry.get(mode);
+          const deployer = savedState.hasLocalState ? registry.get(mode) : undefined;
           if (deployer && typeof deployer.status === "function") {
             try {
               instance = await deployer.status(instance);
@@ -793,17 +797,23 @@ async function readSavedGatewayToken(containerName: string): Promise<string | un
 
 
 /**
- * Read the saved deploy-config.json for a K8s namespace to get the actual deploy mode.
- * Returns "kubernetes" as fallback if no saved config exists.
+ * Read saved installer state for a K8s namespace on this machine.
+ * Falls back to generic Kubernetes when no local state exists.
  */
-async function savedDeployMode(namespace: string): Promise<string> {
+async function readSavedK8sState(namespace: string): Promise<{ hasLocalState: boolean; mode: string }> {
   try {
     const configPath = join(installerDataDir(), "k8s", namespace, "deploy-config.json");
     const content = await readFile(configPath, "utf8");
     const config = JSON.parse(content);
-    return config.mode || "kubernetes";
+    return {
+      hasLocalState: true,
+      mode: config.mode || "kubernetes",
+    };
   } catch {
-    return "kubernetes";
+    return {
+      hasLocalState: false,
+      mode: "kubernetes",
+    };
   }
 }
 
@@ -827,6 +837,7 @@ async function findInstance(name: string): Promise<DeployResult | null> {
         id: name,
         mode: "local",
         status: "stopped",
+        hasLocalState: true,
         volumeName: vol.name,
         config: {
           mode: "local",
@@ -930,11 +941,13 @@ async function findInstance(name: string): Promise<DeployResult | null> {
   const k8sInstances = await discoverK8sInstances({ namespaces: [name] });
   const ki = k8sInstances.find((i) => i.namespace === name);
   if (ki) {
-    const mode = await savedDeployMode(ki.namespace);
+    const savedState = await readSavedK8sState(ki.namespace);
+    const mode = savedState.mode;
     let instance: DeployResult = {
       id: ki.namespace,
       mode,
       status: ki.status,
+      hasLocalState: savedState.hasLocalState,
       config: {
         mode,
         prefix: ki.prefix,
@@ -952,7 +965,7 @@ async function findInstance(name: string): Promise<DeployResult | null> {
       pods: ki.pods,
     };
 
-    const deployer = registry.get(mode);
+    const deployer = savedState.hasLocalState ? registry.get(mode) : undefined;
     if (deployer && typeof deployer.status === "function") {
       try {
         instance = await deployer.status(instance);


### PR DESCRIPTION
On shared clusters where we all can see others namespaces, the openclaws for which there was no matching local state were showing weirdly, this fixes it.

/cc @cooktheryan