### PR TITLE
feat: OpenShift Service CA auto-mount for OTel collector

### DIFF
--- a/provider-plugins/openshift/src/openshift-deployer.ts
+++ b/provider-plugins/openshift/src/openshift-deployer.ts
@@ -10,6 +10,7 @@ import { namespaceName } from "../../../src/server/deployers/k8s-helpers.js";
 import { coreApi, appsApi, k8sApiHttpCode, loadKubeConfig } from "../../../src/server/services/k8s.js";
 import { oauthServiceAccount, oauthConfigSecret, oauthProxyContainer } from "./oauth-proxy.js";
 import { applyRoute, getRouteUrl, deleteRoute } from "./route.js";
+import { shouldUseOtel } from "../../../src/server/deployers/otel.js";
 
 // ── Helper: apply or update a resource ─────────────────────────────
 
@@ -239,6 +240,30 @@ export class OpenShiftDeployer implements Deployer {
       "Secret openclaw-oauth-config",
       log,
     );
+
+    // Service CA ConfigMap for OTel TLS verification
+    if (shouldUseOtel(config) && !config.otelTlsSkipVerify) {
+      const serviceCaCm: k8s.V1ConfigMap = {
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        metadata: {
+          name: "otel-service-ca",
+          namespace: ns,
+          labels: { app: "openclaw" },
+          annotations: {
+            "service.beta.openshift.io/inject-cabundle": "true",
+          },
+        },
+        data: {},
+      };
+      await applyResource(
+        () => core.readNamespacedConfigMap({ name: "otel-service-ca", namespace: ns }),
+        () => core.createNamespacedConfigMap({ namespace: ns, body: serviceCaCm }),
+        () => core.replaceNamespacedConfigMap({ name: "otel-service-ca", namespace: ns, body: serviceCaCm }),
+        "ConfigMap otel-service-ca (Service CA)",
+        log,
+      );
+    }
 
     // Phase 2: Delegate to KubernetesDeployer for all base resources
     const result = await this.k8s.deploy(config, log);

--- a/src/client/components/DeployForm.tsx
+++ b/src/client/components/DeployForm.tsx
@@ -1513,7 +1513,9 @@ export default function DeployForm({ onDeployStarted, instanceCount, onShowInsta
                 Skip OTLP HTTPS certificate verification
               </label>
               <div className="hint">
-                Use only for self-signed or internal OTLP HTTPS endpoints.
+                {mode === "openshift"
+                  ? "Disabled by default — OpenShift Service CA verifies in-cluster endpoints. Enable for external endpoints or self-signed certificates."
+                  : "Enable if your OTLP HTTPS endpoint uses a self-signed or untrusted certificate."}
               </div>
             </div>
             <div className="form-group">

--- a/src/server/deployers/__tests__/otel.test.ts
+++ b/src/server/deployers/__tests__/otel.test.ts
@@ -79,6 +79,82 @@ describe("otel config generation", () => {
     const skipVerifyExporter = (skipVerifyConfig.exporters as Record<string, unknown>).otlphttp as Record<string, unknown>;
     expect(skipVerifyExporter.tls).toMatchObject({ insecure_skip_verify: true });
   });
+
+  it("sets ca_file on openshift with HTTPS endpoint and no skip verify", () => {
+    const config: DeployConfig = {
+      mode: "openshift",
+      agentName: "alpha",
+      agentDisplayName: "Alpha",
+      otelEnabled: true,
+      otelEndpoint: "https://mlflow.apps.cluster.example.com",
+    };
+
+    const obj = generateOtelConfigObject(config);
+    const tls = (
+      (obj.exporters as Record<string, Record<string, unknown>>).otlphttp
+        .tls as Record<string, unknown>
+    );
+
+    expect(tls).not.toHaveProperty("insecure_skip_verify");
+    expect(tls.ca_file).toBe("/etc/pki/tls/service-ca/service-ca.crt");
+  });
+
+  it("skips ca_file when otelTlsSkipVerify is true on openshift", () => {
+    const config: DeployConfig = {
+      mode: "openshift",
+      agentName: "alpha",
+      agentDisplayName: "Alpha",
+      otelEnabled: true,
+      otelEndpoint: "https://mlflow.apps.cluster.example.com",
+      otelTlsSkipVerify: true,
+    };
+
+    const obj = generateOtelConfigObject(config);
+    const tls = (
+      (obj.exporters as Record<string, Record<string, unknown>>).otlphttp
+        .tls as Record<string, unknown>
+    );
+
+    expect(tls.insecure_skip_verify).toBe(true);
+    expect(tls).not.toHaveProperty("ca_file");
+  });
+
+  it("does not set ca_file on non-openshift HTTPS endpoints", () => {
+    const config: DeployConfig = {
+      mode: "kubernetes",
+      agentName: "alpha",
+      agentDisplayName: "Alpha",
+      otelEnabled: true,
+      otelEndpoint: "https://mlflow.example.com",
+    };
+
+    const obj = generateOtelConfigObject(config);
+    const tls = (
+      (obj.exporters as Record<string, Record<string, unknown>>).otlphttp
+        .tls as Record<string, unknown>
+    );
+
+    expect(tls).not.toHaveProperty("ca_file");
+  });
+
+  it("does not set ca_file for non-HTTPS endpoints on openshift", () => {
+    const config: DeployConfig = {
+      mode: "openshift",
+      agentName: "alpha",
+      agentDisplayName: "Alpha",
+      otelEnabled: true,
+      otelEndpoint: "http://mlflow.mlflow.svc:5000",
+    };
+
+    const obj = generateOtelConfigObject(config);
+    const tls = (
+      (obj.exporters as Record<string, Record<string, unknown>>).otlphttp
+        .tls as Record<string, unknown>
+    );
+
+    expect(tls.insecure).toBe(true);
+    expect(tls).not.toHaveProperty("ca_file");
+  });
 });
 
 describe("formatScalar", () => {

--- a/src/server/deployers/k8s-manifests.ts
+++ b/src/server/deployers/k8s-manifests.ts
@@ -937,6 +937,9 @@ export function deploymentManifest(
               ],
               volumeMounts: [
                 { name: "otel-config", mountPath: "/etc/otel", readOnly: true },
+                ...(config.mode === "openshift" && !config.otelTlsSkipVerify
+                  ? [{ name: "otel-service-ca", mountPath: "/etc/pki/tls/service-ca", readOnly: true }]
+                  : []),
               ],
               resources: {
                 requests: { memory: "128Mi", cpu: "100m" },
@@ -1055,6 +1058,9 @@ export function deploymentManifest(
               : []),
             ...(useOtelDirect
               ? [{ name: "otel-config", configMap: { name: "otel-collector-config" } }]
+              : []),
+            ...(useOtelDirect && config.mode === "openshift" && !config.otelTlsSkipVerify
+              ? [{ name: "otel-service-ca", configMap: { name: "otel-service-ca" } }]
               : []),
             ...(useChromium
               ? [

--- a/src/server/deployers/otel.ts
+++ b/src/server/deployers/otel.ts
@@ -68,12 +68,18 @@ function buildOtelConfig(config: DeployConfig): Record<string, unknown> {
       },
     };
   } else {
+    const isHttps = endpoint.startsWith("https://");
+    const isOpenShift = config.mode === "openshift";
+    const tls: Record<string, unknown> = {
+      insecure: !isHttps,
+      ...(config.otelTlsSkipVerify ? { insecure_skip_verify: true } : {}),
+    };
+    if (isOpenShift && isHttps && !config.otelTlsSkipVerify) {
+      tls.ca_file = "/etc/pki/tls/service-ca/service-ca.crt";
+    }
     const otlpHttpExporter: Record<string, unknown> = {
       endpoint,
-      tls: {
-        insecure: !endpoint.startsWith("https://"),
-        ...(config.otelTlsSkipVerify ? { insecure_skip_verify: true } : {}),
-      },
+      tls,
     };
     if (config.otelExperimentId) {
       const ns = config.namespace || config.prefix || "default";


### PR DESCRIPTION
## Summary

Builds on the `otelTlsSkipVerify` toggle from #165 to add OpenShift Service CA support for OTel TLS verification.

When deploying on OpenShift with TLS verification enabled (the default):
- Creates an `otel-service-ca` ConfigMap with the `service.beta.openshift.io/inject-cabundle: "true"` annotation, which causes the Service CA operator to inject the cluster signing CA
- Mounts it into the OTel collector sidecar at `/etc/pki/tls/service-ca/`
- Sets `tls.ca_file` in the otlphttp exporter to use the injected CA bundle

All gated on `mode === "openshift" && !otelTlsSkipVerify` — when skip-verify is enabled, the ConfigMap, volume, and mount are all skipped.

### Files changed
- `src/server/deployers/otel.ts` — add `ca_file` to TLS config for OpenShift
- `src/server/deployers/k8s-manifests.ts` — conditional Service CA volume + mount
- `provider-plugins/openshift/src/openshift-deployer.ts` — create the annotated ConfigMap in Phase 1
- `src/client/components/DeployForm.tsx` — mode-aware hint text for the skip-verify checkbox
- `src/server/deployers/__tests__/otel.test.ts` — 4 new test cases for Service CA behavior

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — all otel tests pass (12/12); InstanceList failures are pre-existing on main
- [x] `npm run lint` — clean

Closes #168

<sub>Generated by Claude Code under the supervision of Khaled Sulayman</sub>