### PR TITLE
fix: add pod-security enforce labels to namespaces for A2A/SPIFFE support

### DIFF
--- a/provider-plugins/openshift/src/openshift-deployer.ts
+++ b/provider-plugins/openshift/src/openshift-deployer.ts
@@ -87,7 +87,11 @@ export class OpenShiftDeployer implements Deployer {
             body: {
               apiVersion: "v1",
               kind: "Namespace",
-              metadata: { name: ns, labels: { "app.kubernetes.io/managed-by": "openclaw-installer" } },
+              metadata: { name: ns, labels: {
+                "app.kubernetes.io/managed-by": "openclaw-installer",
+                "pod-security.kubernetes.io/enforce": "privileged",
+                "pod-security.kubernetes.io/enforce-version": "latest",
+              } },
             },
           });
           log(`Namespace ${ns} created`);

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { deploymentManifest, fileConfigMapManifest, fileTreeConfigMapManifest, secretManifest } from "../k8s-manifests.js";
+import { a2aNamespacePatch } from "../k8s-a2a.js";
 import type { DeployConfig } from "../types.js";
 import type * as k8s from "@kubernetes/client-node";
 
@@ -221,5 +222,23 @@ describe("litellm sidecar env vars in proxy mode", () => {
     // Gateway routes to OpenAI/Anthropic directly
     expect(gwEnvNames).toContain("OPENAI_API_KEY");
     expect(gwEnvNames).toContain("ANTHROPIC_API_KEY");
+  });
+});
+
+// Regression test for #94: pod-security enforce label missing on A2A namespaces
+describe("a2a namespace patch pod-security labels", () => {
+  it("includes pod-security enforce labels for SPIFFE CSI volume support", () => {
+    const patch = a2aNamespacePatch("test-ns");
+    const labels = patch.metadata?.labels ?? {};
+
+    expect(labels["pod-security.kubernetes.io/enforce"]).toBe("privileged");
+    expect(labels["pod-security.kubernetes.io/enforce-version"]).toBe("latest");
+  });
+
+  it("preserves kagenti-enabled label alongside pod-security labels", () => {
+    const patch = a2aNamespacePatch("test-ns");
+    const labels = patch.metadata?.labels ?? {};
+
+    expect(labels["kagenti-enabled"]).toBe("true");
   });
 });

--- a/src/server/deployers/k8s-a2a.ts
+++ b/src/server/deployers/k8s-a2a.ts
@@ -181,6 +181,8 @@ export function a2aNamespacePatch(ns: string): k8s.V1Namespace {
       labels: {
         "app.kubernetes.io/managed-by": "openclaw-installer",
         "kagenti-enabled": "true",
+        "pod-security.kubernetes.io/enforce": "privileged",
+        "pod-security.kubernetes.io/enforce-version": "latest",
       },
     },
   };


### PR DESCRIPTION
## Summary

- Adds `pod-security.kubernetes.io/enforce: privileged` labels to namespaces created for A2A/SPIFFE support in `k8s-a2a.ts` and the OpenShift deployer
- Without these labels, pods requiring elevated privileges (e.g. SPIRE agents) are rejected by the Pod Security Admission controller
- Adds test coverage verifying the labels are present in rendered namespace manifests

Fixes #94

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (282/282, including 2 new tests)

---

Generated with [agent.sh](https://github.com/usize/agent.sh)