### PR TITLE
fix: filter invalid kubeconfig entries

### DIFF
--- a/src/server/services/k8s.ts
+++ b/src/server/services/k8s.ts
@@ -10,7 +10,7 @@ let _kc: k8s.KubeConfig | null = null;
 export function loadKubeConfig(): k8s.KubeConfig {
   if (_kc) return _kc;
   const kc = new k8s.KubeConfig();
-  kc.loadFromDefault();
+  kc.loadFromDefault({ onInvalidEntry: "filter" });
   _kc = kc;
   return kc;
 }


### PR DESCRIPTION
Filtering out invalid kubeconfig entries that was impacting proper detection of k8s/OpenShift support