### PR TITLE
fix installer local endpoints and pairing approval

### DIFF
--- a/src/client/components/__tests__/DeployForm.test.tsx
+++ b/src/client/components/__tests__/DeployForm.test.tsx
@@ -441,6 +441,7 @@ describe("DeployForm agent name validation (issue #7)", () => {
     expect(screen.getByText("OpenAI-Compatible Model Endpoint")).toBeTruthy();
     expect(screen.getByText("OpenAI-Compatible Model Name")).toBeTruthy();
     expect(screen.getByText("OpenAI-Compatible Endpoint API Key (`MODEL_ENDPOINT_API_KEY`)")).toBeTruthy();
+    expect(screen.queryByText("Primary Model")).toBeNull();
   });
 
   it("submits Anthropic and OpenAI credentials together while keeping one primary provider", async () => {

--- a/src/client/components/deploy-form/ProviderSection.tsx
+++ b/src/client/components/deploy-form/ProviderSection.tsx
@@ -2,7 +2,6 @@ import React, { useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import {
   MODEL_DEFAULTS,
-  MODEL_HINTS,
   PROVIDER_OPTIONS,
 } from "./constants.js";
 import type {
@@ -1115,7 +1114,7 @@ export function ProviderSection({
                 onChange={(e) => update("modelEndpointApiKey", e.target.value)}
               />
               <div className="hint">
-                Separate from <code>OPENAI_API_KEY</code>. Use this when your OpenAI-compatible endpoint requires its own token.
+                Separate from <code>OPENAI_API_KEY</code>. Leave blank for local endpoints that do not require auth.
               </div>
               <div className="hint" style={{ marginTop: "0.35rem" }}>
                 {secretInputPreferenceHint(mode)}
@@ -1157,24 +1156,6 @@ export function ProviderSection({
             {PROVIDER_OPTIONS.find((p) => p.id === inferenceProvider)?.desc}. This controls the default primary route for the deployment.
           </div>
         </div>
-
-        {/* Show Primary Model field for custom endpoint only — Anthropic/OpenAI/Vertex have their own model fields */}
-        {inferenceProvider === "custom-endpoint" && (
-          <div className="form-group" style={{ marginTop: "0.75rem" }}>
-            <label>Primary Model</label>
-            <input
-              type="text"
-              placeholder={MODEL_DEFAULTS[inferenceProvider] || "model-id"}
-              value={config.agentModel}
-              onChange={(e) => update("agentModel", e.target.value)}
-            />
-            <div className="hint">
-              {config.agentModel
-                ? "Custom primary model override"
-                : `Leave blank for default${MODEL_DEFAULTS[inferenceProvider] ? ` (${MODEL_DEFAULTS[inferenceProvider]})` : ""}. ${MODEL_HINTS[inferenceProvider]}`}
-            </div>
-          </div>
-        )}
 
         <div className="form-group" style={{ marginTop: "0.75rem" }}>
           <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>

--- a/src/server/__tests__/security.test.ts
+++ b/src/server/__tests__/security.test.ts
@@ -3,6 +3,7 @@ import type { DeployResult } from "../deployers/types.js";
 import {
   installerBindHost,
   installerDisplayHost,
+  installerPort,
   sanitizeDeployResult,
   sanitizeSavedConfigVars,
   validateUserSuppliedPath,
@@ -58,5 +59,11 @@ describe("security helpers", () => {
     expect(installerBindHost({})).toBe("127.0.0.1");
     expect(installerBindHost({ OPENCLAW_INSTALLER_BIND_HOST: "0.0.0.0" })).toBe("0.0.0.0");
     expect(installerDisplayHost("0.0.0.0")).toBe("localhost");
+  });
+
+  it("uses the installer-specific port and ignores ambient PORT", () => {
+    expect(installerPort({ PORT: "58127" })).toBe(3000);
+    expect(installerPort({ OPENCLAW_INSTALLER_PORT: "3100", PORT: "58127" })).toBe(3100);
+    expect(installerPort({ OPENCLAW_INSTALLER_PORT: "not-a-port" })).toBe(3000);
   });
 });

--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -98,6 +98,47 @@ describe("model config generation", () => {
     expect(deriveModel(config)).toBe("google/gemini-3.1-pro-preview");
   });
 
+  it("uses the endpoint model as primary for custom endpoints even when agentModel is present", () => {
+    const config = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      agentModel: "claude-sonnet-4-6",
+      modelEndpoint: "http://localhost:8080/v1",
+      modelEndpointModel: "local-model",
+    });
+
+    expect(deriveModel(config)).toBe("endpoint/local-model");
+  });
+
+  it("normalizes slash-containing endpoint model ids under the endpoint provider", () => {
+    const config = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      modelEndpoint: "http://localhost:8080/v1",
+      modelEndpointModel: "google/gemma-4-E2B-it",
+    });
+
+    expect(normalizeModelRef(config, "google/gemma-4-E2B-it")).toBe("endpoint/google/gemma-4-E2B-it");
+    expect(normalizeModelRef(config, "endpoint/google/gemma-4-E2B-it")).toBe("endpoint/google/gemma-4-E2B-it");
+    expect(deriveModel(config)).toBe("endpoint/google/gemma-4-E2B-it");
+  });
+
+  it("publishes slash-containing endpoint model ids as endpoint provider refs", () => {
+    const config = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      modelEndpoint: "http://localhost:8080/v1",
+      modelEndpointModel: "google/gemma-4-E2B-it",
+    });
+
+    const rendered = buildOpenClawConfig(config, "gateway-token") as {
+      agents?: {
+        defaults?: {
+          model?: { primary?: string };
+        };
+      };
+    };
+
+    expect(rendered.agents?.defaults?.model?.primary).toBe("endpoint/google/gemma-4-E2B-it");
+  });
+
   it("publishes only the configured default model in the agent catalog", () => {
     const config = makeConfig({
       anthropicApiKey: "test-key",
@@ -495,6 +536,29 @@ describe("model config generation", () => {
     expect(rendered.secrets?.providers).toMatchObject({
       default: { source: "env" },
     });
+  });
+
+  it("uses the local no-auth marker for unauthenticated model endpoints", () => {
+    const config = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      openaiApiKey: "openai-key",
+      modelEndpoint: "http://localhost:8080/v1",
+      modelEndpointModel: "local-model",
+    });
+
+    const rendered = buildOpenClawConfig(config, "gateway-token") as {
+      models?: {
+        providers?: Record<string, {
+          apiKey?: unknown;
+          baseUrl?: string;
+          api?: string;
+        }>;
+      };
+    };
+
+    expect(rendered.models?.providers?.endpoint?.baseUrl).toBe("http://localhost:8080/v1");
+    expect(rendered.models?.providers?.endpoint?.api).toBe("openai-completions");
+    expect(rendered.models?.providers?.endpoint?.apiKey).toBeUndefined();
   });
 
   it("adds installer-provided provider models to the OpenClaw picker allowlist", () => {

--- a/src/server/deployers/__tests__/local.test.ts
+++ b/src/server/deployers/__tests__/local.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { applyGatewayRuntimeConfig, parseContainerRunArgs, shouldAlwaysPull } from "../local.js";
+import {
+  applyGatewayRuntimeConfig,
+  parseContainerRunArgs,
+  resolveLocalRuntimeModelEndpoint,
+  shouldAlwaysPull,
+} from "../local.js";
 
 describe("shouldAlwaysPull", () => {
   it("returns true for :latest tag", () => {
@@ -89,6 +94,27 @@ describe("applyGatewayRuntimeConfig", () => {
 
     expect(updated.gateway?.http?.endpoints?.chatCompletions?.enabled).toBe(false);
     expect(updated.gateway?.http?.endpoints?.responses?.enabled).toBe(false);
+  });
+});
+
+describe("resolveLocalRuntimeModelEndpoint", () => {
+  it("rewrites localhost endpoints for podman containers", () => {
+    expect(resolveLocalRuntimeModelEndpoint("http://localhost:8080/v1", "podman"))
+      .toBe("http://host.containers.internal:8080/v1");
+    expect(resolveLocalRuntimeModelEndpoint("http://127.0.0.1:8080/v1", "podman"))
+      .toBe("http://host.containers.internal:8080/v1");
+  });
+
+  it("rewrites localhost endpoints for docker containers", () => {
+    expect(resolveLocalRuntimeModelEndpoint("http://localhost:8080/v1", "docker"))
+      .toBe("http://host.docker.internal:8080/v1");
+  });
+
+  it("leaves already-routable endpoints unchanged", () => {
+    expect(resolveLocalRuntimeModelEndpoint("http://host.containers.internal:8080/v1", "podman"))
+      .toBe("http://host.containers.internal:8080/v1");
+    expect(resolveLocalRuntimeModelEndpoint("http://10.0.0.20:8080/v1", "podman"))
+      .toBe("http://10.0.0.20:8080/v1");
   });
 });
 

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -76,6 +76,9 @@ export function normalizeModelRef(config: DeployConfig, modelRef: string): strin
   if (config.inferenceProvider === OPENROUTER_PROVIDER) {
     return trimmed.startsWith(`${OPENROUTER_PROVIDER}/`) ? trimmed : `${OPENROUTER_PROVIDER}/${trimmed}`;
   }
+  if (config.inferenceProvider === "custom-endpoint") {
+    return trimmed.startsWith(`${CUSTOM_ENDPOINT_PROVIDER}/`) ? trimmed : `${CUSTOM_ENDPOINT_PROVIDER}/${trimmed}`;
+  }
   if (trimmed.includes("/")) return trimmed;
 
   if (config.inferenceProvider === "anthropic") return `anthropic/${trimmed}`;
@@ -84,9 +87,6 @@ export function normalizeModelRef(config: DeployConfig, modelRef: string): strin
   }
   if (config.inferenceProvider === GOOGLE_PROVIDER) {
     return `${GOOGLE_PROVIDER}/${trimmed}`;
-  }
-  if (config.inferenceProvider === "custom-endpoint") {
-    return `${CUSTOM_ENDPOINT_PROVIDER}/${trimmed}`;
   }
   // Fix for #1: check litellm proxy before falling back to direct vertex providers
   if (config.inferenceProvider === "vertex-anthropic") {
@@ -267,6 +267,11 @@ function buildAgentModelConfig(config: DeployConfig, primaryModelRef: string): {
 }
 
 export function deriveModel(config: DeployConfig): string {
+  if (config.inferenceProvider === "custom-endpoint") {
+    return config.modelEndpointModel?.trim()
+      ? normalizeModelRef(config, config.modelEndpointModel)
+      : `${CUSTOM_ENDPOINT_PROVIDER}/default`;
+  }
   if (config.agentModel) return normalizeModelRef(config, config.agentModel);
   if (config.inferenceProvider === "anthropic") {
     return `anthropic/${config.anthropicModel?.trim() || "claude-sonnet-4-6"}`;
@@ -279,11 +284,6 @@ export function deriveModel(config: DeployConfig): string {
   }
   if (config.inferenceProvider === OPENROUTER_PROVIDER) {
     return normalizeProviderModelRef(OPENROUTER_PROVIDER, config.openrouterModel) || `${OPENROUTER_PROVIDER}/auto`;
-  }
-  if (config.inferenceProvider === "custom-endpoint") {
-    return config.modelEndpointModel?.trim()
-      ? normalizeModelRef(config, config.modelEndpointModel)
-      : `${CUSTOM_ENDPOINT_PROVIDER}/default`;
   }
   if (config.inferenceProvider === "vertex-anthropic") {
     const model = config.vertexAnthropicModel?.trim() || config.agentModel?.trim() || "claude-sonnet-4-6";
@@ -588,7 +588,6 @@ function attachSecretHandlingConfig(ocConfig: Record<string, unknown>, config: D
     providersMap[OPENROUTER_PROVIDER] = openrouterProvider;
   }
   if (config.modelEndpoint?.trim()) {
-    const providerApiKeyRef = modelEndpointApiKeyRef || openaiApiKeyRef;
     const endpointProvider: Record<string, unknown> = {
       ...((providersMap[CUSTOM_ENDPOINT_PROVIDER] as Record<string, unknown> | undefined) || {}),
       baseUrl: config.modelEndpoint.trim(),
@@ -597,9 +596,7 @@ function attachSecretHandlingConfig(ocConfig: Record<string, unknown>, config: D
         ? (providersMap[CUSTOM_ENDPOINT_PROVIDER] as Record<string, unknown>).models
         : [],
     };
-    if (providerApiKeyRef) {
-      endpointProvider.apiKey = cloneSecretRef(providerApiKeyRef);
-    }
+    endpointProvider.apiKey = modelEndpointApiKeyRef ? cloneSecretRef(modelEndpointApiKeyRef) : undefined;
     if (config.modelEndpointModel?.trim()) {
       const modelId = config.modelEndpointModel.trim();
       endpointProvider.models = [{ id: modelId, name: config.modelEndpointModelLabel?.trim() || modelId }];

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -32,7 +32,7 @@ import {
   LITELLM_IMAGE,
   LITELLM_PORT,
 } from "./litellm.js";
-import { shouldUseOtel, OTEL_HTTP_PORT } from "./otel.js";
+import { resolveEndpointForContainer, shouldUseOtel, OTEL_HTTP_PORT } from "./otel.js";
 import { startOtelSidecar, stopOtelSidecar, startJaegerSidecar, otelContainerName, jaegerContainerName } from "./local-otel.js";
 import { JAEGER_UI_PORT } from "./otel.js";
 import { shouldUseChromiumSidecar, CHROMIUM_IMAGE, CHROMIUM_CDP_PORT, chromiumContainerName, chromiumAgentEnv } from "./chromium.js";
@@ -59,6 +59,10 @@ import { buildPodmanSecretRunArgs, hasPodmanSecretTarget } from "../../shared/po
 const DEFAULT_IMAGE = process.env.OPENCLAW_IMAGE || "ghcr.io/openclaw/openclaw:latest";
 const DEFAULT_VERTEX_IMAGE = process.env.OPENCLAW_VERTEX_IMAGE || DEFAULT_IMAGE;
 const DEFAULT_PORT = 18789;
+
+export function resolveLocalRuntimeModelEndpoint(endpoint: string, runtime?: ContainerRuntime | string): string {
+  return resolveEndpointForContainer(endpoint, runtime);
+}
 const GCP_SA_CONTAINER_PATH = "/home/node/.openclaw/gcp/sa.json";
 const LITELLM_CONFIG_PATH = "/home/node/.openclaw/litellm/config.yaml";
 const LITELLM_KEY_PATH = "/home/node/.openclaw/litellm/master-key";
@@ -421,6 +425,11 @@ function prepareLocalSandboxSshConfig(config: DeployConfig): {
  * Derive the model ID based on configured provider.
  */
 function deriveModel(config: DeployConfig): string {
+  if (config.inferenceProvider === "custom-endpoint") {
+    return config.modelEndpointModel?.trim()
+      ? normalizeModelRef(config, config.modelEndpointModel)
+      : `${CUSTOM_ENDPOINT_PROVIDER}/default`;
+  }
   if (config.agentModel) {
     return normalizeModelRef(config, config.agentModel);
   }
@@ -435,11 +444,6 @@ function deriveModel(config: DeployConfig): string {
   }
   if (config.inferenceProvider === OPENROUTER_PROVIDER) {
     return normalizeModelRef(config, config.openrouterModel?.trim() || "auto");
-  }
-  if (config.inferenceProvider === "custom-endpoint") {
-    return config.modelEndpointModel?.trim()
-      ? normalizeModelRef(config, config.modelEndpointModel)
-      : `${CUSTOM_ENDPOINT_PROVIDER}/default`;
   }
   if (config.inferenceProvider === "vertex-anthropic") {
     const model = config.vertexAnthropicModel?.trim() || config.agentModel?.trim() || "claude-sonnet-4-6";
@@ -676,18 +680,15 @@ function attachSecretHandlingConfig(ocConfig: Record<string, unknown>, config: D
     providersMap[OPENROUTER_PROVIDER] = openrouterProvider;
   }
   if (config.modelEndpoint?.trim()) {
-    const providerApiKeyRef = modelEndpointApiKeyRef || openaiApiKeyRef;
     const endpointProvider: Record<string, unknown> = {
       ...((providersMap[CUSTOM_ENDPOINT_PROVIDER] as Record<string, unknown> | undefined) || {}),
-      baseUrl: config.modelEndpoint.trim(),
+      baseUrl: resolveLocalRuntimeModelEndpoint(config.modelEndpoint.trim(), config.containerRuntime),
       api: "openai-completions",
       models: Array.isArray((providersMap[CUSTOM_ENDPOINT_PROVIDER] as Record<string, unknown> | undefined)?.models)
         ? (providersMap[CUSTOM_ENDPOINT_PROVIDER] as Record<string, unknown>).models
         : [],
     };
-    if (providerApiKeyRef) {
-      endpointProvider.apiKey = cloneSecretRef(providerApiKeyRef);
-    }
+    endpointProvider.apiKey = modelEndpointApiKeyRef ? cloneSecretRef(modelEndpointApiKeyRef) : undefined;
     if (config.modelEndpointModel?.trim()) {
       const modelId = config.modelEndpointModel.trim();
       endpointProvider.models = [{ id: modelId, name: config.modelEndpointModelLabel?.trim() || modelId }];
@@ -1161,7 +1162,7 @@ function buildRunArgs(
     env[openrouterEnvRefId] = effectiveConfig.openrouterApiKey;
   }
   if (effectiveConfig.modelEndpoint) {
-    env.MODEL_ENDPOINT = effectiveConfig.modelEndpoint;
+    env.MODEL_ENDPOINT = resolveLocalRuntimeModelEndpoint(effectiveConfig.modelEndpoint, runtime);
   }
   if (effectiveConfig.modelEndpointApiKey) {
     env.MODEL_ENDPOINT_API_KEY = effectiveConfig.modelEndpointApiKey;
@@ -1283,6 +1284,7 @@ export class LocalDeployer implements Deployer {
       runtime,
       log,
     );
+    const runtimeConfig: DeployConfig = { ...activeConfig, containerRuntime: runtime };
 
     const agentId = `${config.prefix || "openclaw"}_${config.agentName}`;
     const workspaceDir = `/home/node/.openclaw/workspace-${agentId}`;
@@ -1290,13 +1292,13 @@ export class LocalDeployer implements Deployer {
 
     // Build init script: write config + workspace files on first deploy
     const gatewayToken = generateToken();
-    const ocConfig = buildOpenClawConfig(activeConfig, gatewayToken);
+    const ocConfig = buildOpenClawConfig(runtimeConfig, gatewayToken);
 
     // Fix for #67: warn when bundle subagent models reference unavailable providers
     if (sourceBundle?.agents) {
-      const deployModel = deriveModel(activeConfig);
+      const deployModel = deriveModel(runtimeConfig);
       for (const entry of sourceBundle.agents) {
-        if (entry.model?.primary && detectUnavailableProvider(entry.model.primary, activeConfig)) {
+        if (entry.model?.primary && detectUnavailableProvider(entry.model.primary, runtimeConfig)) {
           log(`WARNING: Subagent "${entry.id}" prefers model "${entry.model.primary}" but that provider does not appear to be configured. The deploy-time model "${deployModel}" has been added as a fallback.`);
         }
       }
@@ -1731,7 +1733,7 @@ Use this table to track verified peer OpenClaw instances.
       }
     }
 
-    const runArgs = buildRunArgs(activeConfig, runtime, name, port, litellmMasterKey, otelEnv);
+    const runArgs = buildRunArgs(runtimeConfig, runtime, name, port, litellmMasterKey, otelEnv);
 
     log(`Starting OpenClaw container: ${name}`);
     const run = await runCommand(runtime, runArgs, log);
@@ -1772,7 +1774,7 @@ Use this table to track verified peer OpenClaw instances.
     }
 
     // Extract and save gateway token to host filesystem
-    await this.saveInstanceInfo(runtime, name, activeConfig, log, gatewayToken);
+    await this.saveInstanceInfo(runtime, name, runtimeConfig, log, gatewayToken);
 
     const url = `http://localhost:${port}`;
     log(`OpenClaw running at ${url}`);
@@ -1782,7 +1784,7 @@ Use this table to track verified peer OpenClaw instances.
       id,
       mode: "local",
       status: "running",
-      config: { ...activeConfig, containerRuntime: runtime },
+      config: runtimeConfig,
       startedAt: new Date().toISOString(),
       url,
       containerId: name,
@@ -1798,18 +1800,19 @@ Use this table to track verified peer OpenClaw instances.
       runtime,
       log,
     );
-    const name = result.containerId ?? containerName(effectiveConfig);
-    const port = effectiveConfig.port ?? DEFAULT_PORT;
-    const image = resolveImage(effectiveConfig);
-    const vol = result.volumeName ?? volumeName(effectiveConfig);
+    const runtimeConfig: DeployConfig = { ...effectiveConfig, containerRuntime: runtime };
+    const name = result.containerId ?? containerName(runtimeConfig);
+    const port = runtimeConfig.port ?? DEFAULT_PORT;
+    const image = resolveImage(runtimeConfig);
+    const vol = result.volumeName ?? volumeName(runtimeConfig);
     const isContainerized = existsSync("/.dockerenv") || existsSync("/run/.containerenv");
 
     // Copy updated agent files from host into volume before starting
-      const agentId = `${effectiveConfig.prefix || "openclaw"}_${effectiveConfig.agentName}`;
-    const agentSourceDir = normalizeHostPath(effectiveConfig.agentSourceDir) || defaultAgentSourceDir(isContainerized);
+      const agentId = `${runtimeConfig.prefix || "openclaw"}_${runtimeConfig.agentName}`;
+    const agentSourceDir = normalizeHostPath(runtimeConfig.agentSourceDir) || defaultAgentSourceDir(isContainerized);
 
     const bootstrapGatewayToken = await this.readSavedToken(name) || generateToken();
-    const ocConfig = buildOpenClawConfig(effectiveConfig, bootstrapGatewayToken);
+    const ocConfig = buildOpenClawConfig(runtimeConfig, bootstrapGatewayToken);
     const ocConfigB64 = Buffer.from(ocConfig).toString("base64");
     const bootstrapResult = await runCommand(runtime, [
       "run", "--rm",
@@ -2081,16 +2084,13 @@ Use this table to track verified peer OpenClaw instances.
     }
 
     log(`Starting OpenClaw container: ${name}`);
-    const runArgs = buildRunArgs(effectiveConfig, runtime, name, port, litellmMasterKey, otelEnv);
+    const runArgs = buildRunArgs(runtimeConfig, runtime, name, port, litellmMasterKey, otelEnv);
     const run = await runCommand(runtime, runArgs, log);
     if (run.code !== 0) {
       throw new Error("Failed to start container");
     }
 
-    const persistedConfig = {
-      ...effectiveConfig,
-      containerRuntime: runtime,
-    };
+    const persistedConfig = runtimeConfig;
     if (bootstrapGatewayToken) {
       await this.saveInstanceInfo(runtime, name, persistedConfig, log, bootstrapGatewayToken);
     } else {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,6 +22,7 @@ import { loadPlugins, getDisabledModes } from "./plugins/loader.js";
 import {
   installerBindHost,
   installerDisplayHost,
+  installerPort,
   sanitizeSavedConfigVars,
   validateUserSuppliedPath,
 } from "./security.js";
@@ -55,7 +56,7 @@ console.log(`Plugins loaded. Registered deployers: ${registry.list().map(r => r.
 
 const app = express();
 const server = createServer(app);
-const PORT = parseInt(process.env.PORT ?? "3000", 10);
+const PORT = installerPort();
 const BIND_HOST = installerBindHost();
 
 app.use(express.json());

--- a/src/server/routes/__tests__/status-operations.test.ts
+++ b/src/server/routes/__tests__/status-operations.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeployResult } from "../../deployers/types.js";
+
+const {
+  mockExecInPod,
+  mockListNamespacedPod,
+} = vi.hoisted(() => ({
+  mockExecInPod: vi.fn(),
+  mockListNamespacedPod: vi.fn(),
+}));
+
+vi.mock("../../services/k8s.js", () => ({
+  coreApi: () => ({
+    listNamespacedPod: mockListNamespacedPod,
+  }),
+  execInPod: mockExecInPod,
+}));
+
+vi.mock("../../services/container.js", () => ({
+  detectRuntime: vi.fn(),
+  discoverContainers: vi.fn(),
+}));
+
+vi.mock("../status-instances.js", () => ({
+  decodeSavedJson: vi.fn(),
+  readSavedConfig: vi.fn(),
+  readSavedGatewayToken: vi.fn(),
+}));
+
+const { approveLatestDevicePairing, selectLatestPendingDeviceRequestId } =
+  await import("../status-operations.js");
+
+const clusterInstance: DeployResult = {
+  id: "ns-1",
+  mode: "openshift",
+  status: "running",
+  config: { mode: "openshift", agentName: "kat", namespace: "ns-1" },
+  startedAt: "2026-04-16T00:00:00.000Z",
+  containerId: "ns-1",
+};
+
+describe("selectLatestPendingDeviceRequestId", () => {
+  it("selects the newest pending request by timestamp", () => {
+    expect(selectLatestPendingDeviceRequestId({
+      pending: [
+        { requestId: "req-old", ts: 1000 },
+        { requestId: "req-new", ts: 3000 },
+        { requestId: "req-mid", ts: 2000 },
+      ],
+    })).toBe("req-new");
+  });
+
+  it("returns null when there is no pending request id", () => {
+    expect(selectLatestPendingDeviceRequestId({ pending: [] })).toBeNull();
+    expect(selectLatestPendingDeviceRequestId({ pending: [{ ts: 1000 }] })).toBeNull();
+  });
+});
+
+describe("approveLatestDevicePairing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListNamespacedPod.mockResolvedValue({
+      items: [{ metadata: { name: "openclaw-pod" } }],
+    });
+  });
+
+  it("lists pending requests and approves the selected request explicitly", async () => {
+    mockExecInPod
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          pending: [
+            { requestId: "req-old", ts: 1000 },
+            { requestId: "req-new", ts: 2000 },
+          ],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ requestId: "req-new" }),
+        stderr: "",
+      });
+
+    await expect(approveLatestDevicePairing(clusterInstance)).resolves.toEqual({
+      status: "approved",
+      output: JSON.stringify({ requestId: "req-new" }),
+    });
+
+    expect(mockExecInPod).toHaveBeenNthCalledWith(
+      1,
+      "ns-1",
+      "openclaw-pod",
+      "gateway",
+      ["openclaw", "devices", "list", "--json"],
+    );
+    expect(mockExecInPod).toHaveBeenNthCalledWith(
+      2,
+      "ns-1",
+      "openclaw-pod",
+      "gateway",
+      ["openclaw", "devices", "approve", "req-new", "--json"],
+    );
+  });
+
+  it("returns noop without running approve when no pending request exists", async () => {
+    mockExecInPod.mockResolvedValueOnce({
+      stdout: JSON.stringify({ pending: [], paired: [] }),
+      stderr: "",
+    });
+
+    await expect(approveLatestDevicePairing(clusterInstance)).resolves.toEqual({
+      status: "noop",
+      error: "No pending device pairing requests",
+    });
+
+    expect(mockExecInPod).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/routes/status-operations.ts
+++ b/src/server/routes/status-operations.ts
@@ -14,6 +14,20 @@ import { decodeSavedJson, readSavedConfig, readSavedGatewayToken } from "./statu
 
 const execFileAsync = promisify(execFile);
 
+interface DeviceCommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+interface PendingDevicePairingRequest {
+  requestId?: unknown;
+  ts?: unknown;
+}
+
+interface DevicePairingList {
+  pending?: PendingDevicePairingRequest[];
+}
+
 async function findRunningLocalContainer(name: string): Promise<{
   runtime: ContainerRuntime;
   container: DiscoveredContainer;
@@ -41,51 +55,86 @@ async function getOpenClawPodName(namespace: string): Promise<string | null> {
   return podList.items[0]?.metadata?.name || null;
 }
 
+function parseDevicePairingList(stdout: string): DevicePairingList {
+  try {
+    const parsed = JSON.parse(stdout) as DevicePairingList;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    throw new Error(`Failed to parse device pairing list JSON: ${stdout}`);
+  }
+}
+
+export function selectLatestPendingDeviceRequestId(list: DevicePairingList): string | null {
+  const pending = Array.isArray(list.pending) ? list.pending : [];
+  const selected = pending.reduce<PendingDevicePairingRequest | null>((latest, current) => {
+    if (!latest) {
+      return current;
+    }
+    const latestTs = typeof latest.ts === "number" ? latest.ts : 0;
+    const currentTs = typeof current.ts === "number" ? current.ts : 0;
+    return currentTs > latestTs ? current : latest;
+  }, null);
+  return typeof selected?.requestId === "string" && selected.requestId.trim()
+    ? selected.requestId.trim()
+    : null;
+}
+
+async function createDeviceCommandRunner(instance: DeployResult): Promise<(args: string[]) => Promise<DeviceCommandResult>> {
+  if (instance.mode === "local") {
+    const running = await findRunningLocalContainer(instance.id);
+    if (!running) {
+      throw new Error("Instance must be running to approve pairing");
+    }
+
+    return async (args: string[]) => {
+      const result = await execFileAsync(running.runtime, [
+        "exec",
+        instance.id,
+        "openclaw",
+        "devices",
+        ...args,
+      ]);
+      return {
+        stdout: result.stdout.trim(),
+        stderr: result.stderr.trim(),
+      };
+    };
+  }
+
+  const namespace = instance.config.namespace || instance.containerId || "";
+  const podName = await getOpenClawPodName(namespace);
+  if (!podName) {
+    throw new Error("No running pod found to approve pairing");
+  }
+
+  return async (args: string[]) => execInPod(
+    namespace,
+    podName,
+    "gateway",
+    ["openclaw", "devices", ...args],
+  );
+}
+
 export async function approveLatestDevicePairing(instance: DeployResult): Promise<{
   status: "approved" | "noop";
   output?: string;
   error?: string;
 }> {
   try {
-    let stdout = "";
-    let stderr = "";
-
-    if (instance.mode === "local") {
-      const running = await findRunningLocalContainer(instance.id);
-      if (!running) {
-        throw new Error("Instance must be running to approve pairing");
-      }
-
-      const result = await execFileAsync(running.runtime, [
-        "exec",
-        instance.id,
-        "openclaw",
-        "devices",
-        "approve",
-        "--latest",
-      ]);
-      stdout = result.stdout.trim();
-      stderr = result.stderr.trim();
-    } else {
-      const namespace = instance.config.namespace || instance.containerId || "";
-      const podName = await getOpenClawPodName(namespace);
-      if (!podName) {
-        throw new Error("No running pod found to approve pairing");
-      }
-
-      const result = await execInPod(
-        namespace,
-        podName,
-        "gateway",
-        ["openclaw", "devices", "approve", "--latest"],
-      );
-      stdout = result.stdout;
-      stderr = result.stderr;
+    const runDeviceCommand = await createDeviceCommandRunner(instance);
+    const listResult = await runDeviceCommand(["list", "--json"]);
+    const requestId = selectLatestPendingDeviceRequestId(parseDevicePairingList(listResult.stdout));
+    if (!requestId) {
+      return {
+        status: "noop",
+        error: "No pending device pairing requests",
+      };
     }
 
+    const { stdout, stderr } = await runDeviceCommand(["approve", requestId, "--json"]);
     return {
       status: "approved",
-      output: [stdout, stderr].filter(Boolean).join("").trim(),
+      output: [stdout, stderr].filter(Boolean).join("\n").trim(),
     };
   } catch (err) {
     const execError = err as Error & { stdout?: string; stderr?: string };

--- a/src/server/security.ts
+++ b/src/server/security.ts
@@ -98,3 +98,16 @@ export function installerBindHost(env: NodeJS.ProcessEnv = process.env): string 
 export function installerDisplayHost(bindHost: string): string {
   return bindHost === "0.0.0.0" ? "localhost" : bindHost;
 }
+
+function parsePort(value: string | undefined): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const port = Number.parseInt(trimmed, 10);
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : undefined;
+}
+
+export function installerPort(env: NodeJS.ProcessEnv = process.env): number {
+  return parsePort(env.OPENCLAW_INSTALLER_PORT) ?? 3000;
+}


### PR DESCRIPTION
OpenClaw change on April 10  commit [192ee081e7 ](https://github.com/openclaw/openclaw/pull/64160)(fix: Implicit latest-device approval can pair the wrong requester). That made implicit/latest approval preview-only. This updates to approve by exact requestID rather than --latest 