### PR TITLE
fix: inject placeholder API key for keyless custom endpoints

### DIFF
--- a/src/server/deployers/__tests__/k8s-helpers.test.ts
+++ b/src/server/deployers/__tests__/k8s-helpers.test.ts
@@ -934,7 +934,7 @@ describe("model config generation", () => {
     });
   });
 
-  it("uses the local no-auth marker for unauthenticated model endpoints", () => {
+  it("injects placeholder apiKey ref for keyless custom endpoints", () => {
     const config = makeConfig({
       inferenceProvider: "custom-endpoint",
       openaiApiKey: "openai-key",
@@ -945,7 +945,7 @@ describe("model config generation", () => {
     const rendered = buildOpenClawConfig(config, "gateway-token") as {
       models?: {
         providers?: Record<string, {
-          apiKey?: unknown;
+          apiKey?: { source?: string; provider?: string; id?: string };
           baseUrl?: string;
           api?: string;
         }>;
@@ -954,7 +954,11 @@ describe("model config generation", () => {
 
     expect(rendered.models?.providers?.endpoint?.baseUrl).toBe("http://localhost:8080/v1");
     expect(rendered.models?.providers?.endpoint?.api).toBe("openai-completions");
-    expect(rendered.models?.providers?.endpoint?.apiKey).toBeUndefined();
+    expect(rendered.models?.providers?.endpoint?.apiKey).toEqual({
+      source: "env",
+      provider: "default",
+      id: "MODEL_ENDPOINT_API_KEY",
+    });
   });
 
   it("adds installer-provided provider models to the OpenClaw picker allowlist", () => {
@@ -1529,5 +1533,25 @@ describe("MCP servers from agent source", () => {
     };
 
     expect(rendered.mcp).toBeUndefined();
+  });
+
+  it("sets apiKey secret ref for keyless custom endpoints", () => {
+    const config = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      modelEndpoint: "http://vllm.local:8000/v1",
+      modelEndpointModel: "mistral-small",
+    });
+
+    const rendered = buildOpenClawConfig(config, "gateway-token") as {
+      models?: {
+        providers?: Record<string, { apiKey?: { source?: string; id?: string } }>;
+      };
+    };
+
+    expect(rendered.models?.providers?.endpoint?.apiKey).toEqual({
+      source: "env",
+      provider: "default",
+      id: "MODEL_ENDPOINT_API_KEY",
+    });
   });
 });

--- a/src/server/deployers/__tests__/k8s-manifests.test.ts
+++ b/src/server/deployers/__tests__/k8s-manifests.test.ts
@@ -767,4 +767,30 @@ describe("litellm sidecar env vars in proxy mode", () => {
     expect(gwEnvNames).toContain("OPENAI_API_KEY");
     expect(gwEnvNames).toContain("ANTHROPIC_API_KEY");
   });
+
+  it("injects placeholder MODEL_ENDPOINT_API_KEY in Secret for keyless custom endpoints", () => {
+    const config = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      modelEndpoint: "http://vllm.local:8000/v1",
+      modelEndpointModel: "mistral-small",
+    });
+
+    const secret = secretManifest("ns", config, "gateway-token");
+
+    expect(secret.stringData?.MODEL_ENDPOINT_API_KEY).toBe("no-key-required");
+    expect(secret.stringData?.MODEL_ENDPOINT).toBe("http://vllm.local:8000/v1");
+  });
+
+  it("uses real API key in Secret when provided for custom endpoints", () => {
+    const config = makeConfig({
+      inferenceProvider: "custom-endpoint",
+      modelEndpoint: "http://vllm.local:8000/v1",
+      modelEndpointApiKey: "real-key",
+      modelEndpointModel: "mistral-small",
+    });
+
+    const secret = secretManifest("ns", config, "gateway-token");
+
+    expect(secret.stringData?.MODEL_ENDPOINT_API_KEY).toBe("real-key");
+  });
 });

--- a/src/server/deployers/k8s-helpers.ts
+++ b/src/server/deployers/k8s-helpers.ts
@@ -36,6 +36,7 @@ export const DEFAULT_IMAGE = process.env.OPENCLAW_IMAGE || "ghcr.io/openclaw/ope
 export const DEFAULT_OPENSHELL_IMAGE = process.env.OPENCLAW_OPENSHELL_IMAGE || "quay.io/sallyom/openclaw:latest";
 export const DEFAULT_VERTEX_IMAGE = process.env.OPENCLAW_VERTEX_IMAGE || DEFAULT_IMAGE;
 export const CUSTOM_ENDPOINT_PROVIDER = "endpoint";
+export const KEYLESS_ENDPOINT_PLACEHOLDER = "no-key-required";
 export const GOOGLE_PROVIDER = "google";
 export const GOOGLE_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 export const OPENAI_BASE_URL = "https://api.openai.com/v1";
@@ -705,7 +706,7 @@ function attachSecretHandlingConfig(ocConfig: Record<string, unknown>, config: D
   const openrouterApiKeyRef = resolveEffectiveOpenRouterApiKeyRef(config);
   const modelEndpointApiKeyRef = hasSecretRef(config.modelEndpointApiKeyRef)
     ? config.modelEndpointApiKeyRef
-    : config.modelEndpointApiKey
+    : (config.modelEndpointApiKey || config.modelEndpoint?.trim())
       ? envSecretRef("MODEL_ENDPOINT_API_KEY")
       : undefined;
   if (openaiApiKeyRef) {

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -6,6 +6,7 @@ import {
   buildOpenClawConfig,
   buildManagedAgentAuthProfilesSecretJson,
   resolveEnvSecretRefId,
+  KEYLESS_ENDPOINT_PLACEHOLDER,
 } from "./k8s-helpers.js";
 import type { DeployConfig } from "./types.js";
 import { shouldUseLitellmProxy, LITELLM_IMAGE, LITELLM_PORT } from "./litellm.js";
@@ -416,7 +417,11 @@ export function secretManifest(ns: string, config: DeployConfig, gatewayToken: s
     data[openrouterEnvRefId] = config.openrouterApiKey;
   }
   if (config.modelEndpoint) data.MODEL_ENDPOINT = config.modelEndpoint;
-  if (config.modelEndpointApiKey) data.MODEL_ENDPOINT_API_KEY = config.modelEndpointApiKey;
+  if (config.modelEndpointApiKey) {
+    data.MODEL_ENDPOINT_API_KEY = config.modelEndpointApiKey;
+  } else if (config.modelEndpoint) {
+    data.MODEL_ENDPOINT_API_KEY = KEYLESS_ENDPOINT_PLACEHOLDER;
+  }
   const authProfilesJson = buildManagedAgentAuthProfilesSecretJson(config);
   if (authProfilesJson) data[CODEX_AUTH_PROFILES_SECRET_KEY] = authProfilesJson;
   const telegramEnvRefId = resolveEnvSecretRefId(config.telegramBotTokenRef, "TELEGRAM_BOT_TOKEN");

--- a/src/server/deployers/local.ts
+++ b/src/server/deployers/local.ts
@@ -44,6 +44,7 @@ import {
   buildVaultSecretProviderConfig,
   buildConfiguredAgentModelCatalog,
   CUSTOM_ENDPOINT_PROVIDER,
+  KEYLESS_ENDPOINT_PLACEHOLDER,
   GOOGLE_BASE_URL,
   GOOGLE_PROVIDER,
   OPENAI_BASE_URL,
@@ -823,7 +824,7 @@ function attachSecretHandlingConfig(ocConfig: Record<string, unknown>, config: D
   const modelEndpointApiKeyRef = hasSecretRef(config.modelEndpointApiKeyRef)
     ? config.modelEndpointApiKeyRef
     : (
-      config.modelEndpointApiKey || hasPodmanSecretTarget(config.podmanSecretMappings, "MODEL_ENDPOINT_API_KEY")
+      config.modelEndpointApiKey || hasPodmanSecretTarget(config.podmanSecretMappings, "MODEL_ENDPOINT_API_KEY") || config.modelEndpoint?.trim()
     )
       ? envSecretRef("MODEL_ENDPOINT_API_KEY")
       : undefined;
@@ -1287,6 +1288,8 @@ export function buildRunArgs(
   }
   if (effectiveConfig.modelEndpointApiKey) {
     env.MODEL_ENDPOINT_API_KEY = effectiveConfig.modelEndpointApiKey;
+  } else if (effectiveConfig.modelEndpoint?.trim()) {
+    env.MODEL_ENDPOINT_API_KEY = KEYLESS_ENDPOINT_PLACEHOLDER;
   }
   if (effectiveConfig.vaultSecretsEnabled) {
     if (effectiveConfig.vaultAddr) {


### PR DESCRIPTION
## Summary

- Fixes #166 — custom endpoints without API keys fail at startup
- When a custom endpoint is configured without an API key, injects a placeholder value (`no-key-required`) so OpenClaw's auth requirement is satisfied
- Applies to both local (podman/docker) and Kubernetes deployers

## Changes

- **k8s-helpers.ts**: Added `KEYLESS_ENDPOINT_PLACEHOLDER` constant; updated `modelEndpointApiKeyRef` resolution to create an env secret ref when `modelEndpoint` is set even without a key
- **local.ts**: Same ref resolution fix; added placeholder env var injection in `buildRunArgs()`
- **k8s-manifests.ts**: Added placeholder to `secretManifest()` Secret data when endpoint exists but no key is provided
- Updated existing test and added 3 new regression tests

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` — all server tests pass, including new regression tests
- [ ] Deploy with keyless vLLM endpoint on OpenShift
- [ ] Deploy with keyless endpoint locally via podman/docker
- [ ] Deploy with a real API key and verify it still works

<sub>Generated by Claude under the supervision of Khaled Sulayman</sub>