### PR TITLE
fix: filter unused provider keys from deploy configs

### DIFF
--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -44,6 +44,7 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
   const [loadedConfigLabel, setLoadedConfigLabel] = useState<string | null>(null);
   const [autoLoadedEnvDir, setAutoLoadedEnvDir] = useState<string | null>(null);
   const [inferenceProvider, setInferenceProvider] = useState<InferenceProvider>("anthropic");
+  const [selectedProviders, setSelectedProviders] = useState<InferenceProvider[]>(["anthropic"]);
   const [modeManuallySelected, setModeManuallySelected] = useState(false);
   const [autoSwitchMessage, setAutoSwitchMessage] = useState<string | null>(null);
   // Refs so refreshEnvironment can read latest values without re-creating the callback
@@ -585,6 +586,10 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
     }
   }, [vertexCredsForFetch]);
 
+  const handleSelectedProvidersChange = useCallback((providers: InferenceProvider[]) => {
+    setSelectedProviders(providers);
+  }, []);
+
   const handleDeploy = async () => {
     if (!isValid) {
       return;
@@ -597,6 +602,7 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
         config,
         isVertex,
         suggestedNamespace,
+        selectedProviders,
         anthropicApiKeyRef,
         openaiApiKeyRef,
         googleApiKeyRef,
@@ -628,6 +634,7 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
       inferenceProvider,
       isVertex,
       suggestedNamespace,
+      selectedProviders,
       anthropicApiKeyRef,
       openaiApiKeyRef,
       googleApiKeyRef,
@@ -1259,6 +1266,7 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
           setConfig={setConfig}
           setInferenceProvider={setInferenceProvider}
           update={update}
+          onSelectedProvidersChange={handleSelectedProvidersChange}
           loadingAnthropicModels={loadingAnthropicModels}
           loadingOpenaiModels={loadingOpenaiModels}
           anthropicModelOptions={anthropicModelOptions}

--- a/src/client/components/__tests__/DeployForm.test.tsx
+++ b/src/client/components/__tests__/DeployForm.test.tsx
@@ -536,14 +536,17 @@ describe("DeployForm agent name validation (issue #7)", () => {
     expect(deployCall).toBeTruthy();
     const body = JSON.parse(String((deployCall?.[1] as RequestInit | undefined)?.body || "{}"));
 
+    // Only the selected primary provider's credentials are sent;
+    // credentials entered while briefly switching the primary are retained
+    // in the form but filtered out at serialization time.
     expect(body.inferenceProvider).toBe("anthropic");
     expect(body.anthropicApiKey).toBe("sk-ant-demo");
-    expect(body.openaiApiKey).toBe("sk-openai-demo");
     expect(body.anthropicModel).toBe("claude-sonnet-4-6");
-    expect(body.openaiModel).toBe("gpt-5");
-    expect(body.modelEndpoint).toBe("http://localhost:8000/v1");
-    expect(body.modelEndpointApiKey).toBe("endpoint-token");
-    expect(body.modelEndpointModel).toBe("mistral-small-24b-w8a8");
+    expect(body.openaiApiKey).toBeUndefined();
+    expect(body.openaiModel).toBeUndefined();
+    expect(body.modelEndpoint).toBeUndefined();
+    expect(body.modelEndpointApiKey).toBeUndefined();
+    expect(body.modelEndpointModel).toBeUndefined();
   });
 
   it("submits the OpenAI-compatible endpoints toggle when disabled", async () => {

--- a/src/client/components/__tests__/multi-model.test.tsx
+++ b/src/client/components/__tests__/multi-model.test.tsx
@@ -199,6 +199,144 @@ describe("Multi-model per provider", () => {
     });
   });
 
+  describe("selectedProviders filtering", () => {
+    it("excludes unselected provider keys from deploy body", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      config.anthropicApiKey = "sk-ant-test";
+      config.anthropicModel = "claude-sonnet-4-6";
+      config.openaiApiKey = "sk-openai-test";
+      config.openaiModel = "gpt-5";
+      config.googleApiKey = "google-key";
+      config.googleModel = "gemini-3.1-pro-preview";
+      const body = buildDeployRequestBody({
+        mode: "local",
+        inferenceProvider: "anthropic",
+        config,
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+        selectedProviders: ["anthropic"],
+      });
+      expect(body.anthropicApiKey).toBe("sk-ant-test");
+      expect(body.anthropicModel).toBe("claude-sonnet-4-6");
+      expect(body.openaiApiKey).toBeUndefined();
+      expect(body.openaiModel).toBeUndefined();
+      expect(body.googleApiKey).toBeUndefined();
+      expect(body.googleModel).toBeUndefined();
+    });
+
+    it("includes keys for all selected providers", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      config.anthropicApiKey = "sk-ant-test";
+      config.openaiApiKey = "sk-openai-test";
+      config.googleApiKey = "google-key";
+      const body = buildDeployRequestBody({
+        mode: "local",
+        inferenceProvider: "anthropic",
+        config,
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+        selectedProviders: ["anthropic", "openai"],
+      });
+      expect(body.anthropicApiKey).toBe("sk-ant-test");
+      expect(body.openaiApiKey).toBe("sk-openai-test");
+      expect(body.googleApiKey).toBeUndefined();
+    });
+
+    it("excludes SecretRefs for unselected providers", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      const body = buildDeployRequestBody({
+        mode: "kubernetes",
+        inferenceProvider: "anthropic",
+        config,
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+        selectedProviders: ["anthropic"],
+        anthropicApiKeyRef: { source: "env", provider: "default", id: "ANTHROPIC_API_KEY" },
+        openaiApiKeyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        googleApiKeyRef: { source: "env", provider: "default", id: "GEMINI_API_KEY" },
+      });
+      expect(body.anthropicApiKeyRef).toEqual({ source: "env", provider: "default", id: "ANTHROPIC_API_KEY" });
+      expect(body.openaiApiKeyRef).toBeUndefined();
+      expect(body.googleApiKeyRef).toBeUndefined();
+    });
+
+    it("includes all provider keys when selectedProviders is omitted (backward compat)", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      config.anthropicApiKey = "sk-ant-test";
+      config.openaiApiKey = "sk-openai-test";
+      config.googleApiKey = "google-key";
+      const body = buildDeployRequestBody({
+        mode: "local",
+        inferenceProvider: "anthropic",
+        config,
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+      });
+      expect(body.anthropicApiKey).toBe("sk-ant-test");
+      expect(body.openaiApiKey).toBe("sk-openai-test");
+      expect(body.googleApiKey).toBe("google-key");
+    });
+
+    it("excludes unselected provider keys from env file content", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      config.anthropicApiKey = "sk-ant-test";
+      config.openaiApiKey = "sk-openai-test";
+      config.googleApiKey = "google-key";
+      const env = buildEnvFileContent({
+        config,
+        inferenceProvider: "anthropic",
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+        selectedProviders: ["anthropic"],
+      });
+      expect(env).toContain("ANTHROPIC_API_KEY=sk-ant-test");
+      expect(env).toContain("OPENAI_API_KEY=\n");
+      expect(env).toContain("GEMINI_API_KEY=\n");
+    });
+
+    it("excludes vertex models when vertex provider is not selected", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      config.vertexAnthropicModel = "claude-sonnet-4-6";
+      config.vertexAnthropicModels = ["claude-opus-4-6"];
+      const body = buildDeployRequestBody({
+        mode: "kubernetes",
+        inferenceProvider: "anthropic",
+        config,
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+        selectedProviders: ["anthropic"],
+      });
+      expect(body.vertexAnthropicModel).toBeUndefined();
+      expect(body.vertexAnthropicModels).toBeUndefined();
+      expect(body.vertexEnabled).toBeUndefined();
+    });
+
+    it("excludes custom-endpoint fields when not selected", () => {
+      const config = createInitialDeployFormConfig();
+      config.agentName = "test";
+      config.modelEndpoint = "https://example.com/v1";
+      config.modelEndpointModel = "my-model";
+      config.modelEndpointApiKey = "ep-key";
+      const body = buildDeployRequestBody({
+        mode: "local",
+        inferenceProvider: "anthropic",
+        config,
+        isVertex: false,
+        suggestedNamespace: "test-ns",
+        selectedProviders: ["anthropic"],
+      });
+      expect(body.modelEndpoint).toBeUndefined();
+      expect(body.modelEndpointModel).toBeUndefined();
+      expect(body.modelEndpointApiKey).toBeUndefined();
+    });
+  });
+
   describe("applySavedVarsToConfig (backward compat)", () => {
     it("loads single-model config without anthropicModels/openaiModels", () => {
       const prev = createInitialDeployFormConfig();

--- a/src/client/components/deploy-form/ProviderSection.tsx
+++ b/src/client/components/deploy-form/ProviderSection.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import {
   MODEL_DEFAULTS,
@@ -40,6 +40,7 @@ interface ProviderSectionProps {
   setConfig: Dispatch<SetStateAction<DeployFormConfig>>;
   setInferenceProvider: Dispatch<SetStateAction<InferenceProvider>>;
   update: (field: string, value: string) => void;
+  onSelectedProvidersChange?: (providers: InferenceProvider[]) => void;
 }
 
 interface AdditionalProvider {
@@ -151,6 +152,7 @@ export function ProviderSection({
   setConfig,
   setInferenceProvider,
   update,
+  onSelectedProvidersChange,
 }: ProviderSectionProps) {
   const [additionalProviders, setAdditionalProviders] = useState<AdditionalProvider[]>([]);
   const nextId = useRef(0);
@@ -160,6 +162,11 @@ export function ProviderSection({
     .filter((p): p is InferenceProvider => p !== "");
 
   const allUsedProviders = [inferenceProvider, ...selectedAdditionalProviders];
+
+  useEffect(() => {
+    onSelectedProvidersChange?.(allUsedProviders);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inferenceProvider, selectedAdditionalProviders.join(",")]);
 
   const allAdded = additionalProviders.length >= PROVIDER_OPTIONS.length - 1;
 

--- a/src/client/components/deploy-form/ProviderSection.tsx
+++ b/src/client/components/deploy-form/ProviderSection.tsx
@@ -163,10 +163,10 @@ export function ProviderSection({
 
   const allUsedProviders = [inferenceProvider, ...selectedAdditionalProviders];
 
+  const additionalKey = selectedAdditionalProviders.join(",");
   useEffect(() => {
     onSelectedProvidersChange?.(allUsedProviders);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inferenceProvider, selectedAdditionalProviders.join(",")]);
+  }, [inferenceProvider, additionalKey]); // onSelectedProvidersChange is stable (useCallback)
 
   const allAdded = additionalProviders.length >= PROVIDER_OPTIONS.length - 1;
 

--- a/src/client/components/deploy-form/serialization.ts
+++ b/src/client/components/deploy-form/serialization.ts
@@ -420,12 +420,21 @@ export function applySavedVarsToConfig(
   };
 }
 
+function isProviderSelected(
+  provider: InferenceProvider,
+  selectedProviders: InferenceProvider[] | undefined,
+): boolean {
+  if (!selectedProviders) return true;
+  return selectedProviders.includes(provider);
+}
+
 export function buildDeployRequestBody(params: {
   mode: string;
   inferenceProvider: InferenceProvider;
   config: DeployFormConfig;
   isVertex: boolean;
   suggestedNamespace: string;
+  selectedProviders?: InferenceProvider[];
   anthropicApiKeyRef?: SecretRefValue;
   openaiApiKeyRef?: SecretRefValue;
   googleApiKeyRef?: SecretRefValue;
@@ -439,6 +448,7 @@ export function buildDeployRequestBody(params: {
     config,
     isVertex,
     suggestedNamespace,
+    selectedProviders,
     anthropicApiKeyRef,
     openaiApiKeyRef,
     googleApiKeyRef,
@@ -448,6 +458,8 @@ export function buildDeployRequestBody(params: {
   } = params;
   const vertexProvider = inferenceProvider === "vertex-google" ? "google" : "anthropic";
   const podmanSecretMappings = parsePodmanSecretMappingsText(config.podmanSecretMappingsText).mappings;
+  const sel = (p: InferenceProvider) => isProviderSelected(p, selectedProviders);
+  const anyVertexSelected = sel("vertex-anthropic") || sel("vertex-google");
 
   return {
     mode,
@@ -459,11 +471,11 @@ export function buildDeployRequestBody(params: {
     containerRunArgs: mode === "local" ? trimToUndefined(config.containerRunArgs) : undefined,
     podmanSecretMappings: mode === "local" && podmanSecretMappings.length > 0 ? podmanSecretMappings : undefined,
     secretsProvidersJson: trimToUndefined(config.secretsProvidersJson),
-    anthropicApiKeyRef,
-    openaiApiKeyRef,
-    googleApiKeyRef,
-    openrouterApiKeyRef,
-    modelEndpointApiKeyRef,
+    anthropicApiKeyRef: sel("anthropic") ? anthropicApiKeyRef : undefined,
+    openaiApiKeyRef: sel("openai") ? openaiApiKeyRef : undefined,
+    googleApiKeyRef: sel("google") ? googleApiKeyRef : undefined,
+    openrouterApiKeyRef: sel("openrouter") ? openrouterApiKeyRef : undefined,
+    modelEndpointApiKeyRef: sel("custom-endpoint") ? modelEndpointApiKeyRef : undefined,
     telegramBotTokenRef: config.telegramEnabled ? telegramBotTokenRef : undefined,
     sandboxEnabled: config.sandboxEnabled || undefined,
     sandboxBackend: config.sandboxEnabled ? "ssh" : undefined,
@@ -496,37 +508,37 @@ export function buildDeployRequestBody(params: {
       config.sandboxEnabled ? config.sandboxSshCertificate || undefined : undefined,
     sandboxSshKnownHosts:
       config.sandboxEnabled ? config.sandboxSshKnownHosts || undefined : undefined,
-    anthropicApiKey: !anthropicApiKeyRef ? trimToUndefined(config.anthropicApiKey) : undefined,
-    openaiApiKey: !openaiApiKeyRef ? trimToUndefined(config.openaiApiKey) : undefined,
-    googleApiKey: !googleApiKeyRef ? trimToUndefined(config.googleApiKey) : undefined,
-    openrouterApiKey: !openrouterApiKeyRef ? trimToUndefined(config.openrouterApiKey) : undefined,
-    anthropicModel: trimToUndefined(config.anthropicModel),
-    anthropicModels: config.anthropicModels.length > 0 ? config.anthropicModels : undefined,
-    openaiModel: trimToUndefined(config.openaiModel),
-    openaiModels: config.openaiModels.length > 0 ? config.openaiModels : undefined,
-    googleModel: trimToUndefined(config.googleModel),
-    googleModels: config.googleModels.length > 0 ? config.googleModels : undefined,
-    openrouterModel: trimToUndefined(config.openrouterModel),
-    openrouterModels: config.openrouterModels.length > 0 ? config.openrouterModels : undefined,
+    anthropicApiKey: sel("anthropic") && !anthropicApiKeyRef ? trimToUndefined(config.anthropicApiKey) : undefined,
+    openaiApiKey: sel("openai") && !openaiApiKeyRef ? trimToUndefined(config.openaiApiKey) : undefined,
+    googleApiKey: sel("google") && !googleApiKeyRef ? trimToUndefined(config.googleApiKey) : undefined,
+    openrouterApiKey: sel("openrouter") && !openrouterApiKeyRef ? trimToUndefined(config.openrouterApiKey) : undefined,
+    anthropicModel: sel("anthropic") ? trimToUndefined(config.anthropicModel) : undefined,
+    anthropicModels: sel("anthropic") && config.anthropicModels.length > 0 ? config.anthropicModels : undefined,
+    openaiModel: sel("openai") ? trimToUndefined(config.openaiModel) : undefined,
+    openaiModels: sel("openai") && config.openaiModels.length > 0 ? config.openaiModels : undefined,
+    googleModel: sel("google") ? trimToUndefined(config.googleModel) : undefined,
+    googleModels: sel("google") && config.googleModels.length > 0 ? config.googleModels : undefined,
+    openrouterModel: sel("openrouter") ? trimToUndefined(config.openrouterModel) : undefined,
+    openrouterModels: sel("openrouter") && config.openrouterModels.length > 0 ? config.openrouterModels : undefined,
     agentModel: config.agentModel || undefined,
-    vertexAnthropicModel: trimToUndefined(config.vertexAnthropicModel),
-    vertexAnthropicModels: config.vertexAnthropicModels.length > 0 ? config.vertexAnthropicModels : undefined,
-    vertexGoogleModel: trimToUndefined(config.vertexGoogleModel),
-    vertexGoogleModels: config.vertexGoogleModels.length > 0 ? config.vertexGoogleModels : undefined,
+    vertexAnthropicModel: sel("vertex-anthropic") ? trimToUndefined(config.vertexAnthropicModel) : undefined,
+    vertexAnthropicModels: sel("vertex-anthropic") && config.vertexAnthropicModels.length > 0 ? config.vertexAnthropicModels : undefined,
+    vertexGoogleModel: sel("vertex-google") ? trimToUndefined(config.vertexGoogleModel) : undefined,
+    vertexGoogleModels: sel("vertex-google") && config.vertexGoogleModels.length > 0 ? config.vertexGoogleModels : undefined,
     openaiCompatibleEndpointsEnabled: config.openaiCompatibleEndpointsEnabled,
-    modelEndpoint: trimToUndefined(config.modelEndpoint),
-    modelEndpointApiKey: !modelEndpointApiKeyRef ? trimToUndefined(config.modelEndpointApiKey) : undefined,
-    modelEndpointModel: trimToUndefined(config.modelEndpointModel),
-    modelEndpointModelLabel: trimToUndefined(config.modelEndpointModelLabel),
-    modelEndpointModels: config.modelEndpointModels.length > 0 ? config.modelEndpointModels : undefined,
+    modelEndpoint: sel("custom-endpoint") ? trimToUndefined(config.modelEndpoint) : undefined,
+    modelEndpointApiKey: sel("custom-endpoint") && !modelEndpointApiKeyRef ? trimToUndefined(config.modelEndpointApiKey) : undefined,
+    modelEndpointModel: sel("custom-endpoint") ? trimToUndefined(config.modelEndpointModel) : undefined,
+    modelEndpointModelLabel: sel("custom-endpoint") ? trimToUndefined(config.modelEndpointModelLabel) : undefined,
+    modelEndpointModels: sel("custom-endpoint") && config.modelEndpointModels.length > 0 ? config.modelEndpointModels : undefined,
     port: parseInt(config.port, 10) || 18789,
-    vertexEnabled: isVertex || undefined,
-    vertexProvider: isVertex ? vertexProvider : undefined,
-    googleCloudProject: isVertex ? trimToUndefined(config.googleCloudProject) : undefined,
-    googleCloudLocation: isVertex ? trimToUndefined(config.googleCloudLocation) : undefined,
-    gcpServiceAccountJson: isVertex ? trimToUndefined(config.gcpServiceAccountJson) : undefined,
-    gcpServiceAccountPath: isVertex ? trimToUndefined(config.gcpServiceAccountPath) : undefined,
-    litellmProxy: isVertex ? config.litellmProxy : undefined,
+    vertexEnabled: anyVertexSelected || undefined,
+    vertexProvider: anyVertexSelected ? vertexProvider : undefined,
+    googleCloudProject: anyVertexSelected ? trimToUndefined(config.googleCloudProject) : undefined,
+    googleCloudLocation: anyVertexSelected ? trimToUndefined(config.googleCloudLocation) : undefined,
+    gcpServiceAccountJson: anyVertexSelected ? trimToUndefined(config.gcpServiceAccountJson) : undefined,
+    gcpServiceAccountPath: anyVertexSelected ? trimToUndefined(config.gcpServiceAccountPath) : undefined,
+    litellmProxy: anyVertexSelected ? config.litellmProxy : undefined,
     namespace: trimToUndefined(config.namespace) || suggestedNamespace || undefined,
     withA2a: config.withA2a || undefined,
     a2aRealm: config.withA2a ? trimToUndefined(config.a2aRealm) : undefined,
@@ -554,6 +566,7 @@ export function buildEnvFileContent(params: {
   inferenceProvider: InferenceProvider;
   isVertex: boolean;
   suggestedNamespace: string;
+  selectedProviders?: InferenceProvider[];
   anthropicApiKeyRef?: SecretRefValue;
   openaiApiKeyRef?: SecretRefValue;
   googleApiKeyRef?: SecretRefValue;
@@ -566,6 +579,7 @@ export function buildEnvFileContent(params: {
     inferenceProvider,
     isVertex,
     suggestedNamespace,
+    selectedProviders,
     anthropicApiKeyRef,
     openaiApiKeyRef,
     googleApiKeyRef,
@@ -573,6 +587,8 @@ export function buildEnvFileContent(params: {
     modelEndpointApiKeyRef,
     telegramBotTokenRef,
   } = params;
+  const sel = (p: InferenceProvider) => isProviderSelected(p, selectedProviders);
+  const anyVertexSelected = sel("vertex-anthropic") || sel("vertex-google");
 
   const lines = [
     "# OpenClaw installer config",
@@ -586,31 +602,31 @@ export function buildEnvFileContent(params: {
     `AGENT_SOURCE_DIR=${config.agentSourceDir}`,
     "",
     `INFERENCE_PROVIDER=${inferenceProvider}`,
-    `ANTHROPIC_API_KEY=${anthropicApiKeyRef ? "" : config.anthropicApiKey}`,
-    `OPENAI_API_KEY=${openaiApiKeyRef ? "" : config.openaiApiKey}`,
-    `GEMINI_API_KEY=${googleApiKeyRef ? "" : config.googleApiKey}`,
-    `OPENROUTER_API_KEY=${openrouterApiKeyRef ? "" : config.openrouterApiKey}`,
-    `ANTHROPIC_MODEL=${config.anthropicModel}`,
-    `ANTHROPIC_MODELS_B64=${encodeBase64(JSON.stringify(config.anthropicModels))}`,
-    `OPENAI_MODEL=${config.openaiModel}`,
-    `OPENAI_MODELS_B64=${encodeBase64(JSON.stringify(config.openaiModels))}`,
-    `GOOGLE_MODEL=${config.googleModel}`,
-    `GOOGLE_MODELS_B64=${encodeBase64(JSON.stringify(config.googleModels))}`,
-    `OPENROUTER_MODEL=${config.openrouterModel}`,
-    `OPENROUTER_MODELS_B64=${encodeBase64(JSON.stringify(config.openrouterModels))}`,
+    `ANTHROPIC_API_KEY=${sel("anthropic") && !anthropicApiKeyRef ? config.anthropicApiKey : ""}`,
+    `OPENAI_API_KEY=${sel("openai") && !openaiApiKeyRef ? config.openaiApiKey : ""}`,
+    `GEMINI_API_KEY=${sel("google") && !googleApiKeyRef ? config.googleApiKey : ""}`,
+    `OPENROUTER_API_KEY=${sel("openrouter") && !openrouterApiKeyRef ? config.openrouterApiKey : ""}`,
+    `ANTHROPIC_MODEL=${sel("anthropic") ? config.anthropicModel : ""}`,
+    `ANTHROPIC_MODELS_B64=${encodeBase64(JSON.stringify(sel("anthropic") ? config.anthropicModels : []))}`,
+    `OPENAI_MODEL=${sel("openai") ? config.openaiModel : ""}`,
+    `OPENAI_MODELS_B64=${encodeBase64(JSON.stringify(sel("openai") ? config.openaiModels : []))}`,
+    `GOOGLE_MODEL=${sel("google") ? config.googleModel : ""}`,
+    `GOOGLE_MODELS_B64=${encodeBase64(JSON.stringify(sel("google") ? config.googleModels : []))}`,
+    `OPENROUTER_MODEL=${sel("openrouter") ? config.openrouterModel : ""}`,
+    `OPENROUTER_MODELS_B64=${encodeBase64(JSON.stringify(sel("openrouter") ? config.openrouterModels : []))}`,
     `OPENAI_COMPATIBLE_ENDPOINTS_ENABLED=${config.openaiCompatibleEndpointsEnabled}`,
-    `MODEL_ENDPOINT=${config.modelEndpoint}`,
-    `MODEL_ENDPOINT_API_KEY=${modelEndpointApiKeyRef ? "" : config.modelEndpointApiKey}`,
-    `MODEL_ENDPOINT_MODEL=${config.modelEndpointModel}`,
-    `MODEL_ENDPOINT_MODEL_LABEL=${config.modelEndpointModelLabel}`,
-    `MODEL_ENDPOINT_MODELS_B64=${encodeBase64(JSON.stringify(config.modelEndpointModels))}`,
+    `MODEL_ENDPOINT=${sel("custom-endpoint") ? config.modelEndpoint : ""}`,
+    `MODEL_ENDPOINT_API_KEY=${sel("custom-endpoint") && !modelEndpointApiKeyRef ? config.modelEndpointApiKey : ""}`,
+    `MODEL_ENDPOINT_MODEL=${sel("custom-endpoint") ? config.modelEndpointModel : ""}`,
+    `MODEL_ENDPOINT_MODEL_LABEL=${sel("custom-endpoint") ? config.modelEndpointModelLabel : ""}`,
+    `MODEL_ENDPOINT_MODELS_B64=${encodeBase64(JSON.stringify(sel("custom-endpoint") ? config.modelEndpointModels : []))}`,
     `AGENT_MODEL=${config.agentModel}`,
-    `VERTEX_ANTHROPIC_MODEL=${config.vertexAnthropicModel}`,
-    `VERTEX_ANTHROPIC_MODELS_B64=${encodeBase64(JSON.stringify(config.vertexAnthropicModels))}`,
-    `VERTEX_GOOGLE_MODEL=${config.vertexGoogleModel}`,
-    `VERTEX_GOOGLE_MODELS_B64=${encodeBase64(JSON.stringify(config.vertexGoogleModels))}`,
+    `VERTEX_ANTHROPIC_MODEL=${sel("vertex-anthropic") ? config.vertexAnthropicModel : ""}`,
+    `VERTEX_ANTHROPIC_MODELS_B64=${encodeBase64(JSON.stringify(sel("vertex-anthropic") ? config.vertexAnthropicModels : []))}`,
+    `VERTEX_GOOGLE_MODEL=${sel("vertex-google") ? config.vertexGoogleModel : ""}`,
+    `VERTEX_GOOGLE_MODELS_B64=${encodeBase64(JSON.stringify(sel("vertex-google") ? config.vertexGoogleModels : []))}`,
     "",
-    `VERTEX_ENABLED=${isVertex}`,
+    `VERTEX_ENABLED=${anyVertexSelected}`,
     `VERTEX_PROVIDER=${inferenceProvider === "vertex-google" ? "google" : "anthropic"}`,
     `GOOGLE_CLOUD_PROJECT=${config.googleCloudProject}`,
     `GOOGLE_CLOUD_LOCATION=${config.googleCloudLocation}`,
@@ -663,19 +679,19 @@ export function buildEnvFileContent(params: {
   if (config.secretsProvidersJson.trim()) {
     lines.push(`SECRETS_PROVIDERS_JSON_B64=${encodeBase64(config.secretsProvidersJson)}`);
   }
-  if (anthropicApiKeyRef) {
+  if (sel("anthropic") && anthropicApiKeyRef) {
     lines.push(`ANTHROPIC_API_KEY_REF_B64=${encodeBase64(JSON.stringify(anthropicApiKeyRef))}`);
   }
-  if (openaiApiKeyRef) {
+  if (sel("openai") && openaiApiKeyRef) {
     lines.push(`OPENAI_API_KEY_REF_B64=${encodeBase64(JSON.stringify(openaiApiKeyRef))}`);
   }
-  if (googleApiKeyRef) {
+  if (sel("google") && googleApiKeyRef) {
     lines.push(`GOOGLE_API_KEY_REF_B64=${encodeBase64(JSON.stringify(googleApiKeyRef))}`);
   }
-  if (openrouterApiKeyRef) {
+  if (sel("openrouter") && openrouterApiKeyRef) {
     lines.push(`OPENROUTER_API_KEY_REF_B64=${encodeBase64(JSON.stringify(openrouterApiKeyRef))}`);
   }
-  if (modelEndpointApiKeyRef) {
+  if (sel("custom-endpoint") && modelEndpointApiKeyRef) {
     lines.push(`MODEL_ENDPOINT_API_KEY_REF_B64=${encodeBase64(JSON.stringify(modelEndpointApiKeyRef))}`);
   }
   if (telegramBotTokenRef) {

--- a/src/client/components/deploy-form/serialization.ts
+++ b/src/client/components/deploy-form/serialization.ts
@@ -446,7 +446,7 @@ export function buildDeployRequestBody(params: {
     mode,
     inferenceProvider,
     config,
-    isVertex,
+    isVertex: _isVertex,
     suggestedNamespace,
     selectedProviders,
     anthropicApiKeyRef,
@@ -578,7 +578,7 @@ export function buildEnvFileContent(params: {
   const {
     config,
     inferenceProvider,
-    isVertex,
+    isVertex: _isVertex,
     suggestedNamespace,
     selectedProviders,
     anthropicApiKeyRef,

--- a/src/client/components/deploy-form/serialization.ts
+++ b/src/client/components/deploy-form/serialization.ts
@@ -464,6 +464,7 @@ export function buildDeployRequestBody(params: {
   return {
     mode,
     inferenceProvider,
+    selectedProviders,
     prefix: config.prefix,
     agentName: config.agentName,
     agentDisplayName: config.agentDisplayName || config.agentName,

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -332,6 +332,7 @@ export function deploymentManifest(
     // natively. LiteLLM only handles Vertex models.
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
     "OPENROUTER_API_KEY",
     "MODEL_ENDPOINT",
     "MODEL_ENDPOINT_API_KEY",

--- a/src/server/routes/__tests__/deploy-env.test.ts
+++ b/src/server/routes/__tests__/deploy-env.test.ts
@@ -96,4 +96,36 @@ describe("applyServerEnvFallbacks", () => {
     expect(config.openaiApiKey).toBe("sk-openai-env");
     expect(config.modelEndpointApiKey).toBe("endpoint-token");
   });
+
+  it("skips env fallbacks for providers not in selectedProviders", () => {
+    const config = makeConfig({
+      inferenceProvider: "vertex-anthropic",
+    });
+
+    applyServerEnvFallbacks(config, {
+      ANTHROPIC_API_KEY: "sk-ant-env",
+      GEMINI_API_KEY: "gemini-env",
+      OPENAI_API_KEY: "sk-openai-env",
+    }, ["vertex-anthropic"]);
+
+    expect(config.anthropicApiKey).toBeUndefined();
+    expect(config.googleApiKey).toBeUndefined();
+    expect(config.openaiApiKey).toBeUndefined();
+  });
+
+  it("hydrates env fallbacks only for selected providers", () => {
+    const config = makeConfig({
+      inferenceProvider: "anthropic",
+    });
+
+    applyServerEnvFallbacks(config, {
+      ANTHROPIC_API_KEY: "sk-ant-env",
+      OPENAI_API_KEY: "sk-openai-env",
+      GEMINI_API_KEY: "gemini-env",
+    }, ["anthropic", "openai"]);
+
+    expect(config.anthropicApiKey).toBe("sk-ant-env");
+    expect(config.openaiApiKey).toBe("sk-openai-env");
+    expect(config.googleApiKey).toBeUndefined();
+  });
 });

--- a/src/server/routes/deploy.ts
+++ b/src/server/routes/deploy.ts
@@ -68,33 +68,42 @@ function normalizeStringArray(arr: string[] | undefined): string[] | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
-export function applyServerEnvFallbacks(config: DeployConfig, env: NodeJS.ProcessEnv = process.env): void {
+export function applyServerEnvFallbacks(
+  config: DeployConfig,
+  env: NodeJS.ProcessEnv = process.env,
+  selectedProviders?: string[],
+): void {
+  const sel = (p: string) => !selectedProviders || selectedProviders.includes(p);
   if (!config.image && env.OPENCLAW_IMAGE) {
     config.image = env.OPENCLAW_IMAGE;
   }
   if (
-    !config.anthropicApiKey
+    sel("anthropic")
+    && !config.anthropicApiKey
     && !config.anthropicApiKeyRef
     && env.ANTHROPIC_API_KEY
   ) {
     config.anthropicApiKey = env.ANTHROPIC_API_KEY;
   }
   if (
-    !config.openaiApiKey
+    sel("openai")
+    && !config.openaiApiKey
     && !config.openaiApiKeyRef
     && env.OPENAI_API_KEY
   ) {
     config.openaiApiKey = env.OPENAI_API_KEY;
   }
   if (
-    !config.googleApiKey
+    sel("google")
+    && !config.googleApiKey
     && !config.googleApiKeyRef
     && (env.GEMINI_API_KEY || env.GOOGLE_API_KEY)
   ) {
     config.googleApiKey = env.GEMINI_API_KEY || env.GOOGLE_API_KEY;
   }
   if (
-    !config.openrouterApiKey
+    sel("openrouter")
+    && !config.openrouterApiKey
     && !config.openrouterApiKeyRef
     && env.OPENROUTER_API_KEY
   ) {
@@ -128,7 +137,8 @@ export function applyServerEnvFallbacks(config: DeployConfig, env: NodeJS.Proces
 }
 
 router.post("/", async (req, res) => {
-  const config = req.body as DeployConfig;
+  const { selectedProviders, ...configBody } = req.body as DeployConfig & { selectedProviders?: string[] };
+  const config = configBody as DeployConfig;
 
   config.image = trimOptional(config.image);
   config.modelEndpoint = trimOptional(config.modelEndpoint);
@@ -254,7 +264,8 @@ router.post("/", async (req, res) => {
   }
 
   // Fall back to server environment for image and credentials.
-  applyServerEnvFallbacks(config);
+  // Only inject env keys for providers the client explicitly selected.
+  applyServerEnvFallbacks(config, process.env, selectedProviders);
 
   if (!config.inferenceProvider) {
     if (config.vertexEnabled) {


### PR DESCRIPTION
## Summary

- Fixes the root cause of #115 (gateway crash from `SecretRefResolutionError` for unused provider keys)
- Surfaces `selectedProviders` from `ProviderSection` to `DeployForm` via a callback, then filters all provider-specific fields (API keys, SecretRefs, models) in both `buildDeployRequestBody` and `buildEnvFileContent`
- Only keys/refs/models for providers the user explicitly selected (primary + additional via "Add Provider") are included in the deploy request
- Also filters server-side env fallback injection (`applyServerEnvFallbacks`) so the server does not re-inject unused keys from its environment
- Fixes missing `GEMINI_API_KEY` env var mapping in K8s deployment manifests (the key was stored in the Secret but never exposed to the gateway container)
- This is a general fix for all providers, not just Google -- any leftover key for any unselected provider is filtered out
- Supersedes #117, which applied a Google-specific guard in the server-side deployer

## Details

The deploy form UI lets users select a primary inference provider and optionally add secondary providers. `ProviderSection` tracked selected providers in local state (`allUsedProviders`) but never communicated this to the parent `DeployForm`. The serialization layer sent ALL non-empty API keys to the server regardless of selection. The server then registered auth profiles and K8s Secret entries for those keys. If an auth profile referenced an env var (e.g. `GEMINI_API_KEY`) that was not present in the K8s Secret, the gateway crashed.

Additionally, the server-side `applyServerEnvFallbacks()` in `deploy.ts` injected API keys from server environment variables for ALL providers, even when the client only selected a subset. This meant that even if the client correctly filtered keys, the server would re-inject them. The fix passes `selectedProviders` from the client to the server and uses it to guard each provider env fallback.

A secondary bug was also found: `GEMINI_API_KEY` was missing from the `optionalKeys` array in `k8s-manifests.ts`, so even when the key was correctly placed in the K8s Secret, the gateway container had no env var mapping to access it.

### Changes

1. **`ProviderSection.tsx`** -- Added `onSelectedProvidersChange` callback prop; fires via `useEffect` when selected providers change
2. **`DeployForm.tsx`** -- Tracks `selectedProviders` state; passes it to both serialization functions
3. **`serialization.ts`** -- Added `isProviderSelected()` helper; both `buildDeployRequestBody` and `buildEnvFileContent` accept optional `selectedProviders` and filter provider keys/refs/models accordingly. Sends `selectedProviders` in the request body for server-side use. When omitted, all providers are treated as selected (backward compat).
4. **`deploy.ts`** (server) -- `applyServerEnvFallbacks()` accepts optional `selectedProviders` and only injects env keys for selected providers. Request handler extracts `selectedProviders` from the request body.
5. **`k8s-manifests.ts`** -- Added `GEMINI_API_KEY` to the `optionalKeys` array so the gateway container receives the Google API key as an env var.
6. **Tests** -- 7 new client-side test cases for provider filtering; 2 new server-side tests for env fallback filtering; updated 1 existing test that was validating the buggy behavior. All 337 tests pass.

## Test plan

- [x] `npm run build && npm test` -- all 337 tests pass
- [x] Deploy to OpenShift with vertex-anthropic while `GEMINI_API_KEY` is set in server env -- gateway starts without `SecretRefResolutionError` (tested as `aj1`, 4/4 running, 0 restarts)
- [x] Deploy with a single provider (Anthropic) -- confirmed only `ANTHROPIC_API_KEY` and `OPENCLAW_GATEWAY_TOKEN` in K8s Secret, no unused keys (tested as `aj3`)
- [x] Add secondary providers via "Add Provider" (Anthropic + Gemini + Vertex), deploy -- gateway starts 3/3, 0 restarts, `GEMINI_API_KEY` correctly mapped (tested as `aj7`)
- [x] Download .env file -- only selected providers have non-empty model values; unselected providers have empty keys and empty model arrays

Generated with [Claude Code](https://claude.com/claude-code)
