### PR TITLE
fix(perf): speed up instance list by eliminating stale namespace probes

### DIFF
--- a/src/server/debug.ts
+++ b/src/server/debug.ts
@@ -1,0 +1,5 @@
+const enabled = process.env.DEBUG_PERF === "1";
+
+export function debugPerf(msg: string): void {
+  if (enabled) console.debug(msg);
+}

--- a/src/server/deployers/k8s-discovery.ts
+++ b/src/server/deployers/k8s-discovery.ts
@@ -1,8 +1,9 @@
 import * as k8s from "@kubernetes/client-node";
-import { readdir } from "node:fs/promises";
+import { readdir, writeFile, unlink, access } from "node:fs/promises";
 import { join } from "node:path";
 import { coreApi, appsApi } from "../services/k8s.js";
 import { installerDataDir } from "../paths.js";
+import { debugPerf } from "../debug.js";
 
 export interface K8sPodInfo {
   name: string;
@@ -30,13 +31,47 @@ export interface DiscoverK8sInstancesOptions {
   namespaces?: string[];
 }
 
+function staleMarkerPath(namespace: string): string {
+  return join(installerDataDir(), "k8s", namespace, "stale.json");
+}
+
+async function isStale(namespace: string): Promise<boolean> {
+  try {
+    await access(staleMarkerPath(namespace));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function markStale(namespace: string): Promise<void> {
+  try {
+    await writeFile(staleMarkerPath(namespace), JSON.stringify({ markedAt: new Date().toISOString() }));
+  } catch {
+    // Directory may not exist — ignore
+  }
+}
+
+export async function clearStaleMarker(namespace: string): Promise<void> {
+  try {
+    await unlink(staleMarkerPath(namespace));
+  } catch {
+    // No marker to remove
+  }
+}
+
 async function loadSavedNamespaces(): Promise<string[]> {
   try {
     const k8sDir = join(installerDataDir(), "k8s");
     const entries = await readdir(k8sDir, { withFileTypes: true });
-    return entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
+    const dirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+    const results: string[] = [];
+    for (const name of dirs) {
+      if (!(await isStale(name))) {
+        results.push(name);
+      }
+    }
+    return results;
   } catch {
     return [];
   }
@@ -127,17 +162,65 @@ export function deriveInstanceStatus(
   return { status: "deploying", statusDetail: detail };
 }
 
+async function probeNamespace(
+  nsName: string,
+  apps: ReturnType<typeof appsApi>,
+  core: ReturnType<typeof coreApi>,
+): Promise<K8sInstance | null> {
+  const tNs = performance.now();
+  try {
+    const dep = await apps.readNamespacedDeployment({ name: "openclaw", namespace: nsName });
+    debugPerf(`[perf]         discover: readDeployment(${nsName}): ${(performance.now() - tNs).toFixed(0)}ms`);
+    const labels = dep.metadata?.labels || {};
+    const replicas = dep.spec?.replicas ?? 1;
+    const readyReplicas = dep.status?.readyReplicas ?? 0;
+    const image = dep.spec?.template?.spec?.containers?.[0]?.image || "";
+
+    const tPods = performance.now();
+    const podList = await core.listNamespacedPod({
+      namespace: nsName,
+      labelSelector: "app=openclaw",
+    });
+    debugPerf(`[perf]         discover: listPods(${nsName}): ${(performance.now() - tPods).toFixed(0)}ms`);
+    const pods = podList.items.map(derivePodInfo);
+
+    const { status, statusDetail } = deriveInstanceStatus(replicas, readyReplicas, pods);
+
+    await clearStaleMarker(nsName);
+
+    return {
+      namespace: nsName,
+      status,
+      prefix: labels["openclaw.prefix"] || nsName.replace(/-openclaw$/, ""),
+      agentName: labels["openclaw.agent"] || "agent",
+      image,
+      url: "",
+      replicas,
+      readyReplicas,
+      pods,
+      statusDetail,
+    };
+  } catch {
+    debugPerf(`[perf]         discover: namespace ${nsName}: ${(performance.now() - tNs).toFixed(0)}ms (failed — marking stale)`);
+    await markStale(nsName);
+    return null;
+  }
+}
+
 export async function discoverK8sInstances(options: DiscoverK8sInstancesOptions = {}): Promise<K8sInstance[]> {
-  const results: K8sInstance[] = [];
+  const t0 = performance.now();
   try {
     const core = coreApi();
     const apps = appsApi();
     const namespaces = new Set((options.namespaces || []).filter(Boolean));
 
+    const tSaved = performance.now();
     for (const nsName of await loadSavedNamespaces()) {
       namespaces.add(nsName);
     }
+    debugPerf(`[perf]         discover: loadSavedNamespaces: ${(performance.now() - tSaved).toFixed(0)}ms, ${namespaces.size} saved`);
 
+    const tListNs = performance.now();
     try {
       const nsList = await core.listNamespace({
         labelSelector: "app.kubernetes.io/managed-by=openclaw-installer",
@@ -148,45 +231,19 @@ export async function discoverK8sInstances(options: DiscoverK8sInstancesOptions 
           namespaces.add(nsName);
         }
       }
+      debugPerf(`[perf]         discover: listNamespace: ${(performance.now() - tListNs).toFixed(0)}ms, ${namespaces.size} total namespaces`);
     } catch {
-      // Namespace-scoped users may not be able to list namespaces cluster-wide.
+      debugPerf(`[perf]         discover: listNamespace: ${(performance.now() - tListNs).toFixed(0)}ms (failed/forbidden)`);
     }
 
-    for (const nsName of namespaces) {
-      try {
-        const dep = await apps.readNamespacedDeployment({ name: "openclaw", namespace: nsName });
-        const labels = dep.metadata?.labels || {};
-        const replicas = dep.spec?.replicas ?? 1;
-        const readyReplicas = dep.status?.readyReplicas ?? 0;
-        const image = dep.spec?.template?.spec?.containers?.[0]?.image || "";
+    const probes = [...namespaces].map((nsName) => probeNamespace(nsName, apps, core));
+    const settled = await Promise.all(probes);
+    const results = settled.filter((r): r is K8sInstance => r !== null);
 
-        // Fetch pods for detailed status
-        const podList = await core.listNamespacedPod({
-          namespace: nsName,
-          labelSelector: "app=openclaw",
-        });
-        const pods = podList.items.map(derivePodInfo);
-
-        const { status, statusDetail } = deriveInstanceStatus(replicas, readyReplicas, pods);
-
-        results.push({
-          namespace: nsName,
-          status,
-          prefix: labels["openclaw.prefix"] || nsName.replace(/-openclaw$/, ""),
-          agentName: labels["openclaw.agent"] || "agent",
-          image,
-          url: "",
-          replicas,
-          readyReplicas,
-          pods,
-          statusDetail,
-        });
-      } catch {
-        // Ignore stale saved namespaces and inaccessible targets.
-      }
-    }
+    debugPerf(`[perf]         discover total: ${(performance.now() - t0).toFixed(0)}ms, ${results.length} instances`);
+    return results;
   } catch {
-    // Can't reach cluster or no permissions
+    debugPerf(`[perf]         discover total: ${(performance.now() - t0).toFixed(0)}ms (cluster unreachable)`);
+    return [];
   }
-  return results;
 }

--- a/src/server/deployers/kubernetes.ts
+++ b/src/server/deployers/kubernetes.ts
@@ -6,7 +6,8 @@ import { readFile } from "node:fs/promises";
 import { v4 as uuid } from "uuid";
 import { coreApi, appsApi, loadKubeConfig, hasOtelOperator, k8sApiHttpCode } from "../services/k8s.js";
 import { ensureK8sPortForward } from "../services/k8s-port-forward.js";
-import { deriveInstanceStatus, derivePodInfo } from "./k8s-discovery.js";
+import { debugPerf } from "../debug.js";
+import { deriveInstanceStatus, derivePodInfo, clearStaleMarker } from "./k8s-discovery.js";
 import { cronJobsFile, installerK8sInstanceDir, skillsDir } from "../paths.js";
 import { loadTextTree } from "../state-tree.js";
 import type {
@@ -54,7 +55,7 @@ import { OPENCLAW_SERVICE_ACCOUNT_NAME } from "./vault-helper.js";
 
 // Re-export discovery for consumers
 export type { K8sPodInfo, K8sInstance } from "./k8s-discovery.js";
-export { discoverK8sInstances } from "./k8s-discovery.js";
+export { discoverK8sInstances, clearStaleMarker } from "./k8s-discovery.js";
 
 // ── Helper: apply or update a resource ─────────────────────────────
 
@@ -480,6 +481,7 @@ export class KubernetesDeployer implements Deployer {
     try {
       const configDir = installerK8sInstanceDir(ns);
       mkdirSync(configDir, { recursive: true });
+      await clearStaleMarker(ns);
       const savedConfig = {
         ...config,
         namespace: ns,
@@ -546,7 +548,9 @@ export class KubernetesDeployer implements Deployer {
     try {
       const apps = appsApi();
       const core = coreApi();
+      const tDep = performance.now();
       const dep = await apps.readNamespacedDeployment({ name: "openclaw", namespace: ns });
+      debugPerf(`[perf]         readDeployment(${ns}): ${(performance.now() - tDep).toFixed(0)}ms`);
       const replicas = dep.spec?.replicas ?? 1;
       const readyReplicas = dep.status?.readyReplicas ?? 0;
 
@@ -556,10 +560,12 @@ export class KubernetesDeployer implements Deployer {
       }
 
       // Fetch pods for accurate status derivation
+      const tPods = performance.now();
       const podList = await core.listNamespacedPod({
         namespace: ns,
         labelSelector: "app=openclaw",
       });
+      debugPerf(`[perf]         listPods(${ns}): ${(performance.now() - tPods).toFixed(0)}ms`);
       const pods = podList.items.map(derivePodInfo);
       const { status, statusDetail } = deriveInstanceStatus(replicas, readyReplicas, pods);
 
@@ -569,16 +575,21 @@ export class KubernetesDeployer implements Deployer {
       }
 
       try {
+        const tPf = performance.now();
         const { url } = await ensureK8sPortForward(ns);
+        debugPerf(`[perf]         portForward(${ns}): ${(performance.now() - tPf).toFixed(0)}ms`);
 
         // Skip the HTTP probe if gateway was already confirmed healthy
         // and readyReplicas hasn't dropped (e.g. pod restart).
         const cached = this.gatewayHealthy.get(ns);
         if (cached && readyReplicas >= cached.readyReplicas) {
+          debugPerf(`[perf]         gatewayProbe(${ns}): skipped (cached)`);
           return { ...result, status: "running", url, statusDetail, pods };
         }
 
+        const tProbe = performance.now();
         const ready = await checkGatewayReady(url);
+        debugPerf(`[perf]         gatewayProbe(${ns}): ${(performance.now() - tProbe).toFixed(0)}ms, ready=${ready}`);
         if (ready) {
           this.gatewayHealthy.set(ns, { readyReplicas });
           return { ...result, status: "running", url, statusDetail, pods };

--- a/src/server/routes/status-instances.ts
+++ b/src/server/routes/status-instances.ts
@@ -7,11 +7,12 @@ import {
   detectRuntime,
   type DiscoveredContainer,
 } from "../services/container.js";
-import { discoverK8sInstances } from "../deployers/kubernetes.js";
+import { discoverK8sInstances, type K8sInstance } from "../deployers/kubernetes.js";
 import { isClusterReachable } from "../services/k8s.js";
 import { registry } from "../deployers/registry.js";
 import type { CodexOauthMode, DeployResult, DeploySecretRef, InferenceProvider } from "../deployers/types.js";
 import type { PodmanSecretMapping } from "../../shared/podman-secrets.js";
+import { debugPerf } from "../debug.js";
 
 function decodeSavedBase64(value?: string): string | undefined {
   if (!value) {
@@ -246,13 +247,7 @@ async function buildStoppedLocalInstance(containerName: string, volumeName: stri
   };
 }
 
-async function buildK8sInstance(namespace: string): Promise<DeployResult | null> {
-  const k8sInstances = await discoverK8sInstances({ namespaces: [namespace] });
-  const discovered = k8sInstances.find((instance) => instance.namespace === namespace);
-  if (!discovered) {
-    return null;
-  }
-
+async function buildK8sInstance(discovered: K8sInstance): Promise<DeployResult | null> {
   const savedState = await readSavedK8sState(discovered.namespace);
   const mode = savedState.mode;
   let instance: DeployResult = {
@@ -280,7 +275,9 @@ async function buildK8sInstance(namespace: string): Promise<DeployResult | null>
   const deployer = savedState.hasLocalState ? registry.get(mode) : undefined;
   if (deployer && typeof deployer.status === "function") {
     try {
+      const tStatus = performance.now();
       instance = await deployer.status(instance);
+      debugPerf(`[perf]       deployer.status(${discovered.namespace}): ${(performance.now() - tStatus).toFixed(0)}ms`);
     } catch {
       // Use base instance if status enrichment fails
     }
@@ -292,6 +289,7 @@ async function buildK8sInstance(namespace: string): Promise<DeployResult | null>
 export async function listInstances(includeK8s: boolean): Promise<DeployResult[]> {
   const instances: DeployResult[] = [];
 
+  const tLocal = performance.now();
   const runtime = await detectRuntime();
   if (runtime) {
     const containers = await discoverContainers(runtime);
@@ -309,12 +307,17 @@ export async function listInstances(includeK8s: boolean): Promise<DeployResult[]
       }
     }
   }
+  debugPerf(`[perf]   local discovery: ${(performance.now() - tLocal).toFixed(0)}ms, ${instances.length} local instances`);
 
   if (includeK8s && await isClusterReachable()) {
     try {
+      const tDiscover = performance.now();
       const k8sInstances = await discoverK8sInstances();
+      debugPerf(`[perf]   discoverK8sInstances: ${(performance.now() - tDiscover).toFixed(0)}ms, ${k8sInstances.length} namespaces`);
       for (const discovered of k8sInstances) {
-        const instance = await buildK8sInstance(discovered.namespace);
+        const tBuild = performance.now();
+        const instance = await buildK8sInstance(discovered);
+        debugPerf(`[perf]     buildK8sInstance(${discovered.namespace}): ${(performance.now() - tBuild).toFixed(0)}ms`);
         if (instance) {
           instances.push(instance);
         }
@@ -343,5 +346,8 @@ export async function findInstance(name: string): Promise<DeployResult | null> {
     }
   }
 
-  return await buildK8sInstance(name);
+  const k8sInstances = await discoverK8sInstances({ namespaces: [name] });
+  const discovered = k8sInstances.find((inst) => inst.namespace === name);
+  if (!discovered) return null;
+  return await buildK8sInstance(discovered);
 }

--- a/src/server/routes/status.ts
+++ b/src/server/routes/status.ts
@@ -3,6 +3,7 @@ import { registry } from "../deployers/registry.js";
 import { createLogCallback, sendStatus } from "../ws.js";
 import type { DeployResult } from "../deployers/types.js";
 import { sanitizeDeployResult } from "../security.js";
+import { debugPerf } from "../debug.js";
 import {
   findInstance,
   listInstances,
@@ -21,11 +22,14 @@ export { parseSavedLocalInstanceConfig } from "./status-instances.js";
 // List all instances: running containers + stopped local volumes + K8s
 router.get("/", async (req, res) => {
   const includeK8s = req.query.includeK8s === "1";
+  const t0 = performance.now();
 
   try {
     const instances = await listInstances(includeK8s);
+    debugPerf(`[perf] GET /api/instances (includeK8s=${includeK8s}): ${(performance.now() - t0).toFixed(0)}ms, ${instances.length} instances`);
     res.json(instances.map(sanitizeDeployResult));
   } catch (err) {
+    debugPerf(`[perf] GET /api/instances FAILED after ${(performance.now() - t0).toFixed(0)}ms`);
     const message = err instanceof Error ? err.message : String(err);
     res.status(500).json({ error: message });
   }


### PR DESCRIPTION
## Summary

- **Mark stale saved namespaces**: when `readNamespacedDeployment` fails for a saved namespace in `~/.openclaw/installer/k8s/`, write a `stale.json` marker so it is skipped on future polls. The marker is cleared on successful deploy or live discovery.
- **Eliminate redundant re-discovery**: `buildK8sInstance` was calling `discoverK8sInstances` a second time per namespace — pass the already-discovered data through instead.
- **Parallelize namespace probes**: use `Promise.all` instead of a sequential loop, so remaining non-stale namespaces are checked concurrently.
- **Add opt-in `DEBUG_PERF=1` logging**: timing instrumentation throughout the instance list code path, gated behind an environment variable.

## Results

Tested on a live OpenShift cluster with 1 live instance and 33 stale saved namespaces:

| Metric | Before | After (1st poll) | After (steady state) |
|--------|--------|-------------------|---------------------|
| `GET /api/instances` | ~11,000ms | 2,733ms | ~1,600ms |
| `discoverK8sInstances` | ~5,200ms | 720ms | ~560ms |
| `loadSavedNamespaces` | 34 namespaces | 34 (marks stale) | 1 namespace |

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (383/383)
- [x] Manual test: deployed OpenShift instance (ak12), confirmed Instances tab loads in ~1.6s steady state
- [x] Manual test: `DEBUG_PERF=1 ./run.sh` shows `[perf]` timing lines; without the env var, no output
- [x] Manual test: stale namespaces marked on first poll, skipped on subsequent polls
- [x] Manual test: tear down ak12 → `stale.json` marker created → redeploy to same namespace → marker cleared

Fixes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)