### PR TITLE
docs: consolidate CLAUDE.md into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,7 @@ If you must stop the dev server (only when explicitly asked), do **not** use `ls
 pkill -f "tsx watch src/server/index.ts" 2>/dev/null
 pkill -f "vite --strictPort" 2>/dev/null
 ```
+
+## GitHub CLI
+
+When editing PR descriptions, use `gh api repos/OWNER/REPO/pulls/NUMBER -X PATCH -f body="..."` instead of `gh pr edit --body` — the latter fails on repos with deprecated classic project integrations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,1 @@
-# Claude Code Instructions
-
-See [AGENTS.md](AGENTS.md) for project conventions, build commands, and pre-commit checklist.
-
-Always run `npm run build && npm test` before committing to catch type errors and test failures that match CI.
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Reduce CLAUDE.md to `@AGENTS.md` reference so all agent instructions live in one place
- Add `gh` CLI workaround to AGENTS.md: use `gh api` instead of `gh pr edit --body` to avoid failures on repos with deprecated classic project integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)