### PR TITLE
feat(deployer): add headless Chromium browser sidecar support

### DIFF
--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -1343,6 +1343,41 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
           </>
         )}
 
+        <h3 style={{ marginTop: "1.5rem" }}>Browser</h3>
+
+        <div className="form-group">
+          <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            <input
+              type="checkbox"
+              checked={config.chromiumSidecar}
+              onChange={(e) =>
+                setConfig((prev) => ({ ...prev, chromiumSidecar: e.target.checked }))
+              }
+              style={{ width: "auto" }}
+            />
+            Enable browser sidecar (headless Chromium)
+          </label>
+          <div className="hint">
+            Runs a headless Chromium container alongside the agent so it can browse the web,
+            fill forms, and take screenshots.
+          </div>
+        </div>
+
+        {config.chromiumSidecar && (
+          <div className="form-group">
+            <label>Chromium Image (optional)</label>
+            <input
+              type="text"
+              placeholder="chromedp/headless-shell:stable"
+              value={config.chromiumImage}
+              onChange={(e) => update("chromiumImage", e.target.value)}
+            />
+            <div className="hint">
+              Leave blank for the default. Use ghcr.io/browserless/chromium for advanced features like session queueing and token auth.
+            </div>
+          </div>
+        )}
+
         <SandboxSection
           config={config}
           update={update}

--- a/src/client/components/deploy-form/serialization.ts
+++ b/src/client/components/deploy-form/serialization.ts
@@ -110,6 +110,8 @@ export function createInitialDeployFormConfig(): DeployFormConfig {
     otelJaeger: false,
     otelEndpoint: "",
     otelExperimentId: "",
+    chromiumSidecar: false,
+    chromiumImage: "",
   };
 }
 
@@ -407,6 +409,9 @@ export function applySavedVarsToConfig(
       otelEndpoint: getStringVar(vars, "OTEL_ENDPOINT", "otelEndpoint") || prev.otelEndpoint,
       otelExperimentId:
         getStringVar(vars, "OTEL_EXPERIMENT_ID", "otelExperimentId") || prev.otelExperimentId,
+      chromiumSidecar:
+        vars.CHROMIUM_SIDECAR === "true" || vars.chromiumSidecar === "true" || prev.chromiumSidecar,
+      chromiumImage: getStringVar(vars, "CHROMIUM_IMAGE", "chromiumImage") || prev.chromiumImage,
       otelImage: prev.otelImage,
       cronEnabled: vars.cronEnabled === "true" ? true : prev.cronEnabled,
       subagentPolicy:
@@ -537,6 +542,8 @@ export function buildDeployRequestBody(params: {
     otelJaeger: config.otelEnabled ? config.otelJaeger || undefined : undefined,
     otelEndpoint: config.otelEnabled ? trimToUndefined(config.otelEndpoint) : undefined,
     otelExperimentId: config.otelEnabled ? trimToUndefined(config.otelExperimentId) : undefined,
+    chromiumSidecar: config.chromiumSidecar || undefined,
+    chromiumImage: config.chromiumSidecar ? trimToUndefined(config.chromiumImage) : undefined,
     cronEnabled: config.cronEnabled || undefined,
     subagentPolicy: config.subagentPolicy !== "none" ? config.subagentPolicy : undefined,
   };
@@ -638,6 +645,8 @@ export function buildEnvFileContent(params: {
     `OTEL_JAEGER=${config.otelJaeger}`,
     `OTEL_ENDPOINT=${config.otelEndpoint}`,
     `OTEL_EXPERIMENT_ID=${config.otelExperimentId}`,
+    `CHROMIUM_SIDECAR=${config.chromiumSidecar}`,
+    `CHROMIUM_IMAGE=${config.chromiumImage}`,
     "",
     `K8S_NAMESPACE=${config.namespace || suggestedNamespace}`,
     `WITH_A2A=${config.withA2a}`,

--- a/src/client/components/deploy-form/types.ts
+++ b/src/client/components/deploy-form/types.ts
@@ -166,5 +166,7 @@ export interface DeployFormConfig {
   otelJaeger: boolean;
   otelEndpoint: string;
   otelExperimentId: string;
+  chromiumSidecar: boolean;
+  chromiumImage: string;
   podmanSecretMappings?: PodmanSecretMapping[];
 }

--- a/src/server/deployers/__tests__/chromium.test.ts
+++ b/src/server/deployers/__tests__/chromium.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldUseChromiumSidecar,
+  chromiumContainerName,
+  chromiumAgentEnv,
+  CHROMIUM_IMAGE,
+  CHROMIUM_CDP_PORT,
+} from "../chromium.js";
+import type { DeployConfig } from "../types.js";
+
+describe("chromium sidecar", () => {
+  const baseConfig: DeployConfig = {
+    mode: "local",
+    agentName: "test-agent",
+    agentDisplayName: "Test Agent",
+  };
+
+  describe("shouldUseChromiumSidecar", () => {
+    it("returns false when chromiumSidecar is not set", () => {
+      expect(shouldUseChromiumSidecar(baseConfig)).toBe(false);
+    });
+
+    it("returns false when chromiumSidecar is false", () => {
+      expect(shouldUseChromiumSidecar({ ...baseConfig, chromiumSidecar: false })).toBe(false);
+    });
+
+    it("returns true when chromiumSidecar is true", () => {
+      expect(shouldUseChromiumSidecar({ ...baseConfig, chromiumSidecar: true })).toBe(true);
+    });
+  });
+
+  describe("chromiumContainerName", () => {
+    it("generates correct container name with default prefix", () => {
+      expect(chromiumContainerName(baseConfig)).toBe("openclaw-openclaw-test-agent-chromium");
+    });
+
+    it("generates correct container name with custom prefix", () => {
+      expect(chromiumContainerName({ ...baseConfig, prefix: "myprefix" })).toBe(
+        "openclaw-myprefix-test-agent-chromium",
+      );
+    });
+
+    it("lowercases the container name", () => {
+      expect(chromiumContainerName({ ...baseConfig, agentName: "MyAgent" })).toBe(
+        "openclaw-openclaw-myagent-chromium",
+      );
+    });
+  });
+
+  describe("chromiumAgentEnv", () => {
+    it("returns CHROME_CDP_URL pointing to localhost:9222", () => {
+      const env = chromiumAgentEnv();
+      expect(env).toEqual({
+        CHROME_CDP_URL: "http://localhost:9222",
+      });
+    });
+  });
+
+  describe("constants", () => {
+    it("exports correct default image", () => {
+      expect(CHROMIUM_IMAGE).toBe("chromedp/headless-shell:stable");
+    });
+
+    it("exports correct CDP port", () => {
+      expect(CHROMIUM_CDP_PORT).toBe(9222);
+    });
+  });
+});

--- a/src/server/deployers/chromium.ts
+++ b/src/server/deployers/chromium.ts
@@ -1,0 +1,29 @@
+import type { DeployConfig } from "./types.js";
+
+export const CHROMIUM_IMAGE = "chromedp/headless-shell:stable";
+export const CHROMIUM_CDP_PORT = 9222;
+
+/**
+ * Returns true when the Chromium browser sidecar should be deployed.
+ */
+export function shouldUseChromiumSidecar(config: DeployConfig): boolean {
+  return !!config.chromiumSidecar;
+}
+
+/**
+ * Container name for the Chromium sidecar in local deployments.
+ */
+export function chromiumContainerName(config: DeployConfig): string {
+  const prefix = config.prefix || "openclaw";
+  return `openclaw-${prefix}-${config.agentName}-chromium`.toLowerCase();
+}
+
+/**
+ * Environment variables to set on the gateway container so it
+ * knows where to connect to the browser via CDP.
+ */
+export function chromiumAgentEnv(): Record<string, string> {
+  return {
+    CHROME_CDP_URL: `http://localhost:${CHROMIUM_CDP_PORT}`,
+  };
+}

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "node:crypto";
 import type { DeployConfig, DeployModelOption, DeploySecretRef } from "./types.js";
 import { shouldUseLitellmProxy, litellmModelName, litellmRegisteredModelNames, LITELLM_PORT } from "./litellm.js";
 import { shouldUseOtel, OTEL_HTTP_PORT } from "./otel.js";
+import { shouldUseChromiumSidecar, CHROMIUM_CDP_PORT } from "./chromium.js";
 import { buildSandboxConfig } from "./sandbox.js";
 import { buildSandboxToolPolicy } from "./tool-policy.js";
 import { loadAgentSourceBundle, loadAgentSourceMcpServers } from "./agent-source.js";
@@ -753,6 +754,21 @@ export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string):
     },
     cron: { enabled: !!config.cronEnabled },
   };
+
+  // Add browser config for Chromium sidecar
+  if (shouldUseChromiumSidecar(config)) {
+    ocConfig.browser = {
+      enabled: true,
+      defaultProfile: "openclaw",
+      profiles: {
+        openclaw: {
+          cdpUrl: `http://localhost:${CHROMIUM_CDP_PORT}`,
+          attachOnly: true,
+          color: "#4285F4",
+        },
+      },
+    };
+  }
 
   const sandboxToolPolicy = buildSandboxToolPolicy(config);
   if (sandboxToolPolicy) {

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -11,6 +11,7 @@ import {
 import type { DeployConfig } from "./types.js";
 import { shouldUseLitellmProxy, LITELLM_IMAGE, LITELLM_PORT } from "./litellm.js";
 import { shouldUseOtel, OTEL_COLLECTOR_IMAGE, OTEL_GRPC_PORT, OTEL_HTTP_PORT, otelAgentEnv } from "./otel.js";
+import { shouldUseChromiumSidecar, CHROMIUM_IMAGE, CHROMIUM_CDP_PORT, chromiumAgentEnv } from "./chromium.js";
 import type { TreeEntry } from "../state-tree.js";
 import { loadAgentSourceBundle, mainWorkspaceShellCondition } from "./agent-source.js";
 import {
@@ -324,6 +325,7 @@ export function deploymentManifest(
   const withA2a = Boolean(config.withA2a);
   // Direct sidecar only when OTEL is enabled and operator is NOT handling it
   const useOtelDirect = useOtel && !otelViaOperator;
+  const useChromium = shouldUseChromiumSidecar(config);
 
   const optionalKeys = [
     // Gateway always gets provider API keys so it can route to OpenAI/Anthropic
@@ -351,6 +353,13 @@ export function deploymentManifest(
   // OTEL collector env vars (tell the agent where to send traces)
   if (useOtel) {
     for (const [key, val] of Object.entries(otelAgentEnv())) {
+      envVars.push({ name: key, value: val });
+    }
+  }
+
+  // Chromium CDP env var (tell the agent where to connect to the browser)
+  if (useChromium) {
+    for (const [key, val] of Object.entries(chromiumAgentEnv())) {
       envVars.push({ name: key, value: val });
     }
   }
@@ -561,6 +570,34 @@ export function deploymentManifest(
                 capabilities: { drop: ["ALL"] },
               },
             }] : []),
+            // Chromium browser sidecar: headless browser for web browsing via CDP
+            ...(useChromium ? [{
+              name: "chromium",
+              image: config.chromiumImage || CHROMIUM_IMAGE,
+              imagePullPolicy: "IfNotPresent" as const,
+              ports: [
+                { name: "cdp", containerPort: CHROMIUM_CDP_PORT, protocol: "TCP" as const },
+              ],
+              volumeMounts: [
+                { name: "chromium-shm", mountPath: "/dev/shm" },
+                { name: "chromium-tmp", mountPath: "/tmp" },
+              ],
+              resources: {
+                requests: { memory: "512Mi", cpu: "100m" },
+                limits: { memory: "1Gi", cpu: "500m" },
+              },
+              securityContext: {
+                allowPrivilegeEscalation: false,
+                runAsNonRoot: true,
+                capabilities: { drop: ["ALL"] },
+              },
+              readinessProbe: {
+                httpGet: { path: "/json/version", port: CHROMIUM_CDP_PORT as unknown as k8s.IntOrString },
+                initialDelaySeconds: 5,
+                periodSeconds: 10,
+                timeoutSeconds: 5,
+              },
+            }] : []),
             ...(withA2a ? [{
               name: "agent-card",
               image: "registry.redhat.io/ubi9:latest",
@@ -639,6 +676,12 @@ export function deploymentManifest(
               : []),
             ...(useOtelDirect
               ? [{ name: "otel-config", configMap: { name: "otel-collector-config" } }]
+              : []),
+            ...(useChromium
+              ? [
+                  { name: "chromium-shm", emptyDir: { medium: "Memory", sizeLimit: "256Mi" } },
+                  { name: "chromium-tmp", emptyDir: {} },
+                ]
               : []),
             ...(withA2a
               ? [

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -35,6 +35,7 @@ import {
 import { shouldUseOtel, OTEL_HTTP_PORT } from "./otel.js";
 import { startOtelSidecar, stopOtelSidecar, startJaegerSidecar, otelContainerName, jaegerContainerName } from "./local-otel.js";
 import { JAEGER_UI_PORT } from "./otel.js";
+import { shouldUseChromiumSidecar, CHROMIUM_IMAGE, CHROMIUM_CDP_PORT, chromiumContainerName, chromiumAgentEnv } from "./chromium.js";
 import { agentWorkspaceDir, installerLocalInstanceDir, openclawHomeDir } from "../paths.js";
 import {
   buildConfiguredAgentModelCatalog,
@@ -304,6 +305,12 @@ export function buildSavedInstanceEnvContent(config: DeployConfig, name: string)
     }
     if (config.otelImage) {
       lines.push(`OTEL_IMAGE=${config.otelImage}`);
+    }
+  }
+  if (config.chromiumSidecar) {
+    lines.push(`CHROMIUM_SIDECAR=true`);
+    if (config.chromiumImage) {
+      lines.push(`CHROMIUM_IMAGE=${config.chromiumImage}`);
     }
   }
   if (config.telegramBotToken && (!config.telegramBotTokenRef || usesDefaultEnvSecretRef(config.telegramBotTokenRef))) {
@@ -1080,7 +1087,8 @@ function buildRunArgs(
   const image = resolveImage(effectiveConfig);
   const useProxy = shouldUseLitellmProxy(effectiveConfig) && !!litellmMasterKey;
   const useOtelSidecar = shouldUseOtel(effectiveConfig) && !!otelEnvVars;
-  const hasSidecars = useProxy || useOtelSidecar;
+  const useChromium = shouldUseChromiumSidecar(effectiveConfig);
+  const hasSidecars = useProxy || useOtelSidecar || useChromium;
   const isPodman = runtime === "podman";
 
   const runArgs = [
@@ -1100,7 +1108,9 @@ function buildRunArgs(
     // Docker: share the first sidecar's network namespace
     const networkContainer = useProxy
       ? litellmContainerName(effectiveConfig)
-      : otelContainerName(effectiveConfig);
+      : useOtelSidecar
+        ? otelContainerName(effectiveConfig)
+        : chromiumContainerName(effectiveConfig);
     runArgs.push("--network", `container:${networkContainer}`);
   } else {
     runArgs.push("-p", `${port}:18789`);
@@ -1181,6 +1191,11 @@ function buildRunArgs(
   // OTEL collector env vars (tell the agent where to send traces)
   if (useOtelSidecar && otelEnvVars) {
     Object.assign(env, otelEnvVars);
+  }
+
+  // Chromium CDP env var (tell the agent where to connect to the browser)
+  if (useChromium) {
+    Object.assign(env, chromiumAgentEnv());
   }
 
   for (const [key, val] of Object.entries(env)) {
@@ -1627,6 +1642,80 @@ Use this table to track verified peer OpenClaw instances.
       (rt, nm) => removeContainer(rt as ContainerRuntime, nm),
     );
 
+    // Create pod for Chromium sidecar if it's the only sidecar
+    const useChromium = shouldUseChromiumSidecar(config);
+    if (useChromium && !useProxy && !useOtelSidecars && runtime === "podman") {
+      const pod = podName(config);
+      await runCommand(runtime, ["pod", "rm", "-f", pod], () => {});
+      const podPorts = ["-p", `${port}:18789`];
+      await runCommand(runtime, [
+        "pod", "create", "--name", pod, ...podPorts,
+      ], log);
+    }
+
+    // Start Chromium browser sidecar if enabled
+    if (useChromium) {
+      const chromiumImage = config.chromiumImage || CHROMIUM_IMAGE;
+      const chromiumName = chromiumContainerName(config);
+      const isPodman = runtime === "podman";
+
+      try {
+        await execFileAsync(runtime, ["image", "exists", chromiumImage]);
+        log(`Using local Chromium image: ${chromiumImage}`);
+      } catch {
+        log(`Pulling Chromium image ${chromiumImage}...`);
+        const pull = await runCommand(runtime, ["pull", chromiumImage], log);
+        if (pull.code !== 0) {
+          throw new Error("Failed to pull Chromium image");
+        }
+      }
+
+      await removeContainer(runtime, chromiumName);
+
+      const chromiumRunArgs = [
+        "run", "-d",
+        "--name", chromiumName,
+        "--shm-size=256m",
+        "--init",
+      ];
+
+      if (isPodman) {
+        chromiumRunArgs.push("--pod", podName(config));
+      } else if (useProxy) {
+        chromiumRunArgs.push("--network", `container:${litellmContainerName(config)}`);
+      } else if (useOtelSidecars) {
+        chromiumRunArgs.push("--network", `container:${otelContainerName(config)}`);
+      } else {
+        // Chromium is the only sidecar — publish gateway port
+        chromiumRunArgs.push("-p", `${port}:18789`);
+      }
+
+      chromiumRunArgs.push(chromiumImage);
+
+      const chromiumResult = await runCommand(runtime, chromiumRunArgs, log);
+      if (chromiumResult.code !== 0) {
+        throw new Error("Failed to start Chromium sidecar");
+      }
+
+      log("Waiting for Chromium browser to be ready...");
+      for (let i = 0; i < 15; i++) {
+        await new Promise((r) => setTimeout(r, 1000));
+        try {
+          const { stdout } = await execFileAsync(runtime, [
+            "exec", chromiumName, "wget", "-q", "-O-", `http://localhost:${CHROMIUM_CDP_PORT}/json/version`,
+          ]);
+          if (stdout.includes("webSocketDebuggerUrl") || stdout.includes("WebSocket")) {
+            log("Chromium browser is ready");
+            break;
+          }
+        } catch {
+          if (i === 14) {
+            log("WARNING: Chromium readiness check timed out — proceeding anyway");
+          }
+        }
+      }
+    }
+
     const runArgs = buildRunArgs(activeConfig, runtime, name, port, litellmMasterKey, otelEnv);
 
     log(`Starting OpenClaw container: ${name}`);
@@ -1637,7 +1726,7 @@ Use this table to track verified peer OpenClaw instances.
 
     log("");
     log("=== Container Info ===");
-    const hasSidecars = useProxy || !!otelEnv;
+    const hasSidecars = useProxy || !!otelEnv || useChromium;
     if (hasSidecars) {
       const isPodman = runtime === "podman";
       if (isPodman) {
@@ -1647,6 +1736,7 @@ Use this table to track verified peer OpenClaw instances.
       if (useProxy) log(`LiteLLM container: ${litellmContainerName(config)}`);
       if (otelEnv) log(`OTEL container:    ${otelContainerName(config)}`);
       if (config.otelJaeger) log(`Jaeger container:  ${jaegerContainerName(config)}`);
+      if (useChromium) log(`Chromium container: ${chromiumContainerName(config)}`);
       log("");
       if (config.otelJaeger) log(`Jaeger UI: http://localhost:${JAEGER_UI_PORT}`);
       log("");
@@ -1658,6 +1748,7 @@ Use this table to track verified peer OpenClaw instances.
       if (useProxy) log(`  ${runtime} logs ${litellmContainerName(config)}  # LiteLLM proxy logs`);
       if (otelEnv) log(`  ${runtime} logs ${otelContainerName(config)}  # OTEL collector logs`);
       if (config.otelJaeger) log(`  ${runtime} logs ${jaegerContainerName(config)}  # Jaeger logs`);
+      if (useChromium) log(`  ${runtime} logs ${chromiumContainerName(config)}  # Chromium browser logs`);
     } else {
       log(`Container: ${name}`);
       log("");
@@ -1916,6 +2007,17 @@ Use this table to track verified peer OpenClaw instances.
       ], log);
     }
 
+    // Create pod for Chromium sidecar if it's the only sidecar
+    const useChromiumSidecar = shouldUseChromiumSidecar(effectiveConfig);
+    if (useChromiumSidecar && !useProxy && !useOtelSidecars && runtime === "podman") {
+      const pod = podName(effectiveConfig);
+      await runCommand(runtime, ["pod", "rm", "-f", pod], () => {});
+      const podPorts = ["-p", `${port}:18789`];
+      await runCommand(runtime, [
+        "pod", "create", "--name", pod, ...podPorts,
+      ], log);
+    }
+
     // Restart Jaeger sidecar if enabled
     if (effectiveConfig.otelJaeger) {
       await startJaegerSidecar(
@@ -1932,6 +2034,36 @@ Use this table to track verified peer OpenClaw instances.
       port, image, log, runCommand,
       (rt, nm) => removeContainer(rt as ContainerRuntime, nm),
     );
+
+    // Restart Chromium sidecar if enabled
+    if (useChromiumSidecar) {
+      const chromiumImage = effectiveConfig.chromiumImage || CHROMIUM_IMAGE;
+      const chromiumName = chromiumContainerName(effectiveConfig);
+      const isPodman = runtime === "podman";
+
+      await removeContainer(runtime, chromiumName);
+
+      const chromiumRunArgs = [
+        "run", "-d",
+        "--name", chromiumName,
+        "--shm-size=256m",
+        "--init",
+      ];
+
+      if (isPodman) {
+        chromiumRunArgs.push("--pod", podName(effectiveConfig));
+      } else if (useProxy) {
+        chromiumRunArgs.push("--network", `container:${litellmContainerName(effectiveConfig)}`);
+      } else if (useOtelSidecars) {
+        chromiumRunArgs.push("--network", `container:${otelContainerName(effectiveConfig)}`);
+      } else {
+        chromiumRunArgs.push("-p", `${port}:18789`);
+      }
+
+      chromiumRunArgs.push(chromiumImage);
+
+      await runCommand(runtime, chromiumRunArgs, log);
+    }
 
     log(`Starting OpenClaw container: ${name}`);
     const runArgs = buildRunArgs(effectiveConfig, runtime, name, port, litellmMasterKey, otelEnv);
@@ -2154,6 +2286,16 @@ Use this table to track verified peer OpenClaw instances.
     // Stop OTEL sidecar if it exists
     await stopOtelSidecar(result.config, runtime, log, runCommand);
 
+    // Stop Chromium sidecar if it exists
+    const chromiumName = chromiumContainerName(result.config);
+    try {
+      await execFileAsync(runtime, ["inspect", chromiumName]);
+      log(`Stopping Chromium sidecar: ${chromiumName}`);
+      await runCommand(runtime, ["stop", chromiumName], log);
+    } catch {
+      // No sidecar running
+    }
+
     // Remove podman pod if it exists
     if (isPodman) {
       const pod = podName(result.config);
@@ -2181,6 +2323,7 @@ Use this table to track verified peer OpenClaw instances.
     await removeContainer(runtime, litellmName);
     await removeContainer(runtime, otelContainerName(result.config));
     await removeContainer(runtime, jaegerContainerName(result.config));
+    await removeContainer(runtime, chromiumContainerName(result.config));
 
     // Remove podman pod if it exists
     if (isPodman) {

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -883,6 +883,21 @@ function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string
     cron: { enabled: !!config.cronEnabled },
   };
 
+  // Add browser config for Chromium sidecar
+  if (shouldUseChromiumSidecar(config)) {
+    ocConfig.browser = {
+      enabled: true,
+      defaultProfile: "openclaw",
+      profiles: {
+        openclaw: {
+          cdpUrl: `http://localhost:${CHROMIUM_CDP_PORT}`,
+          attachOnly: true,
+          color: "#4285F4",
+        },
+      },
+    };
+  }
+
   const sandboxToolPolicy = buildSandboxToolPolicy(config);
   if (sandboxToolPolicy) {
     ocConfig.tools = sandboxToolPolicy;

--- a/src/server/deployers/types.ts
+++ b/src/server/deployers/types.ts
@@ -104,6 +104,9 @@ export interface DeployConfig {
   otelExperimentId?: string;   // MLflow experiment ID (optional, for MLflow endpoints)
   otelImage?: string;
   otelJaeger?: boolean;        // Run Jaeger all-in-one as a sidecar (UI on port 16686)
+  // Chromium browser sidecar (headless browser for web browsing)
+  chromiumSidecar?: boolean;
+  chromiumImage?: string;
   // Agent security
   cronEnabled?: boolean; // default: false (opt-in)
   subagentPolicy?: "none" | "self" | "unrestricted"; // default: "none"

--- a/src/server/routes/status-instances.ts
+++ b/src/server/routes/status-instances.ts
@@ -133,6 +133,8 @@ export function parseSavedLocalInstanceConfig(savedVars: Record<string, string>)
     otelEndpoint: savedVars.OTEL_ENDPOINT || undefined,
     otelExperimentId: savedVars.OTEL_EXPERIMENT_ID || undefined,
     otelImage: savedVars.OTEL_IMAGE || undefined,
+    chromiumSidecar: savedVars.CHROMIUM_SIDECAR === "true" || undefined,
+    chromiumImage: savedVars.CHROMIUM_IMAGE || undefined,
     telegramBotToken: savedVars.TELEGRAM_BOT_TOKEN || undefined,
     telegramAllowFrom: savedVars.TELEGRAM_ALLOW_FROM || undefined,
     sandboxEnabled: savedVars.SANDBOX_ENABLED === "true" || undefined,


### PR DESCRIPTION
## Summary

- Adds a headless Chromium sidecar container option for both Kubernetes and local (Podman/Docker) deployments
- Enables agents to browse the web, fill forms, and take screenshots via Chrome DevTools Protocol (CDP)
- Follows the existing sidecar patterns (LiteLLM, OTEL) exactly
- Configures the gateway's browser profile in `openclaw.json` so the browser tool connects to the sidecar via CDP

## Changes

### New Files
- `src/server/deployers/chromium.ts` — Image constant, decision function, container naming, gateway env vars
- `src/server/deployers/__tests__/chromium.test.ts` — 9 tests covering all module functions

### Server-Side
- `types.ts` — Added chromiumSidecar and chromiumImage to DeployConfig
- `k8s-manifests.ts` — Chromium sidecar container with CDP port, Memory-backed /dev/shm, security context, readiness probe
- `k8s-helpers.ts` — Browser profile config in `buildOpenClawConfig()` so gateway connects to sidecar via CDP
- `local.ts` — Full sidecar lifecycle (deploy, start, stop, teardown) for Podman and Docker; browser profile config in `buildOpenClawConfig()`

### Client-Side
- `deploy-form/types.ts` — Added chromiumSidecar and chromiumImage to DeployFormConfig
- `deploy-form/serialization.ts` — Config persistence across save/restore cycles
- `DeployForm.tsx` — New top-level Browser section with enable checkbox and image override

## Test plan
- [x] npm run build passes
- [x] npm test passes (328 tests, 29 files)
- [x] New chromium.test.ts (9 tests)
- [x] Local deploy (Podman): sidecar starts, CDP endpoint reachable, browser tool works end-to-end
- [x] Verified CHROME_CDP_URL env var set in gateway container
- [x] Verified browser config in openclaw.json with correct CDP URL
- [x] Agent successfully browsed nytimes.com via the sidecar and read headlines

Fixes #21