### PR TITLE
fix: prefix custom-endpoint model refs with endpoint/ when model ID contains slash

### DIFF
--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -232,6 +232,64 @@ describe("model config generation", () => {
     expect(normalizeModelRef(config, "anthropic-vertex/my-model")).toBe("anthropic-vertex/my-model");
   });
 
+  // Regression tests for #93: custom-endpoint model IDs containing '/' must be
+  // prefixed with 'endpoint/' so the gateway routes to the endpoint provider.
+  it("prefixes custom-endpoint model IDs that contain a slash", () => {
+    const config = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      modelEndpoint: "https://vllm.example.com/v1",
+      modelEndpointModel: "google/gemma-4-26B-A4B-it",
+    });
+
+    expect(normalizeModelRef(config, "google/gemma-4-26B-A4B-it")).toBe("endpoint/google/gemma-4-26B-A4B-it");
+    expect(deriveModel(config)).toBe("endpoint/google/gemma-4-26B-A4B-it");
+  });
+
+  it("does not double-prefix custom-endpoint model IDs already starting with endpoint/", () => {
+    const config = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      modelEndpoint: "https://vllm.example.com/v1",
+    });
+
+    expect(normalizeModelRef(config, "endpoint/google/gemma-4-26B-A4B-it")).toBe("endpoint/google/gemma-4-26B-A4B-it");
+  });
+
+  it("generates correct openclaw.json model refs for custom-endpoint with slashed model IDs", () => {
+    const config = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      modelEndpoint: "https://vllm.example.com/v1",
+      modelEndpointModel: "google/gemma-4-26B-A4B-it",
+      modelEndpointModelLabel: "Gemma 4 26B",
+    });
+
+    const rendered = buildOpenClawConfig(config, "gateway-token") as {
+      agents?: {
+        defaults?: {
+          model?: { primary?: string };
+          models?: Record<string, { alias?: string }>;
+        };
+        list?: Array<{
+          model?: { primary?: string };
+        }>;
+      };
+      models?: {
+        providers?: Record<string, { models?: Array<{ id?: string; name?: string }> }>;
+      };
+    };
+
+    // Agent model refs must use 'endpoint/' prefix
+    expect(rendered.agents?.defaults?.model?.primary).toBe("endpoint/google/gemma-4-26B-A4B-it");
+    expect(rendered.agents?.defaults?.models?.["endpoint/google/gemma-4-26B-A4B-it"]).toBeDefined();
+    expect(rendered.agents?.list?.[0]?.model?.primary).toBe("endpoint/google/gemma-4-26B-A4B-it");
+
+    // The provider's own models[].id should keep the raw model ID
+    expect(rendered.models?.providers?.endpoint?.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "google/gemma-4-26B-A4B-it" }),
+      ]),
+    );
+  });
+
   it("writes external secret provider config without emitting an invalid plain OpenAI provider stub", () => {
     const config = makeConfig({
       inferenceProvider: "openai",

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -58,14 +58,19 @@ export function usesDefaultEnvSecretRef(ref?: DeploySecretRef): ref is DeploySec
 export function normalizeModelRef(config: DeployConfig, modelRef: string): string {
   const trimmed = modelRef.trim();
   if (!trimmed) return trimmed;
+
+  // Fix for #93: custom-endpoint model IDs may contain '/' (e.g. 'google/gemma-4-26B-A4B-it')
+  // which must be prefixed with 'endpoint/' so the gateway routes to the endpoint provider
+  // instead of treating the first segment as a provider name.
+  if (config.inferenceProvider === "custom-endpoint") {
+    return trimmed.startsWith(`${CUSTOM_ENDPOINT_PROVIDER}/`) ? trimmed : `${CUSTOM_ENDPOINT_PROVIDER}/${trimmed}`;
+  }
+
   if (trimmed.includes("/")) return trimmed;
 
   if (config.inferenceProvider === "anthropic") return `anthropic/${trimmed}`;
   if (config.inferenceProvider === "openai") {
     return `openai/${trimmed}`;
-  }
-  if (config.inferenceProvider === "custom-endpoint") {
-    return `${CUSTOM_ENDPOINT_PROVIDER}/${trimmed}`;
   }
   // Fix for #1: check litellm proxy before falling back to direct vertex providers
   if (config.inferenceProvider === "vertex-anthropic") {
@@ -93,6 +98,11 @@ function normalizeProviderModelRef(provider: string, modelRef?: string): string 
   const trimmed = modelRef?.trim();
   if (!trimmed) {
     return undefined;
+  }
+  // Fix for #93: always prefix with the provider, even when the model ID
+  // contains '/' (e.g. 'google/gemma-4-26B-A4B-it' for the 'endpoint' provider).
+  if (provider === CUSTOM_ENDPOINT_PROVIDER) {
+    return trimmed.startsWith(`${CUSTOM_ENDPOINT_PROVIDER}/`) ? trimmed : `${CUSTOM_ENDPOINT_PROVIDER}/${trimmed}`;
   }
   return trimmed.includes("/") ? trimmed : `${provider}/${trimmed}`;
 }


### PR DESCRIPTION
## Summary

- Fixes `normalizeModelRef` and `normalizeProviderModelRef` in `k8s-helpers.ts` to always prefix custom-endpoint model IDs with `endpoint/`, even when the model ID already contains a `/` (e.g. `google/gemma-4-26B-A4B-it`)
- Without this fix, the gateway treats the first segment as a provider name instead of routing to the endpoint provider
- Adds regression tests covering single-agent, double-prefix, and full config rendering scenarios

Fixes #93

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (280/280, including 3 new regression tests)

---

Generated with [agent.sh](https://github.com/usize/agent.sh)