### PR TITLE
fix(deployer): correct stale volume indices in KubernetesDeployer.redeploy

### DIFF
--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -149,6 +149,24 @@ describe("k8s state sync manifests", () => {
     const deployment = deploymentManifest("openclaw-alpha-openclaw", config);
     expect(deployment.spec?.template?.spec?.serviceAccountName).toBe("openclaw");
   });
+
+  it("volume indices used by redeploy match the deployment manifest order", () => {
+    // Regression test for #131: redeploy() uses hardcoded JSON Patch indices
+    // to update specific volume ConfigMaps. If volumes are reordered or new
+    // volumes are inserted, these indices must be updated to match.
+    const deployment = deploymentManifest("openclaw-alpha-openclaw", config);
+    const volumes = deployment.spec?.template.spec?.volumes ?? [];
+
+    // These are the indices redeploy() patches — keep in sync with kubernetes.ts
+    expect(volumes[4]?.name).toBe("skills-config");
+    expect(volumes[4]?.configMap?.name).toBe("openclaw-skills");
+
+    expect(volumes[5]?.name).toBe("cron-config");
+    expect(volumes[5]?.configMap?.name).toBe("openclaw-cron");
+
+    expect(volumes[7]?.name).toBe("agent-tree-config");
+    expect(volumes[7]?.configMap?.name).toBe("openclaw-agent-tree");
+  });
 });
 
 // Regression test for #62: workspace-shadowman not recognized as main agent workspace

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -688,7 +688,7 @@ export class KubernetesDeployer implements Deployer {
       },
       {
         op: "replace",
-        path: "/spec/template/spec/volumes/3/configMap",
+        path: "/spec/template/spec/volumes/4/configMap",
         value: {
           name: "openclaw-skills",
           ...(effectiveSkillEntries.length > 0
@@ -698,7 +698,7 @@ export class KubernetesDeployer implements Deployer {
       },
       {
         op: "replace",
-        path: "/spec/template/spec/volumes/4/configMap",
+        path: "/spec/template/spec/volumes/5/configMap",
         value: {
           name: "openclaw-cron",
           ...(cronJobsContent !== undefined
@@ -708,7 +708,7 @@ export class KubernetesDeployer implements Deployer {
       },
       {
         op: "replace",
-        path: "/spec/template/spec/volumes/6/configMap",
+        path: "/spec/template/spec/volumes/7/configMap",
         value: {
           name: "openclaw-agent-tree",
           ...(agentTreeEntries.length > 0


### PR DESCRIPTION
## Summary

- Fix three hardcoded JSON Patch volume indices in `redeploy()` that no longer match the volume order in `deploymentManifest()` — indices shifted when `openclaw-secrets` and `exec-approvals-config` volumes were added
- Add a regression test that asserts volume positions match the indices used by `redeploy()`, preventing future drift

## What changed

| Line | Before | After | Target ConfigMap |
|------|--------|-------|------------------|
| 691  | `volumes/3` | `volumes/4` | openclaw-skills |
| 701  | `volumes/4` | `volumes/5` | openclaw-cron |
| 711  | `volumes/6` | `volumes/7` | openclaw-agent-tree |

## Test plan

- [x] Full test suite passes (383/383)
- [x] New regression test verifies volume index alignment
- [x] Manual verification: deploy an instance, then redeploy — pod should start successfully with correct ConfigMap mappings

Fixes #131