### PR TITLE
fix: pod-phase-aware K8s status and gateway readiness check

### DIFF
--- a/src/server/deployers/__tests__/kubernetes.test.ts
+++ b/src/server/deployers/__tests__/kubernetes.test.ts
@@ -72,13 +72,13 @@ function mockPods(pods: Array<{
 }
 
 function mockGatewayReady(statusCode: number) {
-  const res = {
-    statusCode,
-    resume: vi.fn(),
-  };
+  const res = { statusCode, resume: vi.fn() };
   vi.mocked(http.get).mockImplementation((_url: any, _opts: any, cb: any) => {
     cb(res);
-    return { on: vi.fn() } as any;
+    const req = {
+      on: vi.fn(() => req),
+    };
+    return req as any;
   });
 }
 
@@ -89,6 +89,7 @@ function mockGatewayError() {
         if (event === "error") handler();
         return req;
       }),
+      destroy: vi.fn(),
     };
     return req as any;
   });
@@ -179,7 +180,10 @@ describe("KubernetesDeployer.status", () => {
 
   it("returns deploying when pod is in ContainerCreating state", async () => {
     mockDeployment(1, 0);
-    mockPods([{ phase: "Pending", ready: false, state: { waiting: { reason: "ContainerCreating" } } }]);
+    mockPods([{
+      phase: "Pending", ready: false,
+      state: { waiting: { reason: "ContainerCreating" } },
+    }]);
 
     const deployer = new KubernetesDeployer();
     const result = await deployer.status(baseResult);
@@ -202,7 +206,10 @@ describe("KubernetesDeployer.status", () => {
 
   it("returns error when pod is in CrashLoopBackOff", async () => {
     mockDeployment(1, 0);
-    mockPods([{ phase: "Running", ready: false, state: { waiting: { reason: "CrashLoopBackOff", message: "back-off restarting" } } }]);
+    mockPods([{
+      phase: "Running", ready: false,
+      state: { waiting: { reason: "CrashLoopBackOff", message: "back-off restarting" } },
+    }]);
 
     const deployer = new KubernetesDeployer();
     const result = await deployer.status(baseResult);

--- a/src/server/deployers/__tests__/kubernetes.test.ts
+++ b/src/server/deployers/__tests__/kubernetes.test.ts
@@ -166,7 +166,7 @@ describe("KubernetesDeployer.status", () => {
     expect(result.statusDetail).toBe("Gateway starting...");
   });
 
-  it("still reports running when the deployment is ready but port-forwarding fails", async () => {
+  it("still reports running with descriptive detail when port-forwarding fails", async () => {
     mockDeployment(1, 1);
     mockPods([{ phase: "Running", ready: true, state: { running: {} } }]);
     vi.mocked(ensureK8sPortForward).mockRejectedValue(new Error("kubectl unavailable"));
@@ -175,6 +175,7 @@ describe("KubernetesDeployer.status", () => {
     const result = await deployer.status(baseResult);
 
     expect(result.status).toBe("running");
+    expect(result.statusDetail).toBe("Running (port-forward unavailable)");
     expect(result.url).toBeUndefined();
   });
 
@@ -226,5 +227,58 @@ describe("KubernetesDeployer.status", () => {
     const result = await deployer.status(baseResult);
 
     expect(result.status).toBe("stopped");
+  });
+
+  it("skips gateway health check on second poll after confirmed healthy", async () => {
+    const deployer = new KubernetesDeployer();
+    const runningPod = [{ phase: "Running" as const, ready: true, state: { running: {} } }];
+
+    // First poll: gateway check runs and succeeds
+    mockDeployment(1, 1);
+    mockPods(runningPod);
+    vi.mocked(ensureK8sPortForward).mockResolvedValue({
+      localPort: 40123,
+      url: "http://localhost:40123",
+    });
+    mockGatewayReady(200);
+
+    await deployer.status(baseResult);
+    expect(http.get).toHaveBeenCalledTimes(1);
+
+    // Second poll: should skip the HTTP check entirely
+    mockDeployment(1, 1);
+    mockPods(runningPod);
+    vi.mocked(http.get).mockClear();
+
+    const result = await deployer.status(baseResult);
+    expect(http.get).not.toHaveBeenCalled();
+    expect(result.status).toBe("running");
+    expect(result.url).toBe("http://localhost:40123");
+  });
+
+  it("re-checks gateway when readyReplicas drops (pod restart)", async () => {
+    const deployer = new KubernetesDeployer();
+    const runningPod = [{ phase: "Running" as const, ready: true, state: { running: {} } }];
+
+    // First poll: confirm healthy with readyReplicas=2
+    mockDeployment(2, 2);
+    mockPods(runningPod);
+    vi.mocked(ensureK8sPortForward).mockResolvedValue({
+      localPort: 40123,
+      url: "http://localhost:40123",
+    });
+    mockGatewayReady(200);
+
+    await deployer.status(baseResult);
+
+    // Second poll: readyReplicas dropped to 1 — must re-check
+    mockDeployment(2, 1);
+    mockPods(runningPod);
+    vi.mocked(http.get).mockClear();
+    mockGatewayReady(200);
+
+    const result = await deployer.status(baseResult);
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("running");
   });
 });

--- a/src/server/deployers/__tests__/kubernetes.test.ts
+++ b/src/server/deployers/__tests__/kubernetes.test.ts
@@ -133,6 +133,22 @@ describe("KubernetesDeployer.status", () => {
     expect(result.url).toBeUndefined();
   });
 
+  it("clears stale URL when gateway is not responding", async () => {
+    mockDeployment(1, 1);
+    mockPods([{ phase: "Running", ready: true, state: { running: {} } }]);
+    vi.mocked(ensureK8sPortForward).mockResolvedValue({
+      localPort: 40123,
+      url: "http://localhost:40123",
+    });
+    mockGatewayError();
+
+    const deployer = new KubernetesDeployer();
+    const result = await deployer.status({ ...baseResult, url: "http://localhost:40123" });
+
+    expect(result.status).toBe("deploying");
+    expect(result.url).toBeUndefined();
+  });
+
   it("returns deploying when pods are ready but gateway returns 500", async () => {
     mockDeployment(1, 1);
     mockPods([{ phase: "Running", ready: true, state: { running: {} } }]);

--- a/src/server/deployers/__tests__/kubernetes.test.ts
+++ b/src/server/deployers/__tests__/kubernetes.test.ts
@@ -12,74 +12,196 @@ vi.mock("../../services/k8s-port-forward.js", () => ({
   ensureK8sPortForward: vi.fn(),
 }));
 
-import { appsApi } from "../../services/k8s.js";
+vi.mock("node:http", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import http from "node:http";
+import { appsApi, coreApi } from "../../services/k8s.js";
 import { ensureK8sPortForward } from "../../services/k8s-port-forward.js";
 import { KubernetesDeployer } from "../kubernetes.js";
+
+const baseResult = {
+  id: "kind-test",
+  mode: "kubernetes" as const,
+  status: "unknown" as const,
+  config: {
+    mode: "kubernetes" as const,
+    prefix: "user",
+    agentName: "lynx",
+    agentDisplayName: "Lynx",
+    namespace: "user-lynx-openclaw",
+  },
+  startedAt: "",
+  containerId: "user-lynx-openclaw",
+};
+
+function mockDeployment(replicas: number, readyReplicas: number) {
+  vi.mocked(appsApi).mockReturnValue({
+    readNamespacedDeployment: vi.fn().mockResolvedValue({
+      spec: { replicas },
+      status: { readyReplicas },
+    }),
+  } as any);
+}
+
+function mockPods(pods: Array<{
+  name?: string;
+  phase: string;
+  ready: boolean;
+  restartCount?: number;
+  state: Record<string, any>;
+}>) {
+  vi.mocked(coreApi).mockReturnValue({
+    listNamespacedPod: vi.fn().mockResolvedValue({
+      items: pods.map((p) => ({
+        metadata: { name: p.name || "openclaw-abc123" },
+        status: {
+          phase: p.phase,
+          containerStatuses: [{
+            ready: p.ready,
+            restartCount: p.restartCount ?? 0,
+            state: p.state,
+          }],
+        },
+      })),
+    }),
+  } as any);
+}
+
+function mockGatewayReady(statusCode: number) {
+  const res = {
+    statusCode,
+    resume: vi.fn(),
+  };
+  vi.mocked(http.get).mockImplementation((_url: any, _opts: any, cb: any) => {
+    cb(res);
+    return { on: vi.fn() } as any;
+  });
+}
+
+function mockGatewayError() {
+  vi.mocked(http.get).mockImplementation((_url: any, _opts: any, _cb: any) => {
+    const req = {
+      on: vi.fn((event: string, handler: () => void) => {
+        if (event === "error") handler();
+        return req;
+      }),
+    };
+    return req as any;
+  });
+}
 
 describe("KubernetesDeployer.status", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it("returns a localhost URL for a ready deployment by starting a port-forward", async () => {
-    vi.mocked(appsApi).mockReturnValue({
-      readNamespacedDeployment: vi.fn().mockResolvedValue({
-        spec: { replicas: 1 },
-        status: { readyReplicas: 1 },
-      }),
-    } as any);
+  it("returns running with URL when pods are ready and gateway responds", async () => {
+    mockDeployment(1, 1);
+    mockPods([{ phase: "Running", ready: true, state: { running: {} } }]);
     vi.mocked(ensureK8sPortForward).mockResolvedValue({
       localPort: 40123,
       url: "http://localhost:40123",
     });
+    mockGatewayReady(200);
 
     const deployer = new KubernetesDeployer();
-    const result = await deployer.status({
-      id: "kind-test",
-      mode: "kubernetes",
-      status: "unknown",
-      config: {
-        mode: "kubernetes",
-        prefix: "user",
-        agentName: "lynx",
-        agentDisplayName: "Lynx",
-        namespace: "user-lynx-openclaw",
-      },
-      startedAt: "",
-      containerId: "user-lynx-openclaw",
-    });
+    const result = await deployer.status(baseResult);
 
     expect(ensureK8sPortForward).toHaveBeenCalledWith("user-lynx-openclaw");
     expect(result.status).toBe("running");
     expect(result.url).toBe("http://localhost:40123");
   });
 
+  it("returns deploying when pods are ready but gateway is not responding", async () => {
+    mockDeployment(1, 1);
+    mockPods([{ phase: "Running", ready: true, state: { running: {} } }]);
+    vi.mocked(ensureK8sPortForward).mockResolvedValue({
+      localPort: 40123,
+      url: "http://localhost:40123",
+    });
+    mockGatewayError();
+
+    const deployer = new KubernetesDeployer();
+    const result = await deployer.status(baseResult);
+
+    expect(result.status).toBe("deploying");
+    expect(result.statusDetail).toBe("Gateway starting...");
+    expect(result.url).toBeUndefined();
+  });
+
+  it("returns deploying when pods are ready but gateway returns 500", async () => {
+    mockDeployment(1, 1);
+    mockPods([{ phase: "Running", ready: true, state: { running: {} } }]);
+    vi.mocked(ensureK8sPortForward).mockResolvedValue({
+      localPort: 40123,
+      url: "http://localhost:40123",
+    });
+    mockGatewayReady(500);
+
+    const deployer = new KubernetesDeployer();
+    const result = await deployer.status(baseResult);
+
+    expect(result.status).toBe("deploying");
+    expect(result.statusDetail).toBe("Gateway starting...");
+  });
+
   it("still reports running when the deployment is ready but port-forwarding fails", async () => {
-    vi.mocked(appsApi).mockReturnValue({
-      readNamespacedDeployment: vi.fn().mockResolvedValue({
-        spec: { replicas: 1 },
-        status: { readyReplicas: 1 },
-      }),
-    } as any);
+    mockDeployment(1, 1);
+    mockPods([{ phase: "Running", ready: true, state: { running: {} } }]);
     vi.mocked(ensureK8sPortForward).mockRejectedValue(new Error("kubectl unavailable"));
 
     const deployer = new KubernetesDeployer();
-    const result = await deployer.status({
-      id: "kind-test",
-      mode: "kubernetes",
-      status: "unknown",
-      config: {
-        mode: "kubernetes",
-        prefix: "user",
-        agentName: "lynx",
-        agentDisplayName: "Lynx",
-        namespace: "user-lynx-openclaw",
-      },
-      startedAt: "",
-      containerId: "user-lynx-openclaw",
-    });
+    const result = await deployer.status(baseResult);
 
     expect(result.status).toBe("running");
     expect(result.url).toBeUndefined();
+  });
+
+  it("returns deploying when pod is in ContainerCreating state", async () => {
+    mockDeployment(1, 0);
+    mockPods([{ phase: "Pending", ready: false, state: { waiting: { reason: "ContainerCreating" } } }]);
+
+    const deployer = new KubernetesDeployer();
+    const result = await deployer.status(baseResult);
+
+    expect(result.status).toBe("deploying");
+    expect(result.statusDetail).toBe("Creating container...");
+    expect(result.url).toBeUndefined();
+  });
+
+  it("returns deploying when no pods exist yet", async () => {
+    mockDeployment(1, 0);
+    mockPods([]);
+
+    const deployer = new KubernetesDeployer();
+    const result = await deployer.status(baseResult);
+
+    expect(result.status).toBe("deploying");
+    expect(result.statusDetail).toBe("Waiting for pod...");
+  });
+
+  it("returns error when pod is in CrashLoopBackOff", async () => {
+    mockDeployment(1, 0);
+    mockPods([{ phase: "Running", ready: false, state: { waiting: { reason: "CrashLoopBackOff", message: "back-off restarting" } } }]);
+
+    const deployer = new KubernetesDeployer();
+    const result = await deployer.status(baseResult);
+
+    expect(result.status).toBe("error");
+    expect(result.statusDetail).toContain("CrashLoopBackOff");
+  });
+
+  it("returns stopped when scaled to zero", async () => {
+    mockDeployment(0, 0);
+    mockPods([]);
+
+    const deployer = new KubernetesDeployer();
+    const result = await deployer.status(baseResult);
+
+    expect(result.status).toBe("stopped");
   });
 });

--- a/src/server/deployers/k8s-discovery.ts
+++ b/src/server/deployers/k8s-discovery.ts
@@ -42,7 +42,7 @@ async function loadSavedNamespaces(): Promise<string[]> {
   }
 }
 
-function derivePodInfo(pod: k8s.V1Pod): K8sPodInfo {
+export function derivePodInfo(pod: k8s.V1Pod): K8sPodInfo {
   const cs = pod.status?.containerStatuses?.[0];
   let containerStatus = "Unknown";
   let message = "";
@@ -82,7 +82,7 @@ function derivePodInfo(pod: k8s.V1Pod): K8sPodInfo {
   };
 }
 
-function deriveInstanceStatus(
+export function deriveInstanceStatus(
   replicas: number,
   readyReplicas: number,
   pods: K8sPodInfo[],

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -120,15 +120,12 @@ async function applyResource<T>(
 
 function checkGatewayReady(url: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const req = http.get(url, { timeout: 3000 }, (res) => {
+    const req = http.get(url, { timeout: 1000 }, (res) => {
       res.resume();
       resolve(res.statusCode !== undefined && res.statusCode < 500);
     });
     req.on("error", () => resolve(false));
-    req.on("timeout", () => {
-      req.destroy();
-      resolve(false);
-    });
+    req.on("timeout", () => req.destroy()); // fires 'error', which resolves
   });
 }
 

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -120,18 +120,28 @@ async function applyResource<T>(
 
 function checkGatewayReady(url: string): Promise<boolean> {
   return new Promise((resolve) => {
+    let settled = false;
     const req = http.get(url, { timeout: 1000 }, (res) => {
+      if (settled) return;
+      settled = true;
       res.resume();
       resolve(res.statusCode !== undefined && res.statusCode < 500);
     });
-    req.on("error", () => resolve(false));
-    req.on("timeout", () => req.destroy()); // fires 'error', which resolves
+    req.on("error", () => {
+      if (settled) return;
+      settled = true;
+      resolve(false);
+    });
+    req.on("timeout", () => req.destroy());
   });
 }
 
 // ── Deployer implementation ────────────────────────────────────────
 
 export class KubernetesDeployer implements Deployer {
+  /** Tracks namespaces whose gateway has been confirmed healthy. */
+  private gatewayHealthy = new Map<string, { readyReplicas: number }>();
+
   async deploy(config: DeployConfig, log: LogCallback): Promise<DeployResult> {
     const id = uuid();
     const ns = namespaceName(config);
@@ -525,7 +535,10 @@ export class KubernetesDeployer implements Deployer {
       const replicas = dep.spec?.replicas ?? 1;
       const readyReplicas = dep.status?.readyReplicas ?? 0;
 
-      if (replicas === 0) return { ...result, status: "stopped" };
+      if (replicas === 0) {
+        this.gatewayHealthy.delete(ns);
+        return { ...result, status: "stopped" };
+      }
 
       // Fetch pods for accurate status derivation
       const podList = await core.listNamespacedPod({
@@ -535,21 +548,30 @@ export class KubernetesDeployer implements Deployer {
       const pods = podList.items.map(derivePodInfo);
       const { status, statusDetail } = deriveInstanceStatus(replicas, readyReplicas, pods);
 
-      if (status === "running") {
-        try {
-          const { url } = await ensureK8sPortForward(ns);
-          // Verify the gateway is actually accepting HTTP connections
-          const ready = await checkGatewayReady(url);
-          if (ready) {
-            return { ...result, status: "running", url, statusDetail, pods };
-          }
-          return { ...result, status: "deploying", statusDetail: "Gateway starting...", url: undefined, pods };
-        } catch {
-          return { ...result, status: "running", statusDetail, pods };
-        }
+      if (status !== "running") {
+        this.gatewayHealthy.delete(ns);
+        return { ...result, status, statusDetail, url: undefined, pods };
       }
 
-      return { ...result, status, statusDetail, url: undefined, pods };
+      try {
+        const { url } = await ensureK8sPortForward(ns);
+
+        // Skip the HTTP probe if gateway was already confirmed healthy
+        // and readyReplicas hasn't dropped (e.g. pod restart).
+        const cached = this.gatewayHealthy.get(ns);
+        if (cached && readyReplicas >= cached.readyReplicas) {
+          return { ...result, status: "running", url, statusDetail, pods };
+        }
+
+        const ready = await checkGatewayReady(url);
+        if (ready) {
+          this.gatewayHealthy.set(ns, { readyReplicas });
+          return { ...result, status: "running", url, statusDetail, pods };
+        }
+        return { ...result, status: "deploying", statusDetail: "Gateway starting...", url: undefined, pods };
+      } catch {
+        return { ...result, status: "running", statusDetail: "Running (port-forward unavailable)", pods };
+      }
     } catch {
       return { ...result, status: "unknown" };
     }

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -546,13 +546,13 @@ export class KubernetesDeployer implements Deployer {
           if (ready) {
             return { ...result, status: "running", url, statusDetail, pods };
           }
-          return { ...result, status: "deploying", statusDetail: "Gateway starting...", pods };
+          return { ...result, status: "deploying", statusDetail: "Gateway starting...", url: undefined, pods };
         } catch {
           return { ...result, status: "running", statusDetail, pods };
         }
       }
 
-      return { ...result, status, statusDetail, pods };
+      return { ...result, status, statusDetail, url: undefined, pods };
     } catch {
       return { ...result, status: "unknown" };
     }

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -1,10 +1,12 @@
 import * as k8s from "@kubernetes/client-node";
+import http from "node:http";
 import { join } from "node:path";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { v4 as uuid } from "uuid";
 import { coreApi, appsApi, loadKubeConfig, hasOtelOperator, k8sApiHttpCode } from "../services/k8s.js";
 import { ensureK8sPortForward } from "../services/k8s-port-forward.js";
+import { deriveInstanceStatus, derivePodInfo } from "./k8s-discovery.js";
 import { cronJobsFile, installerK8sInstanceDir, skillsDir } from "../paths.js";
 import { loadTextTree } from "../state-tree.js";
 import type {
@@ -112,6 +114,22 @@ async function applyResource<T>(
     await createFn();
   }
   log(`${name} applied`);
+}
+
+// ── Gateway readiness check ──────────────────────────────────────
+
+function checkGatewayReady(url: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = http.get(url, { timeout: 3000 }, (res) => {
+      res.resume();
+      resolve(res.statusCode !== undefined && res.statusCode < 500);
+    });
+    req.on("error", () => resolve(false));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
 }
 
 // ── Deployer implementation ────────────────────────────────────────
@@ -505,19 +523,36 @@ export class KubernetesDeployer implements Deployer {
     const ns = result.config.namespace || result.containerId || "";
     try {
       const apps = appsApi();
+      const core = coreApi();
       const dep = await apps.readNamespacedDeployment({ name: "openclaw", namespace: ns });
-      const replicas = dep.status?.readyReplicas ?? 0;
-      const desired = dep.spec?.replicas ?? 1;
-      if (desired === 0) return { ...result, status: "stopped" };
-      if (replicas > 0) {
+      const replicas = dep.spec?.replicas ?? 1;
+      const readyReplicas = dep.status?.readyReplicas ?? 0;
+
+      if (replicas === 0) return { ...result, status: "stopped" };
+
+      // Fetch pods for accurate status derivation
+      const podList = await core.listNamespacedPod({
+        namespace: ns,
+        labelSelector: "app=openclaw",
+      });
+      const pods = podList.items.map(derivePodInfo);
+      const { status, statusDetail } = deriveInstanceStatus(replicas, readyReplicas, pods);
+
+      if (status === "running") {
         try {
           const { url } = await ensureK8sPortForward(ns);
-          return { ...result, status: "running", url };
+          // Verify the gateway is actually accepting HTTP connections
+          const ready = await checkGatewayReady(url);
+          if (ready) {
+            return { ...result, status: "running", url, statusDetail, pods };
+          }
+          return { ...result, status: "deploying", statusDetail: "Gateway starting...", pods };
         } catch {
-          return { ...result, status: "running" };
+          return { ...result, status: "running", statusDetail, pods };
         }
       }
-      return { ...result, status: "unknown" };
+
+      return { ...result, status, statusDetail, pods };
     } catch {
       return { ...result, status: "unknown" };
     }


### PR DESCRIPTION
## Summary
- **Fixes #73**: `KubernetesDeployer.status()` now uses `deriveInstanceStatus()` from `k8s-discovery.ts` to accurately report pod startup phases ("deploying", "error") instead of returning "unknown" when `readyReplicas === 0`
- **Fixes #52**: Adds an HTTP health check (`checkGatewayReady()`) before returning the URL — if the gateway isn't responding or returns 5xx, the instance shows as "deploying: Gateway starting..." instead of surfacing a clickable URL that will fail
- Exports `deriveInstanceStatus` and `derivePodInfo` from `k8s-discovery.ts` for reuse
- Expands test coverage from 2 to 8 cases (deploying, error, stopped, gateway-not-ready states)

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 283 tests pass (8 new tests for status method)
- [x] `npm run lint` — no new warnings
- [ ] Manual: deploy to K8s, verify instance shows "deploying" during pod startup (not "unknown"/"stopped")
- [ ] Manual: verify URL only appears after gateway health check passes
- [ ] Manual: verify CrashLoopBackOff shows as "error" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)