### PR TITLE
add codex oauth option

### DIFF
--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -1180,7 +1180,11 @@ export default function DeployForm({ onDeployStarted }: DeployFormProps) {
               <label>Additional podman/docker run args <span style={{ color: "var(--text-secondary)", fontWeight: "normal" }}>(optional)</span></label>
               <input
                 type="text"
+                autoComplete="new-password"
+                data-1p-ignore="true"
+                data-lpignore="true"
                 placeholder="e.g., --userns=keep-id --security-opt label=disable"
+                spellCheck={false}
                 value={config.containerRunArgs}
                 onChange={(e) => update("containerRunArgs", e.target.value)}
               />

--- a/src/client/components/deploy-form/ProviderSection.tsx
+++ b/src/client/components/deploy-form/ProviderSection.tsx
@@ -75,6 +75,12 @@ const CURATED_MODEL_OPTIONS: Partial<Record<InferenceProvider, Array<{ id: strin
     { id: "gpt-5.4", name: "GPT-5.4" },
     { id: "gpt-5-mini", name: "GPT-5 Mini" },
   ],
+  "openai-codex": [
+    { id: "gpt-5.4", name: "GPT-5.4 Codex" },
+    { id: "gpt-5.4-mini", name: "GPT-5.4 Mini" },
+    { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+    { id: "gpt-5.3-codex-spark", name: "GPT-5.3 Codex Spark" },
+  ],
   google: [
     { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
     { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
@@ -111,6 +117,10 @@ function applyProviderDefaultModel(
       return prev.anthropicModel.trim() ? prev : { ...prev, anthropicModel: MODEL_DEFAULTS.anthropic };
     case "openai":
       return prev.openaiModel.trim() ? prev : { ...prev, openaiModel: MODEL_DEFAULTS.openai.replace(/^openai\//, "") };
+    case "openai-codex":
+      return prev.codexModel.trim()
+        ? prev
+        : { ...prev, codexModel: MODEL_DEFAULTS["openai-codex"].replace(/^openai-codex\//, "") };
     case "google":
       return prev.googleModel.trim() ? prev : { ...prev, googleModel: MODEL_DEFAULTS.google.replace(/^google\//, "") };
     case "openrouter":
@@ -487,6 +497,140 @@ export function ProviderSection({
               </button>
               <div className="hint">
                 Additional models appear in the OpenClaw model picker as <code>openai/&lt;model&gt;</code>.
+              </div>
+            </div>
+          </>
+        );
+      }
+
+      case "openai-codex": {
+        const visibleCodexOptions = CURATED_MODEL_OPTIONS["openai-codex"] || [];
+        const additionalCodexOptions = visibleCodexOptions.filter(
+          (option) => option.id !== config.codexModel,
+        );
+        return (
+          <>
+            <div className="form-group">
+              <label>Codex CLI auth.json Path</label>
+              <input
+                type="text"
+                autoComplete="new-password"
+                data-1p-ignore="true"
+                data-lpignore="true"
+                placeholder="Leave blank for ~/.codex/auth.json"
+                spellCheck={false}
+                value={config.codexOauthAuthJsonPath}
+                onChange={(e) => update("codexOauthAuthJsonPath", e.target.value)}
+              />
+              <div className="hint">
+                The installer reads this file on the server host and imports the ChatGPT OAuth tokens into the managed OpenClaw state as <code>openai-codex:default</code>.
+              </div>
+            </div>
+            <div className="form-group">
+              <label>Codex Model</label>
+              {visibleCodexOptions.length > 0 && (
+                <select
+                  value={getModelSelectValue(config.codexModel, visibleCodexOptions)}
+                  onChange={(e) => {
+                    if (e.target.value === "__custom__") {
+                      if (visibleCodexOptions.some((option) => option.id === config.codexModel)) {
+                        update("codexModel", "");
+                      }
+                      return;
+                    }
+                    update("codexModel", e.target.value);
+                  }}
+                >
+                  <option value="">Select a model...</option>
+                  {visibleCodexOptions.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {formatModelOptionLabel(option)}
+                    </option>
+                  ))}
+                  <option value="__custom__">
+                    {getCustomModelOptionLabel(config.codexModel, visibleCodexOptions)}
+                  </option>
+                </select>
+              )}
+              <input
+                type="text"
+                placeholder="e.g., gpt-5.4"
+                value={config.codexModel}
+                onChange={(e) => update("codexModel", e.target.value)}
+              />
+              <div className="hint">
+                The primary model is used as <code>openai-codex/&lt;model&gt;</code>.
+              </div>
+            </div>
+            <div className="form-group">
+              <label>Additional Codex Models</label>
+              {additionalCodexOptions.length > 0 && (
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", marginBottom: "0.5rem", maxHeight: "150px", overflowY: "auto", border: "1px solid var(--border)", borderRadius: "6px", padding: "0.5rem" }}>
+                  {additionalCodexOptions.map((option) => (
+                    <label key={option.id} style={{ display: "flex", alignItems: "center", gap: "0.5rem", fontSize: "0.85rem", cursor: "pointer" }}>
+                      <input
+                        type="checkbox"
+                        checked={config.codexModels.includes(option.id)}
+                        onChange={() => {
+                          setConfig((prev) => ({
+                            ...prev,
+                            codexModels: prev.codexModels.includes(option.id)
+                              ? prev.codexModels.filter((model) => model !== option.id)
+                              : [...prev.codexModels, option.id],
+                          }));
+                        }}
+                        style={{ width: "auto" }}
+                      />
+                      <code>{option.id}</code>
+                    </label>
+                  ))}
+                </div>
+              )}
+              {config.codexModels.map((modelId, index) => (
+                <div key={index} style={{ display: "flex", gap: "0.5rem", alignItems: "center", marginBottom: "0.25rem" }}>
+                  <input
+                    type="text"
+                    placeholder="e.g., gpt-5.4-mini"
+                    value={modelId}
+                    onChange={(e) => {
+                      setConfig((prev) => ({
+                        ...prev,
+                        codexModels: prev.codexModels.map((m, i) => i === index ? e.target.value : m),
+                      }));
+                    }}
+                    style={{ flex: 1 }}
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-ghost"
+                    style={{ padding: "0.25rem 0.5rem" }}
+                    onClick={() => {
+                      setConfig((prev) => ({
+                        ...prev,
+                        codexModels: prev.codexModels.filter((_, i) => i !== index),
+                      }));
+                    }}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                className="btn btn-ghost"
+                style={{ fontSize: "0.85rem", padding: "0.25rem 0.5rem", marginTop: "0.25rem" }}
+                disabled={!config.codexModel.trim()}
+                onClick={() => {
+                  setConfig((prev) => ({
+                    ...prev,
+                    codexModels: [...prev.codexModels, ""],
+                  }));
+                }}
+              >
+                + Add Model
+              </button>
+              <div className="hint">
+                Additional models appear in the OpenClaw model picker as <code>openai-codex/&lt;model&gt;</code>.
               </div>
             </div>
           </>

--- a/src/client/components/deploy-form/constants.ts
+++ b/src/client/components/deploy-form/constants.ts
@@ -10,6 +10,7 @@ export const MODE_ICONS: Record<string, string> = {
 export const PROVIDER_OPTIONS: Array<{ id: InferenceProvider; label: string; desc: string }> = [
   { id: "anthropic", label: "Anthropic", desc: "Claude models via Anthropic API" },
   { id: "openai", label: "OpenAI", desc: "GPT models via OpenAI API" },
+  { id: "openai-codex", label: "OpenAI Codex", desc: "GPT models via ChatGPT OAuth" },
   { id: "google", label: "Google (Gemini)", desc: "Gemini models via Google AI Studio" },
   { id: "openrouter", label: "OpenRouter", desc: "Unified model routing via OpenRouter" },
   { id: "vertex-anthropic", label: "Google Vertex AI (Claude)", desc: "Claude models via Google Cloud" },
@@ -20,6 +21,7 @@ export const PROVIDER_OPTIONS: Array<{ id: InferenceProvider; label: string; des
 export const MODEL_DEFAULTS: Record<InferenceProvider, string> = {
   "anthropic": "claude-sonnet-4-6",
   "openai": "openai/gpt-5",
+  "openai-codex": "openai-codex/gpt-5.4",
   "google": "google/gemini-3.1-pro-preview",
   "openrouter": "openrouter/auto",
   "vertex-anthropic": "anthropic-vertex/claude-sonnet-4-6",
@@ -30,6 +32,7 @@ export const MODEL_DEFAULTS: Record<InferenceProvider, string> = {
 export const MODEL_HINTS: Record<InferenceProvider, string> = {
   "anthropic": "Examples: claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5",
   "openai": "Examples: openai/gpt-5, openai/gpt-5.3",
+  "openai-codex": "Examples: openai-codex/gpt-5.4, openai-codex/gpt-5.4-mini",
   "google": "Examples: google/gemini-3.1-pro-preview, google/gemini-2.5-flash",
   "openrouter": "Examples: openrouter/auto, openrouter/anthropic/claude-sonnet-4-6",
   "vertex-anthropic": "Examples: anthropic-vertex/claude-sonnet-4-6, anthropic-vertex/claude-opus-4-6",

--- a/src/client/components/deploy-form/serialization.ts
+++ b/src/client/components/deploy-form/serialization.ts
@@ -69,12 +69,17 @@ export function createInitialDeployFormConfig(): DeployFormConfig {
     openaiApiKey: "",
     googleApiKey: "",
     openrouterApiKey: "",
+    codexOauthMode: "codex-cli",
+    codexOauthProfileId: "openai-codex:default",
+    codexOauthAuthJsonPath: "",
     anthropicModel: "",
     openaiModel: "",
+    codexModel: "",
     googleModel: "",
     openrouterModel: "",
     anthropicModels: [],
     openaiModels: [],
+    codexModels: [],
     googleModels: [],
     openrouterModels: [],
     agentModel: "",
@@ -183,6 +188,7 @@ export function inferSavedInferenceProvider(vars: Record<string, unknown>): Infe
   if (
     savedInferenceProvider === "anthropic"
     || savedInferenceProvider === "openai"
+    || savedInferenceProvider === "openai-codex"
     || savedInferenceProvider === "google"
     || savedInferenceProvider === "openrouter"
     || savedInferenceProvider === "vertex-anthropic"
@@ -204,6 +210,13 @@ export function inferSavedInferenceProvider(vars: Record<string, unknown>): Infe
   }
   if (getStringVar(vars, "MODEL_ENDPOINT", "modelEndpoint") || modelEndpointApiKeyRef) {
     return "custom-endpoint";
+  }
+  if (
+    getStringVar(vars, "CODEX_OAUTH_PROFILE_ID", "codexOauthProfileId")
+    || getStringVar(vars, "CODEX_OAUTH_AUTH_JSON_PATH", "codexOauthAuthJsonPath")
+    || getStringVar(vars, "CODEX_MODEL", "codexModel")
+  ) {
+    return "openai-codex";
   }
   if (getStringVar(vars, "OPENROUTER_API_KEY", "openrouterApiKey") || openrouterApiKeyRef) {
     return "openrouter";
@@ -351,7 +364,13 @@ export function applySavedVarsToConfig(
         || prev.sandboxSshKnownHosts,
       port: getStringVar(vars, "OPENCLAW_PORT", "port") || prev.port,
       anthropicModel: getStringVar(vars, "ANTHROPIC_MODEL", "anthropicModel") || prev.anthropicModel,
+      codexOauthMode: "codex-cli",
+      codexOauthProfileId:
+        getStringVar(vars, "CODEX_OAUTH_PROFILE_ID", "codexOauthProfileId") || prev.codexOauthProfileId,
+      codexOauthAuthJsonPath:
+        getStringVar(vars, "CODEX_OAUTH_AUTH_JSON_PATH", "codexOauthAuthJsonPath") || prev.codexOauthAuthJsonPath,
       openaiModel: getStringVar(vars, "OPENAI_MODEL", "openaiModel") || prev.openaiModel,
+      codexModel: getStringVar(vars, "CODEX_MODEL", "codexModel") || prev.codexModel,
       googleApiKey:
         getStringVar(vars, "GEMINI_API_KEY", "googleApiKey")
           || getStringVar(vars, "GOOGLE_API_KEY", "googleApiKey")
@@ -364,6 +383,8 @@ export function applySavedVarsToConfig(
         decodeStringArrayVar(vars, "ANTHROPIC_MODELS_B64", "anthropicModels") || prev.anthropicModels,
       openaiModels:
         decodeStringArrayVar(vars, "OPENAI_MODELS_B64", "openaiModels") || prev.openaiModels,
+      codexModels:
+        decodeStringArrayVar(vars, "CODEX_MODELS_B64", "codexModels") || prev.codexModels,
       googleModels:
         decodeStringArrayVar(vars, "GOOGLE_MODELS_B64", "googleModels") || prev.googleModels,
       openrouterModels:
@@ -511,12 +532,17 @@ export function buildDeployRequestBody(params: {
       config.sandboxEnabled ? config.sandboxSshKnownHosts || undefined : undefined,
     anthropicApiKey: sel("anthropic") && !anthropicApiKeyRef ? trimToUndefined(config.anthropicApiKey) : undefined,
     openaiApiKey: sel("openai") && !openaiApiKeyRef ? trimToUndefined(config.openaiApiKey) : undefined,
+    codexOauthMode: sel("openai-codex") ? "codex-cli" : undefined,
+    codexOauthProfileId: sel("openai-codex") ? trimToUndefined(config.codexOauthProfileId) : undefined,
+    codexOauthAuthJsonPath: sel("openai-codex") ? trimToUndefined(config.codexOauthAuthJsonPath) : undefined,
     googleApiKey: sel("google") && !googleApiKeyRef ? trimToUndefined(config.googleApiKey) : undefined,
     openrouterApiKey: sel("openrouter") && !openrouterApiKeyRef ? trimToUndefined(config.openrouterApiKey) : undefined,
     anthropicModel: sel("anthropic") ? trimToUndefined(config.anthropicModel) : undefined,
     anthropicModels: sel("anthropic") && config.anthropicModels.length > 0 ? config.anthropicModels : undefined,
     openaiModel: sel("openai") ? trimToUndefined(config.openaiModel) : undefined,
     openaiModels: sel("openai") && config.openaiModels.length > 0 ? config.openaiModels : undefined,
+    codexModel: sel("openai-codex") ? trimToUndefined(config.codexModel) : undefined,
+    codexModels: sel("openai-codex") && config.codexModels.length > 0 ? config.codexModels : undefined,
     googleModel: sel("google") ? trimToUndefined(config.googleModel) : undefined,
     googleModels: sel("google") && config.googleModels.length > 0 ? config.googleModels : undefined,
     openrouterModel: sel("openrouter") ? trimToUndefined(config.openrouterModel) : undefined,
@@ -605,12 +631,17 @@ export function buildEnvFileContent(params: {
     `INFERENCE_PROVIDER=${inferenceProvider}`,
     `ANTHROPIC_API_KEY=${sel("anthropic") && !anthropicApiKeyRef ? config.anthropicApiKey : ""}`,
     `OPENAI_API_KEY=${sel("openai") && !openaiApiKeyRef ? config.openaiApiKey : ""}`,
+    `CODEX_OAUTH_MODE=${sel("openai-codex") ? "codex-cli" : ""}`,
+    `CODEX_OAUTH_PROFILE_ID=${sel("openai-codex") ? config.codexOauthProfileId : ""}`,
+    `CODEX_OAUTH_AUTH_JSON_PATH=${sel("openai-codex") ? config.codexOauthAuthJsonPath : ""}`,
     `GEMINI_API_KEY=${sel("google") && !googleApiKeyRef ? config.googleApiKey : ""}`,
     `OPENROUTER_API_KEY=${sel("openrouter") && !openrouterApiKeyRef ? config.openrouterApiKey : ""}`,
     `ANTHROPIC_MODEL=${sel("anthropic") ? config.anthropicModel : ""}`,
     `ANTHROPIC_MODELS_B64=${encodeBase64(JSON.stringify(sel("anthropic") ? config.anthropicModels : []))}`,
     `OPENAI_MODEL=${sel("openai") ? config.openaiModel : ""}`,
     `OPENAI_MODELS_B64=${encodeBase64(JSON.stringify(sel("openai") ? config.openaiModels : []))}`,
+    `CODEX_MODEL=${sel("openai-codex") ? config.codexModel : ""}`,
+    `CODEX_MODELS_B64=${encodeBase64(JSON.stringify(sel("openai-codex") ? config.codexModels : []))}`,
     `GOOGLE_MODEL=${sel("google") ? config.googleModel : ""}`,
     `GOOGLE_MODELS_B64=${encodeBase64(JSON.stringify(sel("google") ? config.googleModels : []))}`,
     `OPENROUTER_MODEL=${sel("openrouter") ? config.openrouterModel : ""}`,

--- a/src/client/components/deploy-form/types.ts
+++ b/src/client/components/deploy-form/types.ts
@@ -3,11 +3,13 @@ import type { PodmanSecretMapping } from "../../../shared/podman-secrets.js";
 export type InferenceProvider =
   | "anthropic"
   | "openai"
+  | "openai-codex"
   | "google"
   | "openrouter"
   | "vertex-anthropic"
   | "vertex-google"
   | "custom-endpoint";
+export type CodexOauthMode = "codex-cli" | "profile";
 
 export type SecretRefSource = "env" | "file" | "exec";
 
@@ -125,12 +127,17 @@ export interface DeployFormConfig {
   openaiApiKey: string;
   googleApiKey: string;
   openrouterApiKey: string;
+  codexOauthMode: CodexOauthMode;
+  codexOauthProfileId: string;
+  codexOauthAuthJsonPath: string;
   anthropicModel: string;
   openaiModel: string;
+  codexModel: string;
   googleModel: string;
   openrouterModel: string;
   anthropicModels: string[];
   openaiModels: string[];
+  codexModels: string[];
   googleModels: string[];
   openrouterModels: string[];
   agentModel: string;

--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -86,6 +86,36 @@ describe("model config generation", () => {
     expect(deriveModel(config)).toBe("openrouter/google/gemma-4-26b-a4b-it");
   });
 
+  it("normalizes Codex OAuth model ids and writes auth routing metadata", () => {
+    const config = makeConfig({
+      inferenceProvider: "openai-codex",
+      codexOauthProfileId: "openai-codex:default",
+      codexModel: "gpt-5.4",
+      codexModels: ["gpt-5.4-mini"],
+    });
+
+    expect(normalizeModelRef(config, "gpt-5.4")).toBe("openai-codex/gpt-5.4");
+    expect(deriveModel(config)).toBe("openai-codex/gpt-5.4");
+
+    const rendered = buildOpenClawConfig(config, "gateway-token") as {
+      auth?: {
+        profiles?: Record<string, { provider?: string; mode?: string }>;
+        order?: Record<string, string[]>;
+      };
+      agents?: { defaults?: { models?: Record<string, { alias?: string }> } };
+    };
+
+    expect(rendered.auth?.profiles?.["openai-codex:default"]).toEqual({
+      provider: "openai-codex",
+      mode: "oauth",
+    });
+    expect(rendered.auth?.order?.["openai-codex"]).toEqual(["openai-codex:default"]);
+    expect(rendered.agents?.defaults?.models).toMatchObject({
+      "openai-codex/gpt-5.4": { alias: "gpt-5.4" },
+      "openai-codex/gpt-5.4-mini": { alias: "gpt-5.4-mini" },
+    });
+  });
+
   it("normalizes Google model ids whether or not they already include the provider prefix", () => {
     const config = makeConfig({
       inferenceProvider: "google",

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -119,6 +119,32 @@ describe("k8s state sync manifests", () => {
     expect(initScript).toContain('"id": "providers/openai/apiKey"');
   });
 
+  it("stores imported Codex OAuth profiles in the Secret instead of the init command", () => {
+    const codexAuthJson = JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: {
+        access_token: "codex-access-token",
+        refresh_token: "codex-refresh-token",
+        account_id: "acct_123",
+      },
+    });
+    const codexConfig = makeConfig({
+      inferenceProvider: "openai-codex",
+      codexOauthAuthJson: codexAuthJson,
+      codexOauthProfileId: "openai-codex:default",
+      codexModel: "gpt-5.4",
+    });
+
+    const secret = secretManifest("openclaw-alpha-openclaw", codexConfig, "gateway-token");
+    const deployment = deploymentManifest("openclaw-alpha-openclaw", codexConfig);
+    const initScript = deployment.spec?.template.spec?.initContainers?.[0]?.command?.[2] ?? "";
+
+    expect(secret.stringData?.OPENAI_CODEX_AUTH_PROFILES_JSON).toContain('"openai-codex:default"');
+    expect(secret.stringData?.OPENAI_CODEX_AUTH_PROFILES_JSON).toContain("codex-refresh-token");
+    expect(initScript).toContain("/openclaw-secrets/OPENAI_CODEX_AUTH_PROFILES_JSON");
+    expect(initScript).not.toContain("codex-refresh-token");
+  });
+
   it("uses the dedicated openclaw service account for non-A2A deployments", () => {
     const deployment = deploymentManifest("openclaw-alpha-openclaw", config);
     expect(deployment.spec?.template?.spec?.serviceAccountName).toBe("openclaw");

--- a/src/server/deployers/codex-oauth.ts
+++ b/src/server/deployers/codex-oauth.ts
@@ -1,0 +1,148 @@
+import type { DeployConfig } from "./types.js";
+
+export const OPENAI_CODEX_PROVIDER = "openai-codex";
+export const DEFAULT_CODEX_MODEL = "gpt-5.4";
+export const DEFAULT_CODEX_PROFILE_ID = `${OPENAI_CODEX_PROVIDER}:default`;
+export const CODEX_AUTH_PROFILES_SECRET_KEY = "OPENAI_CODEX_AUTH_PROFILES_JSON";
+
+type CodexCliAuthFile = {
+  auth_mode?: unknown;
+  tokens?: {
+    access_token?: unknown;
+    refresh_token?: unknown;
+    account_id?: unknown;
+  };
+};
+
+type AuthProfileStoreJson = {
+  version: 1;
+  profiles: Record<string, Record<string, unknown>>;
+};
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function decodeBase64UrlJson(segment: string): Record<string, unknown> | undefined {
+  try {
+    const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    const decoded = Buffer.from(padded, "base64").toString("utf8");
+    const parsed = JSON.parse(decoded);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveJwtExpiresMs(accessToken: string): number {
+  const payload = accessToken.split(".")[1];
+  if (!payload) {
+    return 0;
+  }
+  const parsed = decodeBase64UrlJson(payload);
+  const exp = parsed?.exp;
+  return typeof exp === "number" && Number.isFinite(exp) ? exp * 1000 : 0;
+}
+
+export function normalizeCodexOauthProfileId(value?: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return DEFAULT_CODEX_PROFILE_ID;
+  }
+  return trimmed.includes(":") ? trimmed : `${OPENAI_CODEX_PROVIDER}:${trimmed}`;
+}
+
+export function normalizeCodexModelRef(modelRef?: string): string {
+  const trimmed = modelRef?.trim() || DEFAULT_CODEX_MODEL;
+  return trimmed.startsWith(`${OPENAI_CODEX_PROVIDER}/`)
+    ? trimmed
+    : `${OPENAI_CODEX_PROVIDER}/${trimmed}`;
+}
+
+export function codexModelIdFromRef(modelRef?: string): string {
+  const ref = normalizeCodexModelRef(modelRef);
+  return ref.slice(`${OPENAI_CODEX_PROVIDER}/`.length);
+}
+
+export function shouldUseCodexOauth(config: DeployConfig): boolean {
+  return config.inferenceProvider === OPENAI_CODEX_PROVIDER
+    || Boolean(config.codexOauthProfileId?.trim())
+    || Boolean(config.codexOauthAuthJson?.trim())
+    || Boolean(config.codexModel?.trim())
+    || Boolean(config.codexModels?.length);
+}
+
+export function buildCodexOauthCredentialFromCliAuthJson(raw: string): Record<string, unknown> {
+  let parsed: CodexCliAuthFile;
+  try {
+    parsed = JSON.parse(raw) as CodexCliAuthFile;
+  } catch {
+    throw new Error("Codex OAuth auth.json is not valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || parsed.auth_mode !== "chatgpt") {
+    throw new Error('Codex OAuth auth.json must have auth_mode: "chatgpt"');
+  }
+  const access = readString(parsed.tokens?.access_token);
+  const refresh = readString(parsed.tokens?.refresh_token);
+  if (!access || !refresh) {
+    throw new Error("Codex OAuth auth.json is missing access_token or refresh_token");
+  }
+  const accountId = readString(parsed.tokens?.account_id);
+  return {
+    type: "oauth",
+    provider: OPENAI_CODEX_PROVIDER,
+    access,
+    refresh,
+    expires: resolveJwtExpiresMs(access),
+    ...(accountId ? { accountId } : {}),
+  };
+}
+
+export function buildCodexOauthAuthProfileStore(
+  config: DeployConfig,
+  baseProfiles: Record<string, Record<string, unknown>> = {},
+): AuthProfileStoreJson | undefined {
+  const raw = config.codexOauthAuthJson?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const profileId = normalizeCodexOauthProfileId(config.codexOauthProfileId);
+  return {
+    version: 1,
+    profiles: {
+      ...baseProfiles,
+      [profileId]: buildCodexOauthCredentialFromCliAuthJson(raw),
+    },
+  };
+}
+
+export function codexOauthAuthProfileStoreJson(
+  config: DeployConfig,
+  baseProfiles: Record<string, Record<string, unknown>> = {},
+): string | undefined {
+  const store = buildCodexOauthAuthProfileStore(config, baseProfiles);
+  return store ? JSON.stringify(store, null, 2) : undefined;
+}
+
+export function attachCodexOauthConfig(ocConfig: Record<string, unknown>, config: DeployConfig): void {
+  if (!shouldUseCodexOauth(config)) {
+    return;
+  }
+  const profileId = normalizeCodexOauthProfileId(config.codexOauthProfileId);
+  const auth = (ocConfig.auth as Record<string, unknown> | undefined) || {};
+  const profiles = (auth.profiles as Record<string, unknown> | undefined) || {};
+  const order = (auth.order as Record<string, string[]> | undefined) || {};
+  profiles[profileId] = {
+    provider: OPENAI_CODEX_PROVIDER,
+    mode: "oauth",
+  };
+  order[OPENAI_CODEX_PROVIDER] = [profileId];
+  ocConfig.auth = {
+    ...auth,
+    profiles,
+    order,
+  };
+}

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -10,6 +10,13 @@ import { loadAgentSourceBundle, loadAgentSourceMcpServers } from "./agent-source
 import type { AgentSourceBundle } from "./agent-source.js";
 import { normalizeManagedVaultProviders } from "./vault-helper.js";
 import { hasPodmanSecretTarget } from "../../shared/podman-secrets.js";
+import {
+  OPENAI_CODEX_PROVIDER,
+  attachCodexOauthConfig,
+  codexModelIdFromRef,
+  codexOauthAuthProfileStoreJson,
+  normalizeCodexModelRef,
+} from "./codex-oauth.js";
 
 export const DEFAULT_IMAGE = process.env.OPENCLAW_IMAGE || "ghcr.io/openclaw/openclaw:latest";
 export const DEFAULT_VERTEX_IMAGE = process.env.OPENCLAW_VERTEX_IMAGE || DEFAULT_IMAGE;
@@ -85,6 +92,9 @@ export function normalizeModelRef(config: DeployConfig, modelRef: string): strin
   if (config.inferenceProvider === "openai") {
     return `openai/${trimmed}`;
   }
+  if (config.inferenceProvider === OPENAI_CODEX_PROVIDER) {
+    return normalizeCodexModelRef(trimmed);
+  }
   if (config.inferenceProvider === GOOGLE_PROVIDER) {
     return `${GOOGLE_PROVIDER}/${trimmed}`;
   }
@@ -154,6 +164,13 @@ export function buildConfiguredAgentModelCatalog(
     },
     {
       ref: normalizeProviderModelRef(
+        OPENAI_CODEX_PROVIDER,
+        config.codexModel || (config.inferenceProvider === OPENAI_CODEX_PROVIDER ? "gpt-5.4" : undefined),
+      ),
+      alias: codexModelIdFromRef(config.codexModel || "gpt-5.4"),
+    },
+    {
+      ref: normalizeProviderModelRef(
         GOOGLE_PROVIDER,
         config.googleModel
           || ((config.googleApiKey || config.googleApiKeyRef || hasLocalProviderSecret(config, "GEMINI_API_KEY") || hasLocalProviderSecret(config, "GOOGLE_API_KEY"))
@@ -195,6 +212,12 @@ export function buildConfiguredAgentModelCatalog(
     if (!trimmed) continue;
     const ref = trimmed.includes("/") ? trimmed : `openai/${trimmed}`;
     catalog[ref] = { alias: trimmed };
+  }
+  for (const modelId of config.codexModels || []) {
+    const trimmed = modelId.trim();
+    if (!trimmed) continue;
+    const ref = normalizeCodexModelRef(trimmed);
+    catalog[ref] = { alias: codexModelIdFromRef(trimmed) };
   }
   for (const modelId of config.googleModels || []) {
     const trimmed = modelId.trim();
@@ -279,6 +302,9 @@ export function deriveModel(config: DeployConfig): string {
   if (config.inferenceProvider === "openai") {
     return `openai/${config.openaiModel?.trim() || "gpt-5.4"}`;
   }
+  if (config.inferenceProvider === OPENAI_CODEX_PROVIDER) {
+    return normalizeCodexModelRef(config.codexModel);
+  }
   if (config.inferenceProvider === GOOGLE_PROVIDER) {
     return `${GOOGLE_PROVIDER}/${config.googleModel?.trim() || "gemini-3.1-pro-preview"}`;
   }
@@ -302,6 +328,7 @@ export function deriveModel(config: DeployConfig): string {
       : "google-vertex/gemini-2.5-pro";
   }
   if (config.openaiApiKey || config.openaiApiKeyRef) return "openai/gpt-5.4";
+  if (config.codexOauthAuthJson || config.codexOauthProfileId) return normalizeCodexModelRef(config.codexModel);
   if (config.googleApiKey || config.googleApiKeyRef) return `${GOOGLE_PROVIDER}/gemini-3.1-pro-preview`;
   if (config.openrouterApiKey || config.openrouterApiKeyRef) return `${OPENROUTER_PROVIDER}/auto`;
   if (config.modelEndpoint) {
@@ -376,6 +403,10 @@ export function detectUnavailableProvider(
     case "openai":
       return !config.openaiApiKey && !config.openaiApiKeyRef
         && config.inferenceProvider !== "openai";
+    case OPENAI_CODEX_PROVIDER:
+      return config.inferenceProvider !== OPENAI_CODEX_PROVIDER
+        && !config.codexOauthAuthJson
+        && !config.codexOauthProfileId;
     case GOOGLE_PROVIDER:
       return !config.googleApiKey && !config.googleApiKeyRef
         && config.inferenceProvider !== GOOGLE_PROVIDER;
@@ -510,6 +541,11 @@ export function buildManagedAgentAuthProfiles(config: DeployConfig): {
         profiles,
       }
     : undefined;
+}
+
+export function buildManagedAgentAuthProfilesSecretJson(config: DeployConfig): string | undefined {
+  const baseProfiles = buildManagedAgentAuthProfiles(config)?.profiles || {};
+  return codexOauthAuthProfileStoreJson(config, baseProfiles);
 }
 
 function attachSecretHandlingConfig(ocConfig: Record<string, unknown>, config: DeployConfig): void {
@@ -785,6 +821,7 @@ export function buildOpenClawConfig(config: DeployConfig, gatewayToken: string):
     ocConfig.mcp = { servers: mcpServers };
   }
 
+  attachCodexOauthConfig(ocConfig, config);
   attachSecretHandlingConfig(ocConfig, config);
 
   return ocConfig;

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -5,8 +5,8 @@ import {
   tryParseProjectId,
   buildOpenClawConfig,
   buildManagedAgentAuthProfiles,
+  buildManagedAgentAuthProfilesSecretJson,
   resolveEnvSecretRefId,
-  usesDefaultEnvSecretRef,
 } from "./k8s-helpers.js";
 import type { DeployConfig } from "./types.js";
 import { shouldUseLitellmProxy, LITELLM_IMAGE, LITELLM_PORT } from "./litellm.js";
@@ -18,6 +18,7 @@ import {
   buildManagedVaultHelperScript,
   OPENCLAW_SERVICE_ACCOUNT_NAME,
 } from "./vault-helper.js";
+import { CODEX_AUTH_PROFILES_SECRET_KEY } from "./codex-oauth.js";
 
 export function namespaceManifest(ns: string): k8s.V1Namespace {
   return {
@@ -170,6 +171,8 @@ export function secretManifest(ns: string, config: DeployConfig, gatewayToken: s
   }
   if (config.modelEndpoint) data.MODEL_ENDPOINT = config.modelEndpoint;
   if (config.modelEndpointApiKey) data.MODEL_ENDPOINT_API_KEY = config.modelEndpointApiKey;
+  const authProfilesJson = buildManagedAgentAuthProfilesSecretJson(config);
+  if (authProfilesJson) data[CODEX_AUTH_PROFILES_SECRET_KEY] = authProfilesJson;
   const telegramEnvRefId = resolveEnvSecretRefId(config.telegramBotTokenRef, "TELEGRAM_BOT_TOKEN");
   if (config.telegramBotToken && telegramEnvRefId) {
     data[telegramEnvRefId] = config.telegramBotToken;
@@ -253,9 +256,18 @@ export function buildInitScript(config: DeployConfig): string {
   const workspaceRouting = mainWorkspaceShellCondition(mainWorkspaceDest, bundle);
   const vaultHelperScript = buildManagedVaultHelperScript();
   const authProfiles = buildManagedAgentAuthProfiles(config);
+  const authProfilesSecretJson = buildManagedAgentAuthProfilesSecretJson(config);
   const authManagedAgentIds = Array.from(new Set([id, ...((bundle?.agents || []).map((entry) => entry.id).filter(Boolean))]));
-  const authProfileLines = authProfiles
+  const authProfileLines = authProfilesSecretJson
     ? authManagedAgentIds
+      .map((agentId) => [
+        `mkdir -p /home/node/.openclaw/agents/${agentId}/agent`,
+        `if [ -f /openclaw-secrets/${CODEX_AUTH_PROFILES_SECRET_KEY} ]; then cp /openclaw-secrets/${CODEX_AUTH_PROFILES_SECRET_KEY} /home/node/.openclaw/agents/${agentId}/agent/auth-profiles.json; fi`,
+        `chmod 600 /home/node/.openclaw/agents/${agentId}/agent/auth-profiles.json 2>/dev/null || true`,
+      ].join("\n"))
+      .join("\n")
+    : authProfiles
+      ? authManagedAgentIds
       .map((agentId) => [
         `mkdir -p /home/node/.openclaw/agents/${agentId}/agent`,
         `cat > /home/node/.openclaw/agents/${agentId}/agent/auth-profiles.json <<'EOF_AUTH_PROFILES'`,
@@ -264,7 +276,7 @@ export function buildInitScript(config: DeployConfig): string {
         `chmod 600 /home/node/.openclaw/agents/${agentId}/agent/auth-profiles.json`,
       ].join("\n"))
       .join("\n")
-    : "";
+      : "";
 
   return `
 cp /config/openclaw.json /home/node/.openclaw/openclaw.json
@@ -307,7 +319,6 @@ export function deploymentManifest(
   _execApprovalsContent?: string,
 ): k8s.V1Deployment {
   const image = defaultImage(config);
-  const id = agentId(config);
 
   const envVars: k8s.V1EnvVar[] = [
     { name: "HOME", value: "/home/node" },
@@ -449,6 +460,7 @@ export function deploymentManifest(
               volumeMounts: [
                 { name: "openclaw-home", mountPath: "/home/node/.openclaw" },
                 { name: "config-template", mountPath: "/config" },
+                { name: "openclaw-secrets", mountPath: "/openclaw-secrets", readOnly: true },
                 { name: "agent-config", mountPath: "/agents" },
                 { name: "agent-tree-config", mountPath: "/agents-tree", readOnly: true },
                 { name: "skills-config", mountPath: "/skills-src", readOnly: true },
@@ -629,6 +641,7 @@ export function deploymentManifest(
           ],
           volumes: [
             { name: "openclaw-home", persistentVolumeClaim: { claimName: "openclaw-home-pvc" } },
+            { name: "openclaw-secrets", secret: { secretName: "openclaw-secrets" } },
             { name: "config-template", configMap: { name: "openclaw-config" } },
             { name: "agent-config", configMap: { name: "openclaw-agent" } },
             {

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -494,6 +494,7 @@ export class KubernetesDeployer implements Deployer {
             : (config.openaiApiKey ? "(set)" : undefined),
         modelEndpointApiKey: config.modelEndpointApiKey || undefined,
         gcpServiceAccountJson: config.gcpServiceAccountJson ? "(set)" : undefined,
+        codexOauthAuthJson: undefined,
         telegramBotToken:
           config.telegramBotToken && (!config.telegramBotTokenRef || usesDefaultEnvSecretRef(config.telegramBotTokenRef))
             ? config.telegramBotToken

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -1,7 +1,8 @@
 import { spawn, execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { homedir, tmpdir } from "node:os";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { v4 as uuid } from "uuid";
 import type {
@@ -51,6 +52,13 @@ import {
   resolveSubagentModel,
   usesDefaultEnvSecretRef,
 } from "./k8s-helpers.js";
+import {
+  OPENAI_CODEX_PROVIDER,
+  attachCodexOauthConfig,
+  buildCodexOauthCredentialFromCliAuthJson,
+  codexOauthAuthProfileStoreJson,
+  normalizeCodexModelRef,
+} from "./codex-oauth.js";
 import { buildSandboxConfig } from "./sandbox.js";
 import { buildSandboxToolPolicy } from "./tool-policy.js";
 import { loadAgentSourceBundle, loadAgentSourceMcpServers, mainWorkspaceShellCondition } from "./agent-source.js";
@@ -70,6 +78,7 @@ const SANDBOX_SSH_DIR = "/home/node/.openclaw/sandbox-ssh";
 const SANDBOX_SSH_IDENTITY_CONTAINER_PATH = `${SANDBOX_SSH_DIR}/identity`;
 const SANDBOX_SSH_CERTIFICATE_CONTAINER_PATH = `${SANDBOX_SSH_DIR}/certificate.pub`;
 const SANDBOX_SSH_KNOWN_HOSTS_CONTAINER_PATH = `${SANDBOX_SSH_DIR}/known_hosts`;
+const AUTH_PROFILE_IMPORT_CONTAINER_PATH = "/tmp/openclaw-auth-profiles/auth-profiles.json";
 
 /** Returns true if the image tag is `:latest` or absent — mutable tags that should always be pulled. */
 export function shouldAlwaysPull(image: string): boolean {
@@ -229,6 +238,15 @@ export function buildSavedInstanceEnvContent(config: DeployConfig, name: string)
   if (config.openaiApiKey && (!config.openaiApiKeyRef || usesDefaultEnvSecretRef(config.openaiApiKeyRef))) {
     lines.push(`OPENAI_API_KEY=${config.openaiApiKey}`);
   }
+  if (config.codexOauthMode) {
+    lines.push(`CODEX_OAUTH_MODE=${config.codexOauthMode}`);
+  }
+  if (config.codexOauthProfileId) {
+    lines.push(`CODEX_OAUTH_PROFILE_ID=${config.codexOauthProfileId}`);
+  }
+  if (config.codexOauthAuthJsonPath) {
+    lines.push(`CODEX_OAUTH_AUTH_JSON_PATH=${config.codexOauthAuthJsonPath}`);
+  }
   if (config.googleApiKey && (!config.googleApiKeyRef || usesDefaultEnvSecretRef(config.googleApiKeyRef))) {
     lines.push(`GEMINI_API_KEY=${config.googleApiKey}`);
   }
@@ -240,6 +258,12 @@ export function buildSavedInstanceEnvContent(config: DeployConfig, name: string)
   }
   if (config.openaiModel) {
     lines.push(`OPENAI_MODEL=${config.openaiModel}`);
+  }
+  if (config.codexModel) {
+    lines.push(`CODEX_MODEL=${config.codexModel}`);
+  }
+  if (config.codexModels && config.codexModels.length > 0) {
+    lines.push(`CODEX_MODELS_B64=${encodeEnvValue(JSON.stringify(config.codexModels))}`);
   }
   if (config.googleModel) {
     lines.push(`GOOGLE_MODEL=${config.googleModel}`);
@@ -420,6 +444,104 @@ function prepareLocalSandboxSshConfig(config: DeployConfig): {
   return { effectiveConfig };
 }
 
+function prepareLocalCodexOauthConfig(config: DeployConfig): DeployConfig {
+  if (
+    config.inferenceProvider !== OPENAI_CODEX_PROVIDER
+    || config.codexOauthMode === "profile"
+    || config.codexOauthAuthJson?.trim()
+  ) {
+    return config;
+  }
+
+  const authPath = normalizeHostPath(config.codexOauthAuthJsonPath)
+    || join(homedir(), ".codex", "auth.json");
+  if (!existsSync(authPath)) {
+    throw new Error(`Codex OAuth auth.json file not found: ${authPath}`);
+  }
+
+  const authJson = readFileSync(authPath, "utf8");
+  buildCodexOauthCredentialFromCliAuthJson(authJson);
+  return {
+    ...config,
+    codexOauthAuthJsonPath: authPath,
+    codexOauthAuthJson: authJson,
+  };
+}
+
+async function importLocalCodexAuthProfiles(params: {
+  runtime: ContainerRuntime;
+  config: DeployConfig;
+  image: string;
+  agentIds: string[];
+  log: LogCallback;
+}): Promise<void> {
+  const authProfilesJson = codexOauthAuthProfileStoreJson(params.config);
+  if (!authProfilesJson) {
+    return;
+  }
+
+  const authProfileImportLines = (sourcePath: string) =>
+    Array.from(new Set(params.agentIds))
+      .map((agentId) =>
+        `if [ -f '${sourcePath}' ]; then mkdir -p /home/node/.openclaw/agents/${agentId}/agent && cp '${sourcePath}' /home/node/.openclaw/agents/${agentId}/agent/auth-profiles.json && chmod 600 /home/node/.openclaw/agents/${agentId}/agent/auth-profiles.json; fi`
+      )
+      .join("\n");
+
+  if (params.runtime === "podman") {
+    const secretName = `openclaw-codex-auth-${uuid()}`;
+    const secretPath = `/run/secrets/${secretName}`;
+    const authProfileImportDir = join(tmpdir(), `openclaw-auth-profiles-${uuid()}`);
+    const authProfileImportPath = join(authProfileImportDir, "auth-profiles.json");
+    await mkdir(authProfileImportDir, { recursive: true });
+    await writeFile(authProfileImportPath, authProfilesJson, { mode: 0o600 });
+    try {
+      await execFileAsync("podman", ["secret", "create", secretName, authProfileImportPath]);
+      params.log("Importing Codex OAuth profile into local OpenClaw state via Podman secret");
+      const result = await runCommand(params.runtime, [
+        "run", "--rm",
+        ...localStateMountArgs(params.config),
+        "--secret", `${secretName},type=mount`,
+        params.image,
+        "sh", "-c", [
+          authProfileImportLines(secretPath),
+          runtimeOwnershipFixupCommand(),
+        ].join("\n"),
+      ], params.log);
+      if (result.code !== 0) {
+        throw new Error("Failed to import Codex OAuth profile into local runtime state");
+      }
+      return;
+    } finally {
+      await execFileAsync("podman", ["secret", "rm", secretName]).catch(() => undefined);
+      await rm(authProfileImportDir, { recursive: true, force: true });
+    }
+  }
+
+  const authProfileImportDir = join(tmpdir(), `openclaw-auth-profiles-${uuid()}`);
+  await mkdir(authProfileImportDir, { recursive: true });
+  await writeFile(join(authProfileImportDir, "auth-profiles.json"), authProfilesJson, { mode: 0o600 });
+
+  try {
+    params.log("Importing Codex OAuth profile into local OpenClaw state");
+    const result = await runCommand(params.runtime, [
+      "run", "--rm",
+      "--user", "0",
+      ...localStateMountArgs(params.config),
+      "-v", bindMountSpec(authProfileImportDir, "/tmp/openclaw-auth-profiles", "ro"),
+      params.image,
+      "sh", "-c", [
+        authProfileImportLines(AUTH_PROFILE_IMPORT_CONTAINER_PATH),
+        runtimeOwnershipFixupCommand(),
+      ].join("\n"),
+    ], params.log);
+    if (result.code !== 0) {
+      throw new Error("Failed to import Codex OAuth profile into local runtime state");
+    }
+  } finally {
+    await rm(authProfileImportDir, { recursive: true, force: true });
+  }
+}
+
 
 /**
  * Derive the model ID based on configured provider.
@@ -438,6 +560,9 @@ function deriveModel(config: DeployConfig): string {
   }
   if (config.inferenceProvider === "openai") {
     return `openai/${config.openaiModel?.trim() || "gpt-5.4"}`;
+  }
+  if (config.inferenceProvider === OPENAI_CODEX_PROVIDER) {
+    return normalizeCodexModelRef(config.codexModel);
   }
   if (config.inferenceProvider === GOOGLE_PROVIDER) {
     return `${GOOGLE_PROVIDER}/${config.googleModel?.trim() || "gemini-3.1-pro-preview"}`;
@@ -463,6 +588,9 @@ function deriveModel(config: DeployConfig): string {
   }
   if (config.openaiApiKey || config.openaiApiKeyRef) {
     return "openai/gpt-5.4";
+  }
+  if (config.codexOauthAuthJson || config.codexOauthProfileId) {
+    return normalizeCodexModelRef(config.codexModel);
   }
   if (config.googleApiKey || config.googleApiKeyRef) {
     return `${GOOGLE_PROVIDER}/gemini-3.1-pro-preview`;
@@ -923,6 +1051,7 @@ function buildOpenClawConfig(config: DeployConfig, gatewayToken: string): string
     ocConfig.mcp = { servers: mcpServers };
   }
 
+  attachCodexOauthConfig(ocConfig, config);
   attachSecretHandlingConfig(ocConfig, config);
 
   return JSON.stringify(ocConfig);
@@ -1279,8 +1408,9 @@ export class LocalDeployer implements Deployer {
     log("Initializing local state...");
 
     const localSandboxPrepared = prepareLocalSandboxSshConfig(config);
+    const localCodexPrepared = prepareLocalCodexOauthConfig(localSandboxPrepared.effectiveConfig);
     const activeConfig = await withActivePodmanSecretMappings(
-      localSandboxPrepared.effectiveConfig,
+      localCodexPrepared,
       runtime,
       log,
     );
@@ -1464,6 +1594,16 @@ Use this table to track verified peer OpenClaw instances.
     if (initResult.code !== 0) {
       throw new Error("Failed to initialize config volume");
     }
+    await importLocalCodexAuthProfiles({
+      runtime,
+      config: runtimeConfig,
+      image,
+      agentIds: [
+        agentId,
+        ...((sourceBundle?.agents || []).map((entry) => entry.id).filter(Boolean)),
+      ],
+      log,
+    });
     log(`Default agent provisioned: ${config.agentDisplayName || config.agentName} (${agentId})`);
 
     // Write GCP SA JSON into volume as a separate step (avoids heredoc/shell escaping issues)
@@ -1795,8 +1935,9 @@ Use this table to track verified peer OpenClaw instances.
     const runtime = result.config.containerRuntime ?? (await detectRuntime());
     if (!runtime) throw new Error("No container runtime found");
     const localSandboxPrepared = prepareLocalSandboxSshConfig(result.config);
+    const localCodexPrepared = prepareLocalCodexOauthConfig(localSandboxPrepared.effectiveConfig);
     const effectiveConfig = await withActivePodmanSecretMappings(
-      localSandboxPrepared.effectiveConfig,
+      localCodexPrepared,
       runtime,
       log,
     );
@@ -1833,6 +1974,18 @@ Use this table to track verified peer OpenClaw instances.
       throw new Error("Failed to initialize local runtime state");
     }
 
+    const sourceBundle = loadAgentSourceBundle(runtimeConfig);
+    await importLocalCodexAuthProfiles({
+      runtime,
+      config: runtimeConfig,
+      image,
+      agentIds: [
+        agentId,
+        ...((sourceBundle?.agents || []).map((entry) => entry.id).filter(Boolean)),
+      ],
+      log,
+    });
+
     if (effectiveConfig.gcpServiceAccountJson) {
       const b64 = Buffer.from(effectiveConfig.gcpServiceAccountJson).toString("base64");
       const gcpResult = await runCommand(runtime, [
@@ -1855,12 +2008,11 @@ Use this table to track verified peer OpenClaw instances.
     if (hasWorkspaceDirs) {
       log("Updating agent files from host...");
       const workspaceDir = `/home/node/.openclaw/workspace-${agentId}`;
-      const bundleForCopy = loadAgentSourceBundle(effectiveConfig);
       const copyScript = [
         `for d in /tmp/agent-source/workspace-*; do`,
         `  if [ -d "$d" ]; then`,
         `    base="$(basename "$d")"`,
-        `    ${mainWorkspaceShellCondition(workspaceDir, bundleForCopy)}`,
+        `    ${mainWorkspaceShellCondition(workspaceDir, sourceBundle)}`,
         `    mkdir -p "$dest"`,
         `    cp -r "$d"/* "$dest"/ 2>/dev/null || true`,
         `  fi`,

--- a/src/server/deployers/types.ts
+++ b/src/server/deployers/types.ts
@@ -5,11 +5,13 @@ export type BuiltinDeployMode = "local" | "kubernetes" | "ssh" | "fleet";
 export type InferenceProvider =
   | "anthropic"
   | "openai"
+  | "openai-codex"
   | "google"
   | "openrouter"
   | "vertex-anthropic"
   | "vertex-google"
   | "custom-endpoint";
+export type CodexOauthMode = "codex-cli" | "profile";
 export type SecretRefSource = "env" | "file" | "exec";
 
 export interface DeploySecretRef {
@@ -67,12 +69,18 @@ export interface DeployConfig {
   openaiApiKey?: string;
   googleApiKey?: string;
   openrouterApiKey?: string;
+  codexOauthMode?: CodexOauthMode;
+  codexOauthProfileId?: string;
+  codexOauthAuthJsonPath?: string;
+  codexOauthAuthJson?: string;
   anthropicModel?: string;
   openaiModel?: string;
+  codexModel?: string;
   googleModel?: string;
   openrouterModel?: string;
   anthropicModels?: string[];
   openaiModels?: string[];
+  codexModels?: string[];
   googleModels?: string[];
   openrouterModels?: string[];
   inferenceProvider?: InferenceProvider;

--- a/src/server/routes/__tests__/status.test.ts
+++ b/src/server/routes/__tests__/status.test.ts
@@ -69,4 +69,25 @@ describe("parseSavedLocalInstanceConfig", () => {
       { secretName: "openrouter_api_key", targetEnv: "OPENROUTER_API_KEY" },
     ]);
   });
+
+  it("restores saved Codex OAuth fields", () => {
+    const config = makeConfig({
+      inferenceProvider: "openai-codex",
+      codexOauthMode: "codex-cli",
+      codexOauthProfileId: "openai-codex:default",
+      codexOauthAuthJsonPath: "/Users/example/.codex/auth.json",
+      codexModel: "gpt-5.4",
+      codexModels: ["gpt-5.4-mini"],
+    });
+
+    const savedVars = parseEnvFile(buildSavedInstanceEnvContent(config, "openclaw-demo"));
+    const parsed = parseSavedLocalInstanceConfig(savedVars);
+
+    expect(parsed.inferenceProvider).toBe("openai-codex");
+    expect(parsed.codexOauthMode).toBe("codex-cli");
+    expect(parsed.codexOauthProfileId).toBe("openai-codex:default");
+    expect(parsed.codexOauthAuthJsonPath).toBe("/Users/example/.codex/auth.json");
+    expect(parsed.codexModel).toBe("gpt-5.4");
+    expect(parsed.codexModels).toEqual(["gpt-5.4-mini"]);
+  });
 });

--- a/src/server/routes/deploy.ts
+++ b/src/server/routes/deploy.ts
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { v4 as uuid } from "uuid";
 import { readFileSync, existsSync } from "node:fs";
-import { userInfo } from "node:os";
-import type { DeployConfig, DeploySecretRef } from "../deployers/types.js";
+import { homedir, userInfo } from "node:os";
+import { join } from "node:path";
+import type { CodexOauthMode, DeployConfig, DeploySecretRef } from "../deployers/types.js";
 import { validateAgentName } from "../../shared/validate-agent-name.js";
 import { normalizePodmanSecretMappings } from "../../shared/podman-secrets.js";
 import { detectGcpDefaults, defaultVertexLocation } from "../services/gcp.js";
@@ -12,6 +13,7 @@ import { registry } from "../deployers/registry.js";
 import { k8sApiHttpCode } from "../services/k8s.js";
 import { createLogCallback, sendStatus } from "../ws.js";
 import { validateUserSuppliedPath } from "../security.js";
+import { OPENAI_CODEX_PROVIDER, buildCodexOauthCredentialFromCliAuthJson } from "../deployers/codex-oauth.js";
 
 const router = Router();
 
@@ -66,6 +68,10 @@ function normalizeStringArray(arr: string[] | undefined): string[] | undefined {
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
   return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeCodexOauthMode(value: string | undefined): CodexOauthMode | undefined {
+  return value === "profile" || value === "codex-cli" ? value : undefined;
 }
 
 export function applyServerEnvFallbacks(
@@ -157,8 +163,14 @@ router.post("/", async (req, res) => {
   config.googleModel = trimOptional(config.googleModel);
   config.openrouterApiKey = trimOptional(config.openrouterApiKey);
   config.openrouterModel = trimOptional(config.openrouterModel);
+  config.codexOauthMode = normalizeCodexOauthMode(config.codexOauthMode);
+  config.codexOauthProfileId = trimOptional(config.codexOauthProfileId);
+  config.codexOauthAuthJsonPath = trimOptional(config.codexOauthAuthJsonPath);
+  config.codexOauthAuthJson = trimOptional(config.codexOauthAuthJson);
+  config.codexModel = trimOptional(config.codexModel);
   config.anthropicModels = normalizeStringArray(config.anthropicModels);
   config.openaiModels = normalizeStringArray(config.openaiModels);
+  config.codexModels = normalizeStringArray(config.codexModels);
   config.googleModels = normalizeStringArray(config.googleModels);
   config.openrouterModels = normalizeStringArray(config.openrouterModels);
   config.namespace = trimOptional(config.namespace);
@@ -272,6 +284,8 @@ router.post("/", async (req, res) => {
       config.inferenceProvider = config.vertexProvider === "google" ? "vertex-google" : "vertex-anthropic";
     } else if (config.modelEndpoint) {
       config.inferenceProvider = "custom-endpoint";
+    } else if (config.codexOauthProfileId || config.codexOauthAuthJson || config.codexOauthAuthJsonPath) {
+      config.inferenceProvider = OPENAI_CODEX_PROVIDER;
     } else if (config.openrouterApiKey || config.openrouterApiKeyRef) {
       config.inferenceProvider = "openrouter";
     } else if (config.anthropicApiKey) {
@@ -280,6 +294,33 @@ router.post("/", async (req, res) => {
       config.inferenceProvider = "openai";
     } else if (config.googleApiKey || config.googleApiKeyRef) {
       config.inferenceProvider = "google";
+    }
+  }
+
+  if (config.inferenceProvider === OPENAI_CODEX_PROVIDER && config.codexOauthMode !== "profile") {
+    if (!config.codexOauthAuthJson) {
+      const authPathInput = config.codexOauthAuthJsonPath || join(homedir(), ".codex", "auth.json");
+      let authPath: string;
+      try {
+        authPath = config.codexOauthAuthJsonPath
+          ? validateUserSuppliedPath(authPathInput, "Codex OAuth auth.json")
+          : authPathInput;
+      } catch (err) {
+        res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
+        return;
+      }
+      if (!existsSync(authPath)) {
+        res.status(400).json({ error: `Codex OAuth auth.json file not found: ${authPath}` });
+        return;
+      }
+      config.codexOauthAuthJsonPath = authPath;
+      config.codexOauthAuthJson = readFileSync(authPath, "utf-8");
+    }
+    try {
+      buildCodexOauthCredentialFromCliAuthJson(config.codexOauthAuthJson);
+    } catch (err) {
+      res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
+      return;
     }
   }
 

--- a/src/server/routes/status-instances.ts
+++ b/src/server/routes/status-instances.ts
@@ -10,7 +10,7 @@ import {
 import { discoverK8sInstances } from "../deployers/kubernetes.js";
 import { isClusterReachable } from "../services/k8s.js";
 import { registry } from "../deployers/registry.js";
-import type { DeployResult, DeploySecretRef } from "../deployers/types.js";
+import type { CodexOauthMode, DeployResult, DeploySecretRef, InferenceProvider } from "../deployers/types.js";
 import type { PodmanSecretMapping } from "../../shared/podman-secrets.js";
 
 function decodeSavedBase64(value?: string): string | undefined {
@@ -84,15 +84,7 @@ export function parseSavedLocalInstanceConfig(savedVars: Record<string, string>)
     port: savedVars.OPENCLAW_PORT ? parseInt(savedVars.OPENCLAW_PORT, 10) : undefined,
     containerRunArgs: savedVars.OPENCLAW_CONTAINER_RUN_ARGS || undefined,
     podmanSecretMappings: decodeSavedJson<PodmanSecretMapping[]>(savedVars.PODMAN_SECRET_MAPPINGS_B64),
-    inferenceProvider: savedVars.INFERENCE_PROVIDER as
-      | "anthropic"
-      | "openai"
-      | "google"
-      | "openrouter"
-      | "vertex-anthropic"
-      | "vertex-google"
-      | "custom-endpoint"
-      | undefined,
+    inferenceProvider: savedVars.INFERENCE_PROVIDER as InferenceProvider | undefined,
     agentSecurityMode:
       (savedVars.AGENT_SECURITY_MODE as "basic" | "secretrefs") || undefined,
     secretsProvidersJson: decodeSavedBase64(savedVars.SECRETS_PROVIDERS_JSON_B64),
@@ -108,6 +100,11 @@ export function parseSavedLocalInstanceConfig(savedVars: Record<string, string>)
     openrouterApiKey: savedVars.OPENROUTER_API_KEY || undefined,
     anthropicModel: savedVars.ANTHROPIC_MODEL || undefined,
     openaiModel: savedVars.OPENAI_MODEL || undefined,
+    codexOauthMode: savedVars.CODEX_OAUTH_MODE as CodexOauthMode | undefined,
+    codexOauthProfileId: savedVars.CODEX_OAUTH_PROFILE_ID || undefined,
+    codexOauthAuthJsonPath: savedVars.CODEX_OAUTH_AUTH_JSON_PATH || undefined,
+    codexModel: savedVars.CODEX_MODEL || undefined,
+    codexModels: decodeSavedJson(savedVars.CODEX_MODELS_B64),
     googleModel: savedVars.GOOGLE_MODEL || undefined,
     openrouterModel: savedVars.OPENROUTER_MODEL || undefined,
     modelFallbacks: decodeSavedJson(savedVars.MODEL_FALLBACKS_B64),

--- a/src/server/security.ts
+++ b/src/server/security.ts
@@ -21,6 +21,7 @@ const SENSITIVE_CONFIG_KEYS = new Set<keyof DeployConfig>([
   "modelEndpointApiKey",
   "telegramBotToken",
   "gcpServiceAccountJson",
+  "codexOauthAuthJson",
   "sandboxSshIdentity",
 ]);
 


### PR DESCRIPTION
For Codex OAuth new option for Providers, the installer:
- reads Codex CLI auth.json.
- generates the OpenClaw auth-profiles.json payload.
- creates a transient Podman secret, e.g. openclaw-codex-auth-<uuid>.
- runs one-off import container with that secret mounted under /run/secrets/....
- copies the secret into the OpenClaw data volume as the agent’s auth-profiles.json.
- removes the transient Podman secret immediately after import.
