### PR TITLE
fix: create .env in workspace directory during provisioning

### DIFF
--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -286,6 +286,7 @@ mkdir -p /home/node/.openclaw/workspace
 mkdir -p /home/node/.openclaw/skills
 mkdir -p /home/node/.openclaw/cron
 mkdir -p /home/node/.openclaw/workspace-${id}
+touch /home/node/.openclaw/workspace-${id}/.env
 cat > /home/node/.openclaw/bin/openclaw-vault <<'EOF_VAULT_HELPER'
 ${vaultHelperScript}
 EOF_VAULT_HELPER

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -1551,6 +1551,7 @@ Use this table to track verified peer OpenClaw instances.
         : []),
       // Create workspace directory
       `mkdir -p '${workspaceDir}'`,
+      `touch '${workspaceDir}/.env'`,
       // Create skills directory
       `mkdir -p /home/node/.openclaw/skills`,
       // Write AGENTS.md (always update — lets user change agent name/display on re-deploy)
@@ -1969,6 +1970,7 @@ Use this table to track verified peer OpenClaw instances.
         `test -f /home/node/.openclaw/openclaw.json || echo '${ocConfigB64}' | base64 -d > /home/node/.openclaw/openclaw.json`,
         `node -e "const fs=require('fs');const p='/home/node/.openclaw/openclaw.json';const c=JSON.parse(fs.readFileSync(p,'utf8'));c.gateway ||= {};c.gateway.http ||= {};c.gateway.http.endpoints ||= {};c.gateway.http.endpoints.chatCompletions={enabled:${effectiveConfig.openaiCompatibleEndpointsEnabled !== false}};c.gateway.http.endpoints.responses={enabled:${effectiveConfig.openaiCompatibleEndpointsEnabled !== false}};c.gateway.controlUi ||= {};c.gateway.controlUi.allowedOrigins=['http://localhost:${port}','http://127.0.0.1:${port}'];fs.writeFileSync(p,JSON.stringify(c,null,2))"`,
         `mkdir -p /home/node/.openclaw/workspace-${agentId}`,
+        `touch /home/node/.openclaw/workspace-${agentId}/.env`,
         "mkdir -p /home/node/.openclaw/skills",
         runtimeOwnershipFixupCommand(),
       ].join(" && "),


### PR DESCRIPTION
## Summary

- Adds `touch .env` after the workspace `mkdir -p` in all three bootstrap paths: local initScript, local bootstrap, and K8s init container
- The agent's AGENTS.md instructs it to source `.env` silently and the heartbeat verifies workspace files are present, but no code path actually created the file
- `touch` is idempotent so it won't overwrite an existing `.env`

Closes #70. Supersedes #90 (which only covered the initScript path).

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (383/383)

🤖 Generated with [Claude Code](https://claude.com/claude-code)