### PR TITLE
fix: add redeploy support to OpenShiftDeployer

### DIFF
--- a/provider-plugins/openshift/src/openshift-deployer.ts
+++ b/provider-plugins/openshift/src/openshift-deployer.ts
@@ -291,6 +291,10 @@ export class OpenShiftDeployer implements Deployer {
     return this.k8s.stop(result, log);
   }
 
+  async redeploy(result: DeployResult, log: LogCallback): Promise<void> {
+    return this.k8s.redeploy(result, log);
+  }
+
   async teardown(result: DeployResult, log: LogCallback): Promise<void> {
     const ns = result.config.namespace || result.containerId || "";
     const core = coreApi();


### PR DESCRIPTION
## Summary

`OpenShiftDeployer` implements `Deployer` but was missing a `redeploy`
method. The API route at `/:id/redeploy` checks for the method's presence
at runtime and returned:

```
{"error":"Use Stop/Start for this deployer — redeploy is not supported"}
```

for any OpenShift-mode instance, even though `KubernetesDeployer.redeploy`
(which updates agent ConfigMaps and restarts the pod) works correctly for
OpenShift too.

## Change

Add `redeploy` to `OpenShiftDeployer` that delegates to `this.k8s.redeploy`.
This is consistent with `start`, `stop`, and `status`, which already delegate
to the inner `KubernetesDeployer`.

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] `/api/instances/<openshift-namespace>/redeploy` returns `{"status":"redeploying"}` instead of the 400 error

Made with [Cursor](https://cursor.com)