### PR TITLE
fix(deployers): gate Google provider on inferenceProvider selection

### DIFF
--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -958,3 +958,69 @@ describe("MCP servers from agent source", () => {
     expect(rendered.mcp).toBeUndefined();
   });
 });
+
+// Regression tests for #115: Google provider should not leak into non-Google deployments
+describe("Issue #115: Google provider gating", () => {
+  it("does NOT register Google provider when inferenceProvider is vertex-anthropic", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      anthropicApiKey: "sk-ant-test",
+      googleApiKey: "AIza-leftover-key",
+    });
+    const rendered = buildOpenClawConfig(config, "token") as {
+      models?: { providers?: Record<string, unknown> };
+    };
+
+    expect(rendered.models?.providers?.google).toBeUndefined();
+  });
+
+  it("does NOT register Google provider when inferenceProvider is anthropic", () => {
+    const config = makeConfig({
+      inferenceProvider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+      googleApiKey: "AIza-leftover-key",
+    });
+    const rendered = buildOpenClawConfig(config, "token") as {
+      models?: { providers?: Record<string, unknown> };
+    };
+
+    expect(rendered.models?.providers?.google).toBeUndefined();
+  });
+
+  it("does NOT register Google provider when inferenceProvider is openai", () => {
+    const config = makeConfig({
+      inferenceProvider: "openai",
+      openaiApiKey: "sk-oai-test",
+      googleApiKey: "AIza-leftover-key",
+    });
+    const rendered = buildOpenClawConfig(config, "token") as {
+      models?: { providers?: Record<string, unknown> };
+    };
+
+    expect(rendered.models?.providers?.google).toBeUndefined();
+  });
+
+  it("DOES register Google provider when inferenceProvider is google", () => {
+    const config = makeConfig({
+      inferenceProvider: "google",
+      googleApiKey: "AIza-active-key",
+    });
+    const rendered = buildOpenClawConfig(config, "token") as {
+      models?: { providers?: Record<string, unknown> };
+    };
+
+    expect(rendered.models?.providers?.google).toBeDefined();
+  });
+
+  it("DOES register Google provider when inferenceProvider is vertex-google", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-google",
+      googleApiKey: "AIza-active-key",
+    });
+    const rendered = buildOpenClawConfig(config, "token") as {
+      models?: { providers?: Record<string, unknown> };
+    };
+
+    expect(rendered.models?.providers?.google).toBeDefined();
+  });
+});

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -271,6 +271,53 @@ describe("gateway env vars in proxy mode", () => {
     expect(secret.stringData?.TELEGRAM_BOT_TOKEN).toBeUndefined();
   });
 
+  // Regression tests for #115: GEMINI_API_KEY should not leak into non-Google deployments
+  it("excludes GEMINI_API_KEY when inferenceProvider is vertex-anthropic", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+      anthropicApiKey: "sk-ant-test",
+      googleApiKey: "AIza-leftover-key",
+    });
+
+    const secret = secretManifest("ns", config, "gateway-token");
+
+    expect(secret.stringData?.GEMINI_API_KEY).toBeUndefined();
+  });
+
+  it("excludes GEMINI_API_KEY when inferenceProvider is anthropic", () => {
+    const config = makeConfig({
+      inferenceProvider: "anthropic",
+      anthropicApiKey: "sk-ant-test",
+      googleApiKey: "AIza-leftover-key",
+    });
+
+    const secret = secretManifest("ns", config, "gateway-token");
+
+    expect(secret.stringData?.GEMINI_API_KEY).toBeUndefined();
+  });
+
+  it("includes GEMINI_API_KEY when inferenceProvider is google", () => {
+    const config = makeConfig({
+      inferenceProvider: "google",
+      googleApiKey: "AIza-active-key",
+    });
+
+    const secret = secretManifest("ns", config, "gateway-token");
+
+    expect(secret.stringData?.GEMINI_API_KEY).toBe("AIza-active-key");
+  });
+
+  it("includes GEMINI_API_KEY when inferenceProvider is vertex-google", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-google",
+      googleApiKey: "AIza-active-key",
+    });
+
+    const secret = secretManifest("ns", config, "gateway-token");
+
+    expect(secret.stringData?.GEMINI_API_KEY).toBe("AIza-active-key");
+  });
+
   it("excludes GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION when proxy is active", () => {
     const proxyConfig = makeConfig({
       inferenceProvider: "vertex-anthropic",

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -532,7 +532,10 @@ function attachSecretHandlingConfig(ocConfig: Record<string, unknown>, config: D
       shouldDefineDefaultEnvProvider = true;
     }
   }
-  if (googleApiKeyRef) {
+  // Fix for #115: only register the Google provider when Google is the active
+  // inference provider, not merely because a leftover API key exists in config.
+  const isGoogleInferenceProvider = config.inferenceProvider === "google" || config.inferenceProvider === "vertex-google";
+  if (googleApiKeyRef && isGoogleInferenceProvider) {
     if (googleApiKeyRef.source === "env" && googleApiKeyRef.provider === "default") {
       shouldDefineDefaultEnvProvider = true;
     }

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -160,8 +160,10 @@ export function secretManifest(ns: string, config: DeployConfig, gatewayToken: s
   if (config.openaiApiKey && openaiEnvRefId) {
     data[openaiEnvRefId] = config.openaiApiKey;
   }
+  // Fix for #115: only include GEMINI_API_KEY when Google is the active inference provider.
+  const isGoogleInferenceProvider = config.inferenceProvider === "google" || config.inferenceProvider === "vertex-google";
   const googleEnvRefId = resolveEnvSecretRefId(config.googleApiKeyRef, "GEMINI_API_KEY");
-  if (config.googleApiKey && googleEnvRefId) {
+  if (config.googleApiKey && googleEnvRefId && isGoogleInferenceProvider) {
     data[googleEnvRefId] = config.googleApiKey;
   }
   const openrouterEnvRefId = resolveEnvSecretRefId(config.openrouterApiKeyRef, "OPENROUTER_API_KEY");


### PR DESCRIPTION
## Summary

- Gate Google provider registration in `attachSecretHandlingConfig()` on `inferenceProvider` being `"google"` or `"vertex-google"`
- Gate `GEMINI_API_KEY` inclusion in `secretManifest()` on the same condition
- Add 9 regression tests covering both defect sites with positive and negative cases

## Root Cause

When deploying to K8s with a non-Google inference provider, leftover Google API keys from a previous deployment caused `attachSecretHandlingConfig()` to unconditionally register a `models.providers.google` entry in `openclaw.json` and `secretManifest()` to include `GEMINI_API_KEY` in the K8s Secret. The gateway then crashed at startup:

```
SecretRefResolutionError: Environment variable "GEMINI_API_KEY" is missing or empty.
```

Both functions now check `config.inferenceProvider` before registering Google-specific configuration.

## Test Plan

- [x] 5 regression tests in `k8s-helpers.test.ts` — verify `buildOpenClawConfig` does/doesn't register Google provider based on `inferenceProvider`
- [x] 4 regression tests in `k8s-manifests.test.ts` — verify `secretManifest` does/doesn't include `GEMINI_API_KEY` based on `inferenceProvider`
- [x] Full test suite passes (337/337 tests)
- [x] ESLint and TypeScript type checks pass

Fixes #115
