### PR TITLE
fix: only inject provider env vars when credentials are configured

### DIFF
--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -354,6 +354,27 @@ describe("gateway env vars in proxy mode", () => {
   });
 });
 
+// Regression test for #140: switching providers should not inject stale env var refs
+describe("gateway env vars with custom endpoint only", () => {
+  it("excludes provider env vars when those providers are not configured", () => {
+    const endpointConfig = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      modelEndpoint: "http://vllm:8000/v1",
+      modelEndpointApiKey: "fake",
+    });
+
+    const deployment = deploymentManifest("ns", endpointConfig);
+    const envNames = gatewayEnvNames(deployment);
+
+    expect(envNames).not.toContain("ANTHROPIC_API_KEY");
+    expect(envNames).not.toContain("OPENAI_API_KEY");
+    expect(envNames).not.toContain("GEMINI_API_KEY");
+    expect(envNames).not.toContain("OPENROUTER_API_KEY");
+    expect(envNames).toContain("MODEL_ENDPOINT");
+    expect(envNames).toContain("MODEL_ENDPOINT_API_KEY");
+  });
+});
+
 /** Extract env var names from the LiteLLM sidecar container in a deployment manifest. */
 function litellmEnvNames(deployment: k8s.V1Deployment): string[] {
   const container = deployment.spec?.template.spec?.containers?.find((c) => c.name === "litellm");

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -725,6 +725,48 @@ describe("gateway env vars in proxy mode", () => {
   });
 });
 
+// Regression test for #140: switching providers should not inject stale env var refs
+describe("gateway env vars with custom endpoint only", () => {
+  it("excludes provider env vars when those providers are not configured", () => {
+    const endpointConfig = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      modelEndpoint: "http://vllm:8000/v1",
+      modelEndpointApiKey: "fake",
+    });
+
+    const deployment = deploymentManifest("ns", endpointConfig);
+    const envNames = gatewayEnvNames(deployment);
+
+    expect(envNames).not.toContain("ANTHROPIC_API_KEY");
+    expect(envNames).not.toContain("OPENAI_API_KEY");
+    expect(envNames).not.toContain("GEMINI_API_KEY");
+    expect(envNames).not.toContain("OPENROUTER_API_KEY");
+    expect(envNames).toContain("MODEL_ENDPOINT");
+    expect(envNames).toContain("MODEL_ENDPOINT_API_KEY");
+  });
+
+  it("removes stale auth-profiles.json before writing new ones (issue #140)", () => {
+    const deployment = deploymentManifest("ns", makeConfig());
+    const initScript = deployment.spec?.template.spec?.initContainers?.[0]?.command?.[2] ?? "";
+
+    const rmIdx = initScript.indexOf("rm -f /home/node/.openclaw/agents/*/agent/auth-profiles.json");
+    expect(rmIdx).toBeGreaterThan(-1);
+
+    const writeIdx = initScript.indexOf("auth-profiles.json", rmIdx + 1);
+    if (writeIdx > -1) {
+      expect(rmIdx).toBeLessThan(writeIdx);
+    }
+  });
+
+  it("removes stale models.json and auth-state.json on redeploy (issue #140)", () => {
+    const deployment = deploymentManifest("ns", makeConfig());
+    const initScript = deployment.spec?.template.spec?.initContainers?.[0]?.command?.[2] ?? "";
+
+    expect(initScript).toContain("/home/node/.openclaw/agents/*/agent/models.json");
+    expect(initScript).toContain("/home/node/.openclaw/agents/*/agent/auth-state.json");
+  });
+});
+
 /** Extract env var names from the LiteLLM sidecar container in a deployment manifest. */
 function litellmEnvNames(deployment: k8s.V1Deployment): string[] {
   const container = deployment.spec?.template.spec?.containers?.find((c) => c.name === "litellm");

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -318,7 +318,7 @@ describe("k8s state sync manifests", () => {
     expect(secret.stringData?.OPENAI_CODEX_AUTH_PROFILES_JSON).toContain('"provider": "vault"');
     expect(secret.stringData?.OPENAI_CODEX_AUTH_PROFILES_JSON).toContain('"id": "providers/anthropic/apiKey"');
     expect(secret.stringData?.OPENAI_CODEX_AUTH_PROFILES_JSON).toContain('"id": "providers/openai/apiKey"');
-    expect(initScript).not.toContain("auth-profiles.json");
+    expect(initScript).toContain("rm -f /home/node/.openclaw/agents/*/agent/auth-profiles.json");
     expect(initScript).not.toContain("/openclaw-secrets/OPENAI_CODEX_AUTH_PROFILES_JSON");
     expect(gatewayVolumeMounts).toContain("/openclaw-secrets");
     expect(gatewayScript).toContain("/openclaw-secrets/OPENAI_CODEX_AUTH_PROFILES_JSON");

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -340,15 +340,7 @@ export function deploymentManifest(
   const useOtelDirect = useOtel && !otelViaOperator;
   const useChromium = shouldUseChromiumSidecar(config);
 
-  const optionalKeys = [
-    // Gateway always gets provider API keys so it can route to OpenAI/Anthropic
-    // natively. LiteLLM only handles Vertex models.
-    "ANTHROPIC_API_KEY",
-    "OPENAI_API_KEY",
-    "GEMINI_API_KEY",
-    "OPENROUTER_API_KEY",
-    "MODEL_ENDPOINT",
-    "MODEL_ENDPOINT_API_KEY",
+  const optionalKeys: string[] = [
     "TELEGRAM_BOT_TOKEN",
     // In proxy mode LiteLLM gets project/location from its config.yaml;
     // the gateway doesn't need them.
@@ -357,6 +349,18 @@ export function deploymentManifest(
     "SSH_CERTIFICATE",
     "SSH_KNOWN_HOSTS",
   ];
+  if (config.anthropicApiKey || config.anthropicApiKeyRef)
+    optionalKeys.push("ANTHROPIC_API_KEY");
+  if (config.openaiApiKey || config.openaiApiKeyRef)
+    optionalKeys.push("OPENAI_API_KEY");
+  if (config.googleApiKey || config.googleApiKeyRef)
+    optionalKeys.push("GEMINI_API_KEY");
+  if (config.openrouterApiKey || config.openrouterApiKeyRef)
+    optionalKeys.push("OPENROUTER_API_KEY");
+  if (config.modelEndpoint)
+    optionalKeys.push("MODEL_ENDPOINT");
+  if (config.modelEndpointApiKey || config.modelEndpoint)
+    optionalKeys.push("MODEL_ENDPOINT_API_KEY");
   for (const key of optionalKeys) {
     envVars.push({
       name: key,

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -626,6 +626,7 @@ done
 cp -r /skills-src/. ${OPENCLAW_RUNTIME_DIR}/skills/ 2>/dev/null || true
 cp /cron-src/jobs.json ${OPENCLAW_RUNTIME_DIR}/cron/jobs.json 2>/dev/null || true
 cp /exec-approvals-src/exec-approvals.json ${OPENCLAW_RUNTIME_DIR}/exec-approvals.json 2>/dev/null || true
+rm -f ${OPENCLAW_RUNTIME_DIR}/agents/*/agent/auth-profiles.json ${OPENCLAW_RUNTIME_DIR}/agents/*/agent/models.json ${OPENCLAW_RUNTIME_DIR}/agents/*/agent/auth-state.json 2>/dev/null || true
 ${sessionStoreLines}
 chown -R 1000:0 ${OPENCLAW_RUNTIME_DIR} 2>/dev/null || true
 chmod -R g=u ${OPENCLAW_RUNTIME_DIR} 2>/dev/null || true
@@ -679,15 +680,7 @@ export function deploymentManifest(
   ]));
   const authProfilesSecretJson = buildManagedAgentAuthProfilesSecretJson(config);
 
-  const optionalKeys = [
-    // Gateway always gets provider API keys so it can route to OpenAI/Anthropic
-    // natively. LiteLLM only handles Vertex models.
-    "ANTHROPIC_API_KEY",
-    "OPENAI_API_KEY",
-    "GEMINI_API_KEY",
-    "OPENROUTER_API_KEY",
-    "MODEL_ENDPOINT",
-    "MODEL_ENDPOINT_API_KEY",
+  const optionalKeys: string[] = [
     "TELEGRAM_BOT_TOKEN",
     // In proxy mode LiteLLM gets project/location from its config.yaml;
     // the gateway doesn't need them.
@@ -696,6 +689,18 @@ export function deploymentManifest(
     "SSH_CERTIFICATE",
     "SSH_KNOWN_HOSTS",
   ];
+  if (config.anthropicApiKey || config.anthropicApiKeyRef)
+    optionalKeys.push("ANTHROPIC_API_KEY");
+  if (config.openaiApiKey || config.openaiApiKeyRef)
+    optionalKeys.push("OPENAI_API_KEY");
+  if (config.googleApiKey || config.googleApiKeyRef)
+    optionalKeys.push("GEMINI_API_KEY");
+  if (config.openrouterApiKey || config.openrouterApiKeyRef)
+    optionalKeys.push("OPENROUTER_API_KEY");
+  if (config.modelEndpoint)
+    optionalKeys.push("MODEL_ENDPOINT");
+  if (config.modelEndpointApiKey || config.modelEndpoint)
+    optionalKeys.push("MODEL_ENDPOINT_API_KEY");
   for (const key of optionalKeys) {
     envVars.push({
       name: key,


### PR DESCRIPTION
## Summary

- Fixes #140 — CrashLoopBackOff after switching model provider on redeploy
- Makes provider env var injection in `deploymentManifest()` conditional, matching the existing conditional logic in `secretManifest()`
- Cleans up stale `auth-profiles.json`, `models.json`, and `auth-state.json` from previous provider configs during init container startup
- Adds regression tests for conditional env var injection and stale file cleanup

## Root cause

The Deployment manifest unconditionally injected `secretKeyRef` env vars for **all** providers (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `MODEL_ENDPOINT`, `MODEL_ENDPOINT_API_KEY`), but the Secret only contained keys for the **active** provider. OpenClaw's secrets reloader treated the referenced-but-empty vars as fatal, causing CrashLoopBackOff when switching providers on redeploy.

Additionally, stale auth profiles and cached model/auth-state files from the previous provider persisted in the PVC across redeploys.

## Changes

1. **Conditional env var injection** — provider-specific `secretKeyRef` env vars are only added to the gateway container when the corresponding credentials exist in the deploy config
2. **Stale file cleanup** — init container now removes `auth-profiles.json`, `models.json`, and `auth-state.json` from all agent directories before writing fresh configs

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` — all k8s-manifests tests pass, including new regression tests
- [ ] Deploy with provider A, redeploy switching to provider B — no CrashLoopBackOff

<sub>Generated by Claude under the supervision of Khaled Sulayman</sub>